### PR TITLE
feat: ignore self/cls method parameters in typed parameter check

### DIFF
--- a/internal/analysis/adk_agents.go
+++ b/internal/analysis/adk_agents.go
@@ -154,7 +154,7 @@ func discoverADKToolsInFile(pf ParsedFile) []models.ToolDef {
 				EndLine:  int(fnDef.EndPoint().Row) + 1,
 			},
 			Description:    astutil.FunctionDocstring(fnDef, pf.Source),
-			HasTypedParams: astutil.FunctionHasTypedParams(fnDef),
+			HasTypedParams: astutil.FunctionHasTypedParams(fnDef, pf.Source),
 			ParamNames:     astutil.FunctionParams(fnDef, pf.Source),
 		})
 		return true

--- a/internal/analysis/astutil/astutil.go
+++ b/internal/analysis/astutil/astutil.go
@@ -271,7 +271,7 @@ func KwargValue(call *sitter.Node, src []byte, name string) (value string, prese
 
 // FunctionHasTypedParams reports whether the function declares at least one
 // type-annotated parameter (excluding self/cls).
-func FunctionHasTypedParams(fn *sitter.Node) bool {
+func FunctionHasTypedParams(fn *sitter.Node, src []byte) bool {
 	if fn == nil {
 		return false
 	}
@@ -283,6 +283,16 @@ func FunctionHasTypedParams(fn *sitter.Node) bool {
 	for i := 0; i < count; i++ {
 		p := params.NamedChild(i)
 		if p.Type() == "typed_parameter" || p.Type() == "typed_default_parameter" {
+			// First named child is the identifier in both types.
+			if int(p.NamedChildCount()) > 0 {
+				name := p.NamedChild(0)
+				if name.Type() == "identifier" {
+					text := NodeText(name, src)
+					if text == "self" || text == "cls" {
+						continue
+					}
+				}
+			}
 			return true
 		}
 	}

--- a/internal/analysis/astutil/astutil_test.go
+++ b/internal/analysis/astutil/astutil_test.go
@@ -111,3 +111,28 @@ func TestKwargValue(t *testing.T) {
 		})
 	}
 }
+
+func TestFunctionHasTypedParams(t *testing.T) {
+	cases := []struct {
+		name string
+		code string
+		want bool
+	}{
+		{"no-params", "def f():\n    pass", false},
+		{"untyped-params", "def f(a, b):\n    pass", false},
+		{"typed-param", "def f(a: int, b):\n    pass", true},
+		{"typed-self-only", "def f(self: MyClass, b):\n    pass", false},
+		{"typed-self-and-other-typed", "def f(self: MyClass, b: int):\n    pass", true},
+		{"typed-cls-only", "def f(cls: MyClass, b):\n    pass", false},
+		{"typed-cls-and-other-typed", "def f(cls: MyClass, b: int):\n    pass", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fn := parseFirstFunc(t, c.code)
+			got := FunctionHasTypedParams(fn, []byte(c.code))
+			if got != c.want {
+				t.Errorf("FunctionHasTypedParams = %v, want %v for code:\n%s", got, c.want, c.code)
+			}
+		})
+	}
+}

--- a/internal/analysis/discovery.go
+++ b/internal/analysis/discovery.go
@@ -226,7 +226,7 @@ func buildTool(fn *sitter.Node, pf ParsedFile, kind models.ToolKind) models.Tool
 			EndLine:  astutil.NodeEndLine(fn),
 		},
 		Description:    astutil.FunctionDocstring(fn, pf.Source),
-		HasTypedParams: astutil.FunctionHasTypedParams(fn),
+		HasTypedParams: astutil.FunctionHasTypedParams(fn, pf.Source),
 		ParamNames:     filtered,
 		Facts:          map[string]string{},
 	}

--- a/internal/rules/predicates_test.go
+++ b/internal/rules/predicates_test.go
@@ -46,7 +46,7 @@ func parsePy(t *testing.T, src string, kind models.ToolKind) (models.ToolDef, an
 			EndLine:  astutil.NodeEndLine(fn),
 		},
 		Description:    doc,
-		HasTypedParams: astutil.FunctionHasTypedParams(fn),
+		HasTypedParams: astutil.FunctionHasTypedParams(fn, b),
 		ParamNames:     filtered,
 		Facts:          map[string]string{},
 	}


### PR DESCRIPTION
## Description

This PR fixes a bug in python tool discovery where method functions using type-annotated `self` or `cls` parameters (e.g. `self: "MyClass"`) were falsely identified as having typed parameters, even when all functional arguments were completely untyped. This directly violates the docstring contract:

> `// FunctionHasTypedParams reports whether the function declares at least one type-annotated parameter (excluding self/cls).`

### Key Changes
1. **Signature & Logic Update**: Updated `FunctionHasTypedParams` in `internal/analysis/astutil/astutil.go` to accept the source bytes (`src []byte`), inspect parameter names, and exclude `self` and `cls` parameters from triggering the type-safety check.
2. **Callsite Synchronization**: Propagated the new parameter through all callsites in `discovery.go`, `adk_agents.go`, and the predicate tests.
3. **Comprehensive Tests**: Added a new unit test suite (`TestFunctionHasTypedParams`) in `astutil_test.go` explicitly checking:
   - Untyped functions (returns `false`).
   - Functions with actual typed parameters (returns `true`).
   - Method functions with only `self` or `cls` typed (returns `false`).
   - Method functions with `self` or `cls` typed along with other typed parameters (returns `true`).

## Verification Plan

### Automated Tests
Run the following test command to exercise the new parser validations:
```bash
go test ./internal/analysis/astutil/...
go test ./internal/analysis/...
go test ./internal/rules/...
```
