### PR TITLE
Trustabl LLM Config Command

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1534,10 +1534,14 @@ take it absent a concrete distribution requirement.
 
 ## 10. What is intentionally out
 
-- **LLM enrichment is opt-in.** `internal/inference/router.go` defines the BYOK
-  interface and an in-process cache; `Call()` returns `ErrLLMDisabled` when
-  no API key is set. The first planned target is upgrading low-confidence
-  rule-based hits to confirmed findings (CSDK-005 raw-exception detection is
+- **LLM enrichment is opt-in.** `internal/llm/` owns key storage
+  (`~/.config/trustabl/keys.json`, mode 0600) and is managed via
+  `trustabl llm` (list / key set|get|delete / model set).
+  `internal/inference/router.go` defines the BYOK call interface;
+  `Call()` returns `ErrLLMDisabled` when no key is configured.
+  Rule-based detection runs fully without a key and makes no network
+  call without one. The first planned enrichment target is upgrading
+  low-confidence rule-based hits to confirmed findings (CSDK-005 is
   the highest-leverage rule for this).
 - **No corpus-eval benchmark.** Detection quality measured on a 20–40
   real-agent-repo corpus is the detection-quality target. The shipped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to Trustabl are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project aims
 to follow Semantic Versioning once it reaches 1.0.
 
+## [Unreleased]
+
+### Added
+
+- **`trustabl llm` — LLM provider configuration.** New command group for
+  managing LLM provider keys and models, stored at
+  `~/.config/trustabl/keys.json` (mode 0600, atomic write):
+  - `trustabl llm list` — table of configured providers with masked keys;
+    active provider marked with `*`.
+  - `trustabl llm key set [key]` — store an API key (prompts securely if
+    key is omitted; validates format for `anthropic` keys).
+  - `trustabl llm key get` — display the masked key for the active provider.
+  - `trustabl llm key delete` — delete the key with a `y/N` confirmation prompt.
+  - `trustabl llm model set <model>` — set the model for the active provider.
+  Defaults: provider `anthropic`, model `claude-haiku-4-5`. Multi-provider
+  shape is in place from day one. Pre-requisite for `trustabl enrich`.
+
 ## [0.1.2] - 2026-06-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -195,9 +195,11 @@ schema's `language:` field is in place for when those parsers ship.
 
 ### Scope boundaries
 
-- **LLM enrichment is opt-in.** The BYOK interface and cache exist
-  (`internal/inference/router.go`), but rule-based detection runs fully
-  without a key and makes no network call without one.
+- **LLM enrichment is opt-in.** Rule-based detection runs fully without a
+  key and makes no network call without one. Use `trustabl llm key set` to
+  configure a provider key (`~/.config/trustabl/keys.json`, mode 0600);
+  `internal/inference/router.go` is the BYOK interface the enrichment path
+  will call.
 - **Confidence scores are heuristic**, not LLM-judged, and not yet
   calibrated against a labelled real-agent corpus — treat findings as
   signal to investigate.
@@ -365,6 +367,14 @@ trustabl scan ./repo --no-rules-update
 # Progress output (human format): animated on a terminal, plain lines when piped
 trustabl scan ./repo                 # spinner + bars on a TTY; "[phase] summary" lines when piped
 trustabl scan ./repo --no-progress   # disable progress entirely
+
+# Configure LLM provider for enrichment (prerequisite for trustabl enrich)
+trustabl llm list                          # show configured providers with masked keys
+trustabl llm key set                       # prompt securely for an API key
+trustabl llm key set sk-ant-api03-...      # set key non-interactively
+trustabl llm key get                       # show masked key for active provider
+trustabl llm key delete                    # delete key with confirmation prompt
+trustabl llm model set claude-sonnet-4-6   # change model for active provider
 ```
 
 Rules are cached under your OS cache dir (`os.UserCacheDir()`, e.g.
@@ -422,6 +432,7 @@ Two fixes:
 | Scoring engine     | `internal/analysis/scoring.go`           |
 | Report renderer    | `internal/review/diff.go` (human), `internal/sarif/render.go` (SARIF), JSON marshal in `cmd/trustabl` |
 | Inference router   | `internal/inference/router.go`           |
+| LLM config         | `internal/llm/` (key storage · masking · validation) |
 
 Rule packs live in the separate `trustabl-rules` git repository (grouped
 `{claude_sdk,openai_sdk,google_adk}/`), resolved at scan time rather

--- a/cmd/trustabl/llm.go
+++ b/cmd/trustabl/llm.go
@@ -1,0 +1,217 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+
+	"github.com/trustabl/trustabl/internal/llm"
+)
+
+func newLLMCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "llm",
+		Short: "Manage LLM provider configuration",
+	}
+	cmd.AddCommand(newLLMListCommand())
+	cmd.AddCommand(newLLMKeyCommand())
+	cmd.AddCommand(newLLMModelCommand())
+	return cmd
+}
+
+// ── list ─────────────────────────────────────────────────────────────────────
+
+func newLLMListCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "Show current LLM configuration",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runLLMList(cmd)
+		},
+	}
+}
+
+func runLLMList(cmd *cobra.Command) error {
+	if !llm.Exists() {
+		fmt.Fprintln(cmd.OutOrStdout(),
+			"No LLM configuration found. Run `trustabl llm key set` to get started.")
+		return nil
+	}
+	cfg, err := llm.Load()
+	if err != nil {
+		return err
+	}
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "PROVIDER\tMODEL\tKEY")
+	names := make([]string, 0, len(cfg.Providers))
+	for name := range cfg.Providers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		p := cfg.Providers[name]
+		active := ""
+		if name == cfg.Active {
+			active = " *"
+		}
+		fmt.Fprintf(w, "%s%s\t%s\t%s\n", name, active, p.Model, llm.MaskKey(p.Key))
+	}
+	return w.Flush()
+}
+
+// ── key ──────────────────────────────────────────────────────────────────────
+
+func newLLMKeyCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "key",
+		Short: "Manage the API key for the active provider",
+	}
+	cmd.AddCommand(newLLMKeySetCommand())
+	cmd.AddCommand(newLLMKeyGetCommand())
+	cmd.AddCommand(newLLMKeyDeleteCommand())
+	return cmd
+}
+
+func newLLMKeySetCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "set [key]",
+		Short: "Store the API key for the active provider",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runLLMKeySet(cmd, args)
+		},
+	}
+}
+
+func runLLMKeySet(cmd *cobra.Command, args []string) error {
+	var key string
+	if len(args) == 1 {
+		key = strings.TrimSpace(args[0])
+	} else {
+		if !term.IsTerminal(int(os.Stdin.Fd())) {
+			return fmt.Errorf("stdin is not a terminal; pass the key as an argument: trustabl llm key set <key>")
+		}
+		fmt.Fprint(os.Stderr, "Enter API key: ")
+		b, err := term.ReadPassword(int(os.Stdin.Fd()))
+		fmt.Fprintln(os.Stderr)
+		if err != nil {
+			return fmt.Errorf("reading API key: %w", err)
+		}
+		key = strings.TrimSpace(string(b))
+	}
+	cfg, err := llm.Load()
+	if err != nil {
+		return err
+	}
+	if err := llm.ValidateKey(cfg.Active, key); err != nil {
+		return err
+	}
+	cfg.SetKey(key)
+	if err := cfg.Save(); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "API key for %s saved.\n", cfg.Active)
+	return nil
+}
+
+func newLLMKeyGetCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "get",
+		Short: "Show the stored API key (masked)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runLLMKeyGet(cmd)
+		},
+	}
+}
+
+func runLLMKeyGet(cmd *cobra.Command) error {
+	cfg, err := llm.Load()
+	if err != nil {
+		return err
+	}
+	p := cfg.ActiveProvider()
+	if p.Key == "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "No API key configured for %s.\n", cfg.Active)
+		return nil
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), llm.MaskKey(p.Key))
+	return nil
+}
+
+func newLLMKeyDeleteCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete",
+		Short: "Delete the stored API key for the active provider",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runLLMKeyDelete(cmd)
+		},
+	}
+}
+
+func runLLMKeyDelete(cmd *cobra.Command) error {
+	cfg, err := llm.Load()
+	if err != nil {
+		return err
+	}
+	p := cfg.ActiveProvider()
+	if p.Key == "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "No API key configured for %s.\n", cfg.Active)
+		return nil
+	}
+	fmt.Fprintf(cmd.ErrOrStderr(), "Delete API key for %s? [y/N]: ", cfg.Active)
+	var response string
+	fmt.Fscanln(cmd.InOrStdin(), &response)
+	if strings.ToLower(strings.TrimSpace(response)) != "y" {
+		fmt.Fprintln(cmd.OutOrStdout(), "Aborted.")
+		return nil
+	}
+	cfg.ClearKey()
+	if err := cfg.Save(); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "API key for %s deleted.\n", cfg.Active)
+	return nil
+}
+
+// ── model ─────────────────────────────────────────────────────────────────────
+
+func newLLMModelCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "model",
+		Short: "Manage the model for the active provider",
+	}
+	cmd.AddCommand(newLLMModelSetCommand())
+	return cmd
+}
+
+func newLLMModelSetCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "set <model>",
+		Short: "Set the model for the active provider",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runLLMModelSet(cmd, args[0])
+		},
+	}
+}
+
+func runLLMModelSet(cmd *cobra.Command, model string) error {
+	cfg, err := llm.Load()
+	if err != nil {
+		return err
+	}
+	cfg.SetModel(model)
+	if err := cfg.Save(); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Model for %s set to %s.\n", cfg.Active, model)
+	return nil
+}

--- a/cmd/trustabl/llm_test.go
+++ b/cmd/trustabl/llm_test.go
@@ -1,0 +1,290 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/trustabl/trustabl/internal/llm"
+)
+
+// setLLMConfigDir overrides the LLM config directory for the duration of the test.
+func setLLMConfigDir(t *testing.T, dir string) {
+	t.Helper()
+	old := llm.ConfigDir
+	llm.ConfigDir = dir
+	t.Cleanup(func() { llm.ConfigDir = old })
+}
+
+func TestLLMList_NoConfig(t *testing.T) {
+	setLLMConfigDir(t, t.TempDir())
+
+	cmd := newLLMListCommand()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "No LLM configuration found") {
+		t.Errorf("got %q, want output containing 'No LLM configuration found'", buf.String())
+	}
+}
+
+func TestLLMList_WithConfig(t *testing.T) {
+	setLLMConfigDir(t, t.TempDir())
+
+	cfg, _ := llm.Load()
+	cfg.SetKey("sk-ant-api03-testkey12345678901234")
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("setup Save() error: %v", err)
+	}
+
+	cmd := newLLMListCommand()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "anthropic") {
+		t.Errorf("output %q missing 'anthropic'", out)
+	}
+	if !strings.Contains(out, "****...") {
+		t.Errorf("output %q missing masked key pattern '****...'", out)
+	}
+}
+
+func TestLLMKeyGet_NoKey(t *testing.T) {
+	setLLMConfigDir(t, t.TempDir())
+
+	cmd := newLLMKeyGetCommand()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "No API key configured") {
+		t.Errorf("got %q, want output containing 'No API key configured'", buf.String())
+	}
+}
+
+func TestLLMKeyGet_WithKey(t *testing.T) {
+	setLLMConfigDir(t, t.TempDir())
+
+	cfg, _ := llm.Load()
+	cfg.SetKey("sk-ant-api03-testkey12345678901234")
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("setup Save() error: %v", err)
+	}
+
+	cmd := newLLMKeyGetCommand()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := strings.TrimSpace(buf.String())
+	if got != "****...1234" {
+		t.Errorf("got %q, want ****...1234", got)
+	}
+}
+
+func TestLLMList_ActiveMarker(t *testing.T) {
+	setLLMConfigDir(t, t.TempDir())
+
+	cfg, _ := llm.Load()
+	cfg.SetKey("sk-ant-api03-testkey12345678901234")
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("setup Save() error: %v", err)
+	}
+
+	cmd := newLLMListCommand()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "anthropic *") {
+		t.Errorf("output %q missing active-provider marker 'anthropic *'", out)
+	}
+}
+
+func TestLLMKeySet_ValidArg(t *testing.T) {
+	setLLMConfigDir(t, t.TempDir())
+
+	cmd := newLLMKeySetCommand()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAA"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "API key for anthropic saved") {
+		t.Errorf("got %q, want confirmation message", buf.String())
+	}
+
+	cfg, err := llm.Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.ActiveProvider().Key != "sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAA" {
+		t.Errorf("Key not persisted, got %q", cfg.ActiveProvider().Key)
+	}
+}
+
+func TestLLMKeySet_InvalidKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		arg     string
+		wantMsg string
+	}{
+		{"wrong prefix", "not-a-valid-key", "invalid API key format"},
+		{"empty arg", "", "must not be empty"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setLLMConfigDir(t, t.TempDir())
+
+			cmd := newLLMKeySetCommand()
+			var buf bytes.Buffer
+			cmd.SetOut(&buf)
+			cmd.SetErr(&buf)
+			cmd.SetArgs([]string{tt.arg})
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatalf("expected error for key %q, got nil", tt.arg)
+			}
+			if !strings.Contains(err.Error(), tt.wantMsg) {
+				t.Errorf("error %q does not contain %q", err.Error(), tt.wantMsg)
+			}
+		})
+	}
+}
+
+func TestLLMKeySet_NonInteractive(t *testing.T) {
+	// When no arg is supplied and stdin is not a terminal (always true in go test),
+	// the command must return an actionable error rather than hanging.
+	setLLMConfigDir(t, t.TempDir())
+
+	cmd := newLLMKeySetCommand()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when stdin is not a terminal, got nil")
+	}
+	if !strings.Contains(err.Error(), "stdin is not a terminal") {
+		t.Errorf("error %q does not mention 'stdin is not a terminal'", err.Error())
+	}
+}
+
+func TestLLMKeyDelete_Confirm(t *testing.T) {
+	setLLMConfigDir(t, t.TempDir())
+
+	cfg, _ := llm.Load()
+	cfg.SetKey("sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAA")
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("setup Save() error: %v", err)
+	}
+
+	cmd := newLLMKeyDeleteCommand()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetIn(strings.NewReader("y\n"))
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "deleted") {
+		t.Errorf("got %q, want confirmation of deletion", buf.String())
+	}
+
+	cfg, err := llm.Load()
+	if err != nil {
+		t.Fatalf("Load() after delete error: %v", err)
+	}
+	if cfg.ActiveProvider().Key != "" {
+		t.Errorf("key still set after delete: %q", cfg.ActiveProvider().Key)
+	}
+}
+
+func TestLLMKeyDelete_Abort(t *testing.T) {
+	setLLMConfigDir(t, t.TempDir())
+
+	cfg, _ := llm.Load()
+	cfg.SetKey("sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAA")
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("setup Save() error: %v", err)
+	}
+
+	for _, input := range []string{"N\n", "n\n", "\n"} {
+		t.Run("input="+strings.TrimSpace(input), func(t *testing.T) {
+			cmd := newLLMKeyDeleteCommand()
+			var buf bytes.Buffer
+			cmd.SetOut(&buf)
+			cmd.SetErr(&buf)
+			cmd.SetIn(strings.NewReader(input))
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !strings.Contains(buf.String(), "Aborted") {
+				t.Errorf("got %q, want 'Aborted'", buf.String())
+			}
+
+			cfg2, err := llm.Load()
+			if err != nil {
+				t.Fatalf("Load() error: %v", err)
+			}
+			if cfg2.ActiveProvider().Key == "" {
+				t.Error("key was deleted despite abort")
+			}
+		})
+	}
+}
+
+func TestLLMKeyDelete_NoKey(t *testing.T) {
+	setLLMConfigDir(t, t.TempDir())
+
+	cmd := newLLMKeyDeleteCommand()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "No API key configured") {
+		t.Errorf("got %q, want 'No API key configured'", buf.String())
+	}
+}
+
+func TestLLMModelSet(t *testing.T) {
+	setLLMConfigDir(t, t.TempDir())
+
+	cmd := newLLMModelSetCommand()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"claude-opus-4-7"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "claude-opus-4-7") {
+		t.Errorf("output %q missing model name", buf.String())
+	}
+
+	cfg, err := llm.Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.ActiveProvider().Model != "claude-opus-4-7" {
+		t.Errorf("model = %q, want claude-opus-4-7", cfg.ActiveProvider().Model)
+	}
+}

--- a/cmd/trustabl/main.go
+++ b/cmd/trustabl/main.go
@@ -62,6 +62,7 @@ func main() {
 	rootCmd.AddCommand(newScanCommand())
 	rootCmd.AddCommand(newVersionCommand())
 	rootCmd.AddCommand(newRulesCommand())
+	rootCmd.AddCommand(newLLMCommand())
 
 	if err := rootCmd.Execute(); err != nil {
 		var ec exitCodeError

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/muesli/termenv v0.15.2
 	github.com/smacker/go-tree-sitter v0.0.0-20240422154435-0628b34cbf9c
 	github.com/spf13/cobra v1.8.0
+	golang.org/x/term v0.18.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -47,7 +48,6 @@ require (
 	golang.org/x/net v0.22.0 // indirect
 	golang.org/x/sync v0.3.0 // indirect
 	golang.org/x/sys v0.28.0 // indirect
-	golang.org/x/term v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/tools v0.13.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -1,0 +1,171 @@
+// Package llm manages LLM provider configuration for Trustabl.
+// Configuration is stored in ~/.config/trustabl/keys.json (mode 0600).
+package llm
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const (
+	defaultProvider = "anthropic"
+	defaultModel    = "claude-haiku-4-5"
+)
+
+// ConfigDir overrides os.UserConfigDir() when non-empty. Intended for tests only.
+var ConfigDir string
+
+// Config holds the full LLM configuration.
+type Config struct {
+	Active    string              `json:"active"`
+	Providers map[string]Provider `json:"providers"`
+}
+
+// Provider holds the model and API key for a single LLM provider.
+type Provider struct {
+	Model string `json:"model"`
+	Key   string `json:"key"`
+}
+
+// ActiveProvider returns the Provider entry for the active provider name.
+func (c *Config) ActiveProvider() Provider {
+	return c.Providers[c.Active]
+}
+
+// SetKey sets the API key for the active provider.
+func (c *Config) SetKey(key string) {
+	if c.Providers == nil {
+		c.Providers = make(map[string]Provider)
+	}
+	p := c.Providers[c.Active]
+	p.Key = key
+	c.Providers[c.Active] = p
+}
+
+// ClearKey removes the API key for the active provider.
+func (c *Config) ClearKey() {
+	if c.Providers == nil {
+		c.Providers = make(map[string]Provider)
+	}
+	p := c.Providers[c.Active]
+	p.Key = ""
+	c.Providers[c.Active] = p
+}
+
+// SetModel sets the model for the active provider.
+func (c *Config) SetModel(model string) {
+	if c.Providers == nil {
+		c.Providers = make(map[string]Provider)
+	}
+	p := c.Providers[c.Active]
+	p.Model = model
+	c.Providers[c.Active] = p
+}
+
+// Load reads configuration from disk. Returns defaults when the file does not exist.
+func Load() (*Config, error) {
+	path, err := configPath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return defaults(), nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("llm: read config: %w", err)
+	}
+	var c Config
+	if err := json.Unmarshal(data, &c); err != nil {
+		return nil, fmt.Errorf("llm: parse config: %w", err)
+	}
+	if c.Active == "" {
+		c.Active = defaultProvider
+	}
+	if c.Providers == nil {
+		c.Providers = make(map[string]Provider)
+	}
+	if _, ok := c.Providers[c.Active]; !ok {
+		c.Providers[c.Active] = Provider{Model: defaultModel}
+	}
+	if p, ok := c.Providers[c.Active]; ok && p.Model == "" {
+		p.Model = defaultModel
+		c.Providers[c.Active] = p
+	}
+	return &c, nil
+}
+
+// Save writes configuration to disk atomically with mode 0600.
+func (c *Config) Save() error {
+	path, err := configPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return fmt.Errorf("llm: create config dir: %w", err)
+	}
+	data, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return fmt.Errorf("llm: marshal config: %w", err)
+	}
+	tmpf, err := os.CreateTemp(filepath.Dir(path), ".keys-*.json.tmp")
+	if err != nil {
+		return fmt.Errorf("llm: create temp config: %w", err)
+	}
+	tmp := tmpf.Name()
+	defer func() { _ = os.Remove(tmp) }() // no-op after successful rename
+	if _, err := tmpf.Write(data); err != nil {
+		_ = tmpf.Close()
+		return fmt.Errorf("llm: write config: %w", err)
+	}
+	if err := tmpf.Close(); err != nil {
+		return fmt.Errorf("llm: close temp config: %w", err)
+	}
+	if err := os.Chmod(tmp, 0600); err != nil {
+		return fmt.Errorf("llm: chmod config: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("llm: rename config: %w", err)
+	}
+	return nil
+}
+
+// Exists reports whether the configuration file exists on disk.
+// Returns false only when the file is confirmed absent (ErrNotExist).
+// Any other error (permissions, I/O) returns true — safer default than
+// treating an unreadable config as "not configured".
+func Exists() bool {
+	path, err := configPath()
+	if err != nil {
+		return false
+	}
+	_, err = os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return false
+	}
+	return true
+}
+
+func configPath() (string, error) {
+	dir := ConfigDir
+	if dir == "" {
+		var err error
+		dir, err = os.UserConfigDir()
+		if err != nil {
+			return "", fmt.Errorf("llm: config dir: %w", err)
+		}
+	}
+	return filepath.Join(dir, "trustabl", "keys.json"), nil
+}
+
+func defaults() *Config {
+	return &Config{
+		Active: defaultProvider,
+		Providers: map[string]Provider{
+			defaultProvider: {Model: defaultModel},
+		},
+	}
+}

--- a/internal/llm/llm_test.go
+++ b/internal/llm/llm_test.go
@@ -1,0 +1,195 @@
+package llm_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/trustabl/trustabl/internal/llm"
+)
+
+// setConfigDir overrides the config directory for the duration of the test.
+func setConfigDir(t *testing.T, dir string) {
+	t.Helper()
+	old := llm.ConfigDir
+	llm.ConfigDir = dir
+	t.Cleanup(func() { llm.ConfigDir = old })
+}
+
+func TestLoad_Defaults(t *testing.T) {
+	setConfigDir(t, t.TempDir())
+
+	cfg, err := llm.Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.Active != "anthropic" {
+		t.Errorf("Active = %q, want anthropic", cfg.Active)
+	}
+	p := cfg.ActiveProvider()
+	if p.Model != "claude-haiku-4-5" {
+		t.Errorf("Model = %q, want claude-haiku-4-5", p.Model)
+	}
+	if p.Key != "" {
+		t.Errorf("Key = %q, want empty", p.Key)
+	}
+}
+
+func TestLoad_RoundTrip(t *testing.T) {
+	setConfigDir(t, t.TempDir())
+
+	cfg, err := llm.Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	cfg.SetKey("sk-ant-api03-testkey12345678901234")
+	cfg.SetModel("claude-opus-4-7")
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	got, err := llm.Load()
+	if err != nil {
+		t.Fatalf("Load() after Save() error: %v", err)
+	}
+	if got.Active != "anthropic" {
+		t.Errorf("Active = %q, want anthropic", got.Active)
+	}
+	p := got.ActiveProvider()
+	if p.Key != "sk-ant-api03-testkey12345678901234" {
+		t.Errorf("Key = %q, want sk-ant-api03-testkey12345678901234", p.Key)
+	}
+	if p.Model != "claude-opus-4-7" {
+		t.Errorf("Model = %q, want claude-opus-4-7", p.Model)
+	}
+}
+
+func TestSave_FilePermissions(t *testing.T) {
+	dir := t.TempDir()
+	setConfigDir(t, dir)
+
+	cfg, _ := llm.Load()
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	path := filepath.Join(dir, "trustabl", "keys.json")
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat() error: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Errorf("file permission = %04o, want 0600", perm)
+	}
+}
+
+func TestSave_Atomic_NoTmpFile(t *testing.T) {
+	dir := t.TempDir()
+	setConfigDir(t, dir)
+
+	cfg, _ := llm.Load()
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	matches, err := filepath.Glob(filepath.Join(dir, "trustabl", ".keys-*.json.tmp"))
+	if err != nil {
+		t.Fatalf("Glob error: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Errorf("tmp files leaked after Save(): %v", matches)
+	}
+}
+
+func TestExists(t *testing.T) {
+	setConfigDir(t, t.TempDir())
+
+	if llm.Exists() {
+		t.Error("Exists() = true before any Save, want false")
+	}
+	cfg, _ := llm.Load()
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+	if !llm.Exists() {
+		t.Error("Exists() = false after Save, want true")
+	}
+}
+
+func TestValidateKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		key      string
+		wantErr  bool
+	}{
+		{
+			name:     "valid anthropic key",
+			provider: "anthropic",
+			key:      "sk-ant-api03-testkey12345678901234",
+			wantErr:  false,
+		},
+		{
+			name:     "empty key",
+			provider: "anthropic",
+			key:      "",
+			wantErr:  true,
+		},
+		{
+			name:     "wrong prefix",
+			provider: "anthropic",
+			key:      "sk-openai-abc12345678901234567890",
+			wantErr:  true,
+		},
+		{
+			name:     "too short after prefix",
+			provider: "anthropic",
+			key:      "sk-ant-short",
+			wantErr:  true,
+		},
+		{
+			name:     "unknown provider accepts any non-empty key",
+			provider: "openai",
+			key:      "sk-proj-anything",
+			wantErr:  false,
+		},
+		{
+			name:     "unknown provider rejects empty key",
+			provider: "openai",
+			key:      "",
+			wantErr:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := llm.ValidateKey(tt.provider, tt.key)
+			if tt.wantErr && err == nil {
+				t.Errorf("ValidateKey(%q, %q) = nil, want error", tt.provider, tt.key)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("ValidateKey(%q, %q) = %v, want nil", tt.provider, tt.key, err)
+			}
+		})
+	}
+}
+
+func TestMaskKey(t *testing.T) {
+	tests := []struct {
+		key  string
+		want string
+	}{
+		{"sk-ant-api03-abc123xyz789", "****...z789"},
+		{"12345", "****...2345"},
+		{"abcd", "****"},
+		{"abc", "****"},
+		{"", "(not set)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			got := llm.MaskKey(tt.key)
+			if got != tt.want {
+				t.Errorf("MaskKey(%q) = %q, want %q", tt.key, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/llm/mask.go
+++ b/internal/llm/mask.go
@@ -1,0 +1,13 @@
+package llm
+
+// MaskKey returns a masked representation of key for display.
+// Keys longer than 4 chars show "****...{last4}"; shorter or equal show "****"; empty shows "(not set)".
+func MaskKey(key string) string {
+	if key == "" {
+		return "(not set)"
+	}
+	if len(key) <= 4 {
+		return "****"
+	}
+	return "****..." + key[len(key)-4:]
+}

--- a/internal/llm/validate.go
+++ b/internal/llm/validate.go
@@ -1,0 +1,26 @@
+package llm
+
+import (
+	"fmt"
+	"regexp"
+)
+
+var keyPatterns = map[string]*regexp.Regexp{
+	"anthropic": regexp.MustCompile(`^sk-ant-[A-Za-z0-9_-]{20,}$`),
+}
+
+// ValidateKey checks that key matches the expected format for provider.
+// Returns nil for unknown providers — validation is deferred to the provider at call time.
+func ValidateKey(provider, key string) error {
+	if key == "" {
+		return fmt.Errorf("API key must not be empty")
+	}
+	pattern, ok := keyPatterns[provider]
+	if !ok {
+		return nil
+	}
+	if !pattern.MatchString(key) {
+		return fmt.Errorf("invalid API key format for %s (expected format: sk-ant-...)", provider)
+	}
+	return nil
+}


### PR DESCRIPTION
### **Summary**

Introduces `trustabl llm` — a CLI for managing LLM provider configuration stored at `~/.config/trustabl/keys.json` (mode 0600). This is a pre-requisite for `trustabl enrich`, which will consume the stored provider, model, and API key at enrichment time without requiring environment variables or flags.

### **What changed**

- **New `internal/llm` package**: `Config` struct with multi-provider JSON schema (`active` + `providers` map), `Load`/`Save` with atomic write (temp file → `chmod 0600` → rename), `ValidateKey` (Anthropic format: `^sk-ant-[A-Za-z0-9_-]{20,}$`), and `MaskKey` (last-4 reveal)
- **New `trustabl llm` command**: Registered on `rootCmd` following the existing `newXxxCommand()` / cobra pattern
  - `trustabl llm list` — sorted provider table with masked keys
  - `trustabl llm key set [key]` — validates and stores key; prompts with hidden input when key is omitted
  - `trustabl llm key get` — prints masked key
  - `trustabl llm key delete` — confirmation prompt before clearing
  - `trustabl llm model set <model>` — sets model for the active provider
- **Defaults**: provider = `anthropic`, model = `claude-haiku-4-5`; multi-provider shape supports adding `openai` or `google` as a new map entrywith no schema migration
- **Documentation**: Updated `ARCHITECTURE.md`, `README.md`, and `CHANGELOG.md`

### **Verification**

- `go test ./...` passes across all packages
- `trustabl llm list` prints "No LLM configuration found." on a clean install - `trustabl llm key set` rejects keys that don't match the Anthropic format 
- Saved file is created with mode `0600`