### PR TITLE
Extends Model Support

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1536,7 +1536,12 @@ take it absent a concrete distribution requirement.
 
 - **LLM enrichment is opt-in.** `internal/llm/` owns key storage
   (`~/.config/trustabl/keys.json`, mode 0600) and is managed via
-  `trustabl llm` (list / key set|get|delete / model set).
+  `trustabl llm` (list / key set|get|delete / model set / provider set|list).
+  The package exposes `Load`/`Save` (atomic write, mode 0600), `SetActive`
+  (switches active provider, auto-creates entry with a per-provider default
+  model), `ValidateKey`, and `MaskKey`. A `defaultModels` map supplies
+  fast/cheap defaults per known provider (`anthropic → claude-haiku-4-5`,
+  `openai → gpt-4.1-nano`, `google → gemini-2.5-flash-lite`).
   `internal/inference/router.go` defines the BYOK call interface;
   `Call()` returns `ErrLLMDisabled` when no key is configured.
   Rule-based detection runs fully without a key and makes no network

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ to follow Semantic Versioning once it reaches 1.0.
 
 ### Added
 
+- **`trustabl llm provider` — provider switching.** New subcommand group for
+  managing which LLM provider is active:
+  - `trustabl llm provider set <provider>` — switch the active provider;
+    auto-creates an entry with a per-provider default model if not yet
+    configured (`anthropic → claude-haiku-4-5`, `openai → gpt-4.1-nano`,
+    `google → gemini-2.5-flash-lite`). Prints a key hint when a new provider
+    is created.
+  - `trustabl llm provider list` — list all configured providers; active
+    provider marked with `*`.
+
 - **`trustabl llm` — LLM provider configuration.** New command group for
   managing LLM provider keys and models, stored at
   `~/.config/trustabl/keys.json` (mode 0600, atomic write):

--- a/README.md
+++ b/README.md
@@ -375,6 +375,8 @@ trustabl llm key set sk-ant-api03-...      # set key non-interactively
 trustabl llm key get                       # show masked key for active provider
 trustabl llm key delete                    # delete key with confirmation prompt
 trustabl llm model set claude-sonnet-4-6   # change model for active provider
+trustabl llm provider set openai           # switch active provider (auto-creates entry)
+trustabl llm provider list                 # list configured providers
 ```
 
 Rules are cached under your OS cache dir (`os.UserCacheDir()`, e.g.

--- a/cmd/trustabl/llm.go
+++ b/cmd/trustabl/llm.go
@@ -21,6 +21,7 @@ func newLLMCommand() *cobra.Command {
 	cmd.AddCommand(newLLMListCommand())
 	cmd.AddCommand(newLLMKeyCommand())
 	cmd.AddCommand(newLLMModelCommand())
+	cmd.AddCommand(newLLMProviderCommand())
 	return cmd
 }
 
@@ -214,4 +215,83 @@ func runLLMModelSet(cmd *cobra.Command, model string) error {
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "Model for %s set to %s.\n", cfg.Active, model)
 	return nil
+}
+
+// ── provider ──────────────────────────────────────────────────────────────────
+
+func newLLMProviderCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "provider",
+		Short: "Manage LLM providers",
+	}
+	cmd.AddCommand(newLLMProviderSetCommand())
+	cmd.AddCommand(newLLMProviderListCommand())
+	return cmd
+}
+
+func newLLMProviderSetCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "set <provider>",
+		Short: "Set the active LLM provider",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runLLMProviderSet(cmd, args[0])
+		},
+	}
+}
+
+func runLLMProviderSet(cmd *cobra.Command, provider string) error {
+	cfg, err := llm.Load()
+	if err != nil {
+		return err
+	}
+	_, existed := cfg.Providers[provider]
+	cfg.SetActive(provider)
+	if err := cfg.Save(); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Active provider set to %s.\n", provider)
+	if !existed {
+		fmt.Fprintf(cmd.OutOrStdout(),
+			"API key for %s is not set. Run `trustabl llm key set` to configure it.\n", provider)
+	}
+	return nil
+}
+
+func newLLMProviderListCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List configured LLM providers",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runLLMProviderList(cmd)
+		},
+	}
+}
+
+func runLLMProviderList(cmd *cobra.Command) error {
+	if !llm.Exists() {
+		fmt.Fprintln(cmd.OutOrStdout(),
+			"No LLM configuration found. Run `trustabl llm key set` to get started.")
+		return nil
+	}
+	cfg, err := llm.Load()
+	if err != nil {
+		return err
+	}
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "PROVIDER")
+	names := make([]string, 0, len(cfg.Providers))
+	for name := range cfg.Providers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		active := ""
+		if name == cfg.Active {
+			active = " *"
+		}
+		fmt.Fprintf(w, "%s%s\n", name, active)
+	}
+	return w.Flush()
 }

--- a/cmd/trustabl/llm_test.go
+++ b/cmd/trustabl/llm_test.go
@@ -288,3 +288,110 @@ func TestLLMModelSet(t *testing.T) {
 		t.Errorf("model = %q, want claude-opus-4-7", cfg.ActiveProvider().Model)
 	}
 }
+
+func TestLLMProviderSet_New(t *testing.T) {
+	setLLMConfigDir(t, t.TempDir())
+
+	cmd := newLLMProviderSetCommand()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"openai"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Active provider set to openai") {
+		t.Errorf("output %q missing confirmation", out)
+	}
+	if !strings.Contains(out, "API key for openai is not set") {
+		t.Errorf("output %q missing key hint for new provider", out)
+	}
+
+	cfg, err := llm.Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.Active != "openai" {
+		t.Errorf("Active = %q, want openai", cfg.Active)
+	}
+	if cfg.Providers["openai"].Model != "gpt-4.1-nano" {
+		t.Errorf("openai model = %q, want gpt-4.1-nano", cfg.Providers["openai"].Model)
+	}
+}
+
+func TestLLMProviderSet_Existing(t *testing.T) {
+	setLLMConfigDir(t, t.TempDir())
+
+	// Pre-configure two providers.
+	cfg, _ := llm.Load()
+	cfg.SetActive("openai")
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("setup Save() error: %v", err)
+	}
+
+	// Switch back to anthropic (already exists).
+	cmd := newLLMProviderSetCommand()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"anthropic"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Active provider set to anthropic") {
+		t.Errorf("output %q missing confirmation", out)
+	}
+	if strings.Contains(out, "API key for anthropic is not set") {
+		t.Errorf("output %q should not show key hint for existing provider", out)
+	}
+}
+
+func TestLLMProviderList_NoConfig(t *testing.T) {
+	setLLMConfigDir(t, t.TempDir())
+
+	cmd := newLLMProviderListCommand()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "No LLM configuration found") {
+		t.Errorf("got %q, want 'No LLM configuration found'", buf.String())
+	}
+}
+
+func TestLLMProviderList_WithConfig(t *testing.T) {
+	setLLMConfigDir(t, t.TempDir())
+
+	// Configure two providers: anthropic (active) and openai.
+	cfg, _ := llm.Load()
+	cfg.SetActive("openai")
+	cfg.SetActive("anthropic") // switch back so anthropic is active
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("setup Save() error: %v", err)
+	}
+
+	cmd := newLLMProviderListCommand()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "anthropic *") {
+		t.Errorf("output %q missing active marker 'anthropic *'", out)
+	}
+	if !strings.Contains(out, "openai") {
+		t.Errorf("output %q missing 'openai'", out)
+	}
+	// Verify anthropic comes before openai (sorted).
+	anthPos := strings.Index(out, "anthropic")
+	openaiPos := strings.Index(out, "openai")
+	if anthPos > openaiPos {
+		t.Errorf("providers not sorted: anthropic at %d, openai at %d", anthPos, openaiPos)
+	}
+}

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -10,10 +10,15 @@ import (
 	"path/filepath"
 )
 
-const (
-	defaultProvider = "anthropic"
-	defaultModel    = "claude-haiku-4-5"
-)
+const defaultProvider = "anthropic"
+
+// defaultModels maps known provider names to their fast/cheap default model.
+// Unknown providers return "" — the user must run `trustabl llm model set`.
+var defaultModels = map[string]string{
+	"anthropic": "claude-haiku-4-5",
+	"openai":    "gpt-4.1-nano",
+	"google":    "gemini-2.5-flash-lite",
+}
 
 // ConfigDir overrides os.UserConfigDir() when non-empty. Intended for tests only.
 var ConfigDir string
@@ -65,6 +70,18 @@ func (c *Config) SetModel(model string) {
 	c.Providers[c.Active] = p
 }
 
+// SetActive sets the active provider, auto-creating its entry with a default
+// model if it does not already exist. Existing entries are never overwritten.
+func (c *Config) SetActive(provider string) {
+	if c.Providers == nil {
+		c.Providers = make(map[string]Provider)
+	}
+	if _, ok := c.Providers[provider]; !ok {
+		c.Providers[provider] = Provider{Model: defaultModels[provider]}
+	}
+	c.Active = provider
+}
+
 // Load reads configuration from disk. Returns defaults when the file does not exist.
 func Load() (*Config, error) {
 	path, err := configPath()
@@ -89,10 +106,10 @@ func Load() (*Config, error) {
 		c.Providers = make(map[string]Provider)
 	}
 	if _, ok := c.Providers[c.Active]; !ok {
-		c.Providers[c.Active] = Provider{Model: defaultModel}
+		c.Providers[c.Active] = Provider{Model: defaultModels[c.Active]}
 	}
 	if p, ok := c.Providers[c.Active]; ok && p.Model == "" {
-		p.Model = defaultModel
+		p.Model = defaultModels[c.Active]
 		c.Providers[c.Active] = p
 	}
 	return &c, nil
@@ -165,7 +182,7 @@ func defaults() *Config {
 	return &Config{
 		Active: defaultProvider,
 		Providers: map[string]Provider{
-			defaultProvider: {Model: defaultModel},
+			defaultProvider: {Model: defaultModels[defaultProvider]},
 		},
 	}
 }

--- a/internal/llm/llm_test.go
+++ b/internal/llm/llm_test.go
@@ -193,3 +193,89 @@ func TestMaskKey(t *testing.T) {
 		})
 	}
 }
+
+func TestDefaultModels(t *testing.T) {
+	tests := []struct {
+		provider  string
+		wantModel string
+	}{
+		{"anthropic", "claude-haiku-4-5"},
+		{"openai", "gpt-4.1-nano"},
+		{"google", "gemini-2.5-flash-lite"},
+		{"localllm", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.provider, func(t *testing.T) {
+			// Use a fresh config with no existing entry to trigger auto-create.
+			cfg := &llm.Config{
+				Active:    "other",
+				Providers: map[string]llm.Provider{},
+			}
+			cfg.SetActive(tt.provider)
+			p := cfg.Providers[tt.provider]
+			if p.Model != tt.wantModel {
+				t.Errorf("SetActive(%q) default model = %q, want %q", tt.provider, p.Model, tt.wantModel)
+			}
+		})
+	}
+}
+
+func TestSetActive_NewProvider(t *testing.T) {
+	setConfigDir(t, t.TempDir())
+
+	cfg, _ := llm.Load()
+	cfg.SetActive("openai")
+
+	if cfg.Active != "openai" {
+		t.Errorf("Active = %q, want openai", cfg.Active)
+	}
+	p := cfg.ActiveProvider()
+	if p.Model != "gpt-4.1-nano" {
+		t.Errorf("Model = %q, want gpt-4.1-nano", p.Model)
+	}
+	if p.Key != "" {
+		t.Errorf("Key = %q, want empty", p.Key)
+	}
+}
+
+func TestSetActive_ExistingProvider(t *testing.T) {
+	setConfigDir(t, t.TempDir())
+
+	cfg, _ := llm.Load()
+	// Set a key on the default anthropic provider.
+	cfg.SetKey("sk-ant-api03-testkey12345678901234")
+	// Switch to openai and back — the anthropic key must survive.
+	cfg.SetActive("openai")
+	cfg.SetActive("anthropic")
+
+	if cfg.Active != "anthropic" {
+		t.Errorf("Active = %q, want anthropic", cfg.Active)
+	}
+	p := cfg.ActiveProvider()
+	if p.Key != "sk-ant-api03-testkey12345678901234" {
+		t.Errorf("Key = %q, want original key preserved", p.Key)
+	}
+}
+
+func TestLoad_NonDefaultActiveProvider(t *testing.T) {
+	dir := t.TempDir()
+	setConfigDir(t, dir)
+
+	// Save a config with openai as active provider (no openai entry yet).
+	cfg, _ := llm.Load()
+	cfg.SetActive("openai")
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	// Load it back — the openai entry must have the openai default model,
+	// not the anthropic default.
+	got, err := llm.Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	p := got.ActiveProvider()
+	if p.Model != "gpt-4.1-nano" {
+		t.Errorf("openai default model = %q, want gpt-4.1-nano", p.Model)
+	}
+}


### PR DESCRIPTION
Introduces `trustabl llm provider set <provider>` and `trustabl llm provider list` to let users switch the active LLM provider and enumerate configured providers.

- SetActive on internal/llm: auto-creates provider entry with per-provider default model (anthropic/openai/google); never overwrites an existing entry
- defaultModels map is now the single source of truth; removed the redundant defaultModel const
- Fixed Load() to use defaultModels[c.Active] instead of defaultModels[defaultProvider] when bootstrapping a missing entry
- Updated ARCHITECTURE.md, README.md, CHANGELOG.md