### PR TITLE
feat(sarif,cli,scoring): Code-Scanning-valid SARIF, dual-output flags, projected_scores

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -700,6 +700,16 @@ Both `saturation` and the severity weights in [models.SeverityWeight](internal/m
 are initial values pending corpus calibration (architecture § 8). They live in one
 place so the curve can be tuned without touching detectors.
 
+`ScanResult.projected_scores` ([analysis.Project](internal/analysis/scoring.go))
+carries five overall-score projections — `fix_critical`, `fix_high`,
+`fix_medium`, `fix_low`, `fix_all` — each the real `Score` overall recomputed
+with findings at or above that severity tier treated as resolved (dropped),
+cumulatively. It is an estimate, **not a re-scan**: it assumes a fixed finding
+vanishes cleanly and introduces nothing new. Values are non-decreasing
+`fix_critical → fix_all` and each is ≥ the unprojected `overall_score`. Consumers
+(e.g. the GitHub Action's "headroom ladder") read these instead of recomputing
+scoring, keeping the formula in one place.
+
 ### Step 6 — Review ([internal/review/](internal/review/))
 
 The scan is read-only: review renders the `ScanResult`, it does not write
@@ -719,18 +729,26 @@ anything into the scanned repo.
   to a closed-source project), and the renderer has no signal for "was an
   openshell rule loaded."
 - `--format json` marshals the `ScanResult` directly (in `cmd/trustabl`), for
-  CI consumers.
+  CI consumers. `--json-out <file>` / `--sarif-out <file>` additionally persist
+  the JSON / SARIF document to a file independent of `--format`, so a single scan
+  can print the human panel to stdout while writing both machine artifacts
+  (byte-identical to the matching `--format` stdout output).
 
 ### SARIF output (`--format sarif`)
 
 `internal/sarif.Render(ScanResult)` emits a SARIF 2.1.0 JSON document that
-`github/codeql-action/upload-sarif` and other SARIF consumers accept
-unchanged. The field-mapping rules — severity bucketing, the META finding
+GitHub Code Scanning (`github/codeql-action/upload-sarif`) and other SARIF
+consumers accept. The field-mapping rules — severity bucketing, the META finding
 split between results and notifications, the `partialFingerprints` scheme,
 and rule-catalog inclusion — are recorded in the spec at
-`.superpowers/specs/2026-05-24-sarif-output-design.md`. Like JSON, SARIF is
-a pure function of `ScanResult`: no clocks, no map-iteration leakage,
-byte-stable per `ScanID`.
+`.superpowers/specs/2026-05-24-sarif-output-design.md`. A rule's suggested fix is
+carried once at the rule level as `help.text`; Trustabl deliberately emits **no
+per-result `fixes[]`**, because the SARIF spec requires a `fix` to carry
+`artifactChanges` (a concrete patch) while Trustabl's fixes are prose advice — a
+described-but-patchless result is both honest and accepted by the Code Scanning
+schema validator, which rejects a `fixes[]` entry lacking `artifactChanges`. Like
+JSON, SARIF is a pure function of `ScanResult`: no clocks, no map-iteration
+leakage, byte-stable per `ScanID`.
 
 An earlier version of Trustabl also generated committable artifacts
 (Pre/PostToolUse hook scripts, an OpenShell sandbox-policy starter) and could
@@ -1453,6 +1471,7 @@ timestamp, no map iteration order, no goroutine scheduling may influence output.
 
 ```
 trustabl scan <target> [--detectors=…] [--format=human|json|sarif]
+                       [--json-out=FILE] [--sarif-out=FILE]
                        [--strict] [--no-color] [--no-progress]
                        [--rules-repo=URL] [--rules-ref=REF] [--no-rules-update]
 trustabl rules pull    [--rules-repo=URL] [--rules-ref=REF]

--- a/README.md
+++ b/README.md
@@ -243,7 +243,15 @@ interactive terminal, or plain `[phase] summary` lines when piped
 own automation.
 
 `--format sarif` emits a SARIF 2.1.0 document, suitable for
-`github/codeql-action/upload-sarif` and other SARIF-aware tools.
+`github/codeql-action/upload-sarif` and other SARIF-aware tools. The suggested
+fix is carried at the rule level (`help.text`); Trustabl emits no per-result
+`fixes[]`, so the document passes GitHub Code Scanning's schema validator (which
+rejects a `fix` that lacks `artifactChanges`).
+
+`--json-out <file>` and `--sarif-out <file>` write the JSON / SARIF document to a
+file independent of `--format` — one scan can print the human summary to stdout
+while persisting both machine artifacts. The file bytes are identical to the
+matching `--format` stdout output.
 
 `--format json` and `--format sarif` are progress-silent and byte-stable
 across identical-input runs (pure functions of the `ScanResult`). The human
@@ -344,6 +352,9 @@ trustabl scan ./repo --format json
 
 # SARIF output for GitHub Code Scanning / SARIF-aware tools
 trustabl scan ./repo --format sarif > trustabl.sarif
+
+# One scan, both machine artifacts written to files (human summary to stdout)
+trustabl scan ./repo --json-out trustabl.json --sarif-out trustabl.sarif
 
 # Exit 1 on any finding regardless of severity
 trustabl scan ./repo --strict

--- a/cmd/trustabl/main.go
+++ b/cmd/trustabl/main.go
@@ -94,6 +94,8 @@ type scanFlags struct {
 	rulesRef      string
 	noRulesUpdate bool
 	noProgress    bool
+	jsonOut       string
+	sarifOut      string
 }
 
 func newScanCommand() *cobra.Command {
@@ -122,6 +124,10 @@ func newScanCommand() *cobra.Command {
 		"do not fetch rules; use the local cache only")
 	cmd.Flags().BoolVar(&f.noProgress, "no-progress", false,
 		"disable real-time progress output")
+	cmd.Flags().StringVar(&f.jsonOut, "json-out", "",
+		"also write the JSON ScanResult to this file (independent of --format)")
+	cmd.Flags().StringVar(&f.sarifOut, "sarif-out", "",
+		"also write the SARIF report to this file (independent of --format)")
 	return cmd
 }
 
@@ -295,24 +301,63 @@ func finishScan(result models.ScanResult, jobErr error, f scanFlags) error {
 		return fmt.Errorf("unknown --format %q", f.format)
 	}
 
+	// --json-out / --sarif-out persist the respective format to a file
+	// independent of --format, so one scan can print the human panel to stdout
+	// while writing machine artifacts. The bytes are identical to the matching
+	// --format stdout output (shared renderers).
+	if err := writeSideOutputs(result, f); err != nil {
+		return err
+	}
+
 	if code := exitCode(result, f.strict); code != 0 {
 		return exitCodeError{code}
 	}
 	return nil
 }
 
-func emitJSON(result models.ScanResult) error {
+// jsonBytes renders the ScanResult as the canonical pretty JSON document
+// (trailing newline). Shared by stdout (--format json) and file (--json-out) so
+// the two are byte-identical.
+func jsonBytes(result models.ScanResult) ([]byte, error) {
 	b, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(b, '\n'), nil
+}
+
+func emitJSON(result models.ScanResult) error {
+	b, err := jsonBytes(result)
 	if err != nil {
 		return err
 	}
-	_, err = os.Stdout.Write(append(b, '\n'))
+	_, err = os.Stdout.Write(b)
 	return err
 }
 
 func emitSARIF(result models.ScanResult) error {
 	_, err := os.Stdout.Write(sarif.Render(result, version))
 	return err
+}
+
+// writeSideOutputs honors --json-out / --sarif-out, writing each format to its
+// file when the flag is set. No-op when both are empty.
+func writeSideOutputs(result models.ScanResult, f scanFlags) error {
+	if f.jsonOut != "" {
+		b, err := jsonBytes(result)
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(f.jsonOut, b, 0o644); err != nil {
+			return fmt.Errorf("write --json-out: %w", err)
+		}
+	}
+	if f.sarifOut != "" {
+		if err := os.WriteFile(f.sarifOut, sarif.Render(result, version), 0o644); err != nil {
+			return fmt.Errorf("write --sarif-out: %w", err)
+		}
+	}
+	return nil
 }
 
 func exitCode(result models.ScanResult, strict bool) int {

--- a/internal/analysis/scoring.go
+++ b/internal/analysis/scoring.go
@@ -132,3 +132,49 @@ func overallScore(surfaces []models.SurfaceReadiness) float64 {
 	}
 	return num / den
 }
+
+// severityRank maps a severity to an ordinal for tier comparisons: info/unknown
+// 0, low 1, medium 2, high 3, critical 4.
+func severityRank(s models.Severity) int {
+	switch s {
+	case models.SeverityCritical:
+		return 4
+	case models.SeverityHigh:
+		return 3
+	case models.SeverityMedium:
+		return 2
+	case models.SeverityLow:
+		return 1
+	default: // info, unknown
+		return 0
+	}
+}
+
+// Project computes overall-score projections by cumulatively resolving findings
+// at each severity tier and recomputing the real overall via Score(). For a
+// given tier, every finding at or above it is treated as resolved (dropped) and
+// the remaining findings are re-scored against the same seeded surfaces. This is
+// an estimate, not a re-scan: it assumes resolved findings vanish cleanly and
+// introduce nothing new. Results are non-decreasing FixCritical → FixAll and
+// each is ≥ the unprojected overall.
+func Project(tools []models.ToolDef, agents []models.AgentDef, subagents []models.SubagentDef, findings []models.Finding) models.ProjectedScores {
+	// overallResolvingFrom recomputes the overall keeping only findings strictly
+	// below minResolvedRank (i.e. resolving everything at or above that rank).
+	overallResolvingFrom := func(minResolvedRank int) float64 {
+		kept := make([]models.Finding, 0, len(findings))
+		for _, f := range findings {
+			if severityRank(f.Severity) < minResolvedRank {
+				kept = append(kept, f)
+			}
+		}
+		_, overall := Score(tools, agents, subagents, kept)
+		return overall
+	}
+	return models.ProjectedScores{
+		FixCritical: overallResolvingFrom(4), // resolve critical
+		FixHigh:     overallResolvingFrom(3), // resolve high and above
+		FixMedium:   overallResolvingFrom(2), // resolve medium and above
+		FixLow:      overallResolvingFrom(1), // resolve low and above
+		FixAll:      overallResolvingFrom(0), // resolve everything (incl. info)
+	}
+}

--- a/internal/analysis/scoring_test.go
+++ b/internal/analysis/scoring_test.go
@@ -218,3 +218,73 @@ func TestScore_EmptyReturnsOne(t *testing.T) {
 		t.Errorf("overall: got %v, want 1.0", overall)
 	}
 }
+
+// TestProject_EmptyReturnsAllOne: a clean repo (tools, no findings) projects to
+// 1.0 at every tier.
+func TestProject_EmptyReturnsAllOne(t *testing.T) {
+	tools := []models.ToolDef{tool("search", "a.py")}
+	p := analysis.Project(tools, nil, nil, nil)
+	for name, v := range map[string]float64{
+		"fix_critical": p.FixCritical, "fix_high": p.FixHigh, "fix_medium": p.FixMedium,
+		"fix_low": p.FixLow, "fix_all": p.FixAll,
+	} {
+		if math.Abs(v-1.0) > eps {
+			t.Errorf("%s: got %v, want 1.0", name, v)
+		}
+	}
+}
+
+// TestProject_MonotonicAndAboveOverall: with findings spread across surfaces and
+// severities, projections are non-decreasing crit→all, each ≥ the unprojected
+// overall, and fix_all == 1.0 (everything resolved → all surfaces clean).
+func TestProject_MonotonicAndAboveOverall(t *testing.T) {
+	tools := []models.ToolDef{tool("a", "a.py"), tool("b", "b.py"), tool("c", "c.py")}
+	findings := []models.Finding{
+		{RuleID: "X1", Scope: models.ScopeTool, ToolName: "a", FilePath: "a.py", Severity: models.SeverityCritical, Confidence: 1.0},
+		{RuleID: "X2", Scope: models.ScopeTool, ToolName: "b", FilePath: "b.py", Severity: models.SeverityHigh, Confidence: 1.0},
+		{RuleID: "X3", Scope: models.ScopeTool, ToolName: "c", FilePath: "c.py", Severity: models.SeverityLow, Confidence: 1.0},
+	}
+	_, overall := analysis.Score(tools, nil, nil, findings)
+	p := analysis.Project(tools, nil, nil, findings)
+
+	if p.FixCritical < overall-eps {
+		t.Errorf("fix_critical (%v) must be >= overall (%v)", p.FixCritical, overall)
+	}
+	if !(p.FixCritical > overall) {
+		t.Errorf("resolving the critical finding must raise the score: fix_critical=%v overall=%v", p.FixCritical, overall)
+	}
+	chain := []float64{p.FixCritical, p.FixHigh, p.FixMedium, p.FixLow, p.FixAll}
+	for i := 1; i < len(chain); i++ {
+		if chain[i] < chain[i-1]-eps {
+			t.Errorf("projection not monotonic at tier %d: %v then %v (full: %+v)", i, chain[i-1], chain[i], p)
+		}
+	}
+	if math.Abs(p.FixAll-1.0) > eps {
+		t.Errorf("fix_all: got %v, want 1.0 (all findings resolved)", p.FixAll)
+	}
+}
+
+// TestProject_InfoResolvedOnlyAtFixAll: an info-only finding survives every tier
+// except fix_all, so the lower tiers equal the unprojected overall and only
+// fix_all climbs to 1.0. Guards the tier boundary (info has rank 0).
+func TestProject_InfoResolvedOnlyAtFixAll(t *testing.T) {
+	tools := []models.ToolDef{tool("a", "a.py")}
+	findings := []models.Finding{
+		{RuleID: "I1", Scope: models.ScopeTool, ToolName: "a", FilePath: "a.py", Severity: models.SeverityInfo, Confidence: 1.0},
+	}
+	_, overall := analysis.Score(tools, nil, nil, findings)
+	p := analysis.Project(tools, nil, nil, findings)
+	for name, v := range map[string]float64{
+		"fix_critical": p.FixCritical, "fix_high": p.FixHigh, "fix_medium": p.FixMedium, "fix_low": p.FixLow,
+	} {
+		if math.Abs(v-overall) > eps {
+			t.Errorf("%s: got %v, want overall %v (info finding must not resolve below fix_all)", name, v, overall)
+		}
+	}
+	if math.Abs(p.FixAll-1.0) > eps {
+		t.Errorf("fix_all: got %v, want 1.0", p.FixAll)
+	}
+	if overall >= 1.0 {
+		t.Errorf("sanity: overall with an info finding (%v) should be < 1.0", overall)
+	}
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -162,6 +162,21 @@ type SurfaceReadiness struct {
 	WeightedSeverity float64 `json:"weighted_severity"`
 }
 
+// ProjectedScores are overall-score projections after resolving findings up to
+// and including each severity tier, cumulatively. Each value is the real
+// overall score (see analysis.Score) recomputed with the remaining findings —
+// an ESTIMATE, not a re-scan: it assumes each resolved finding is removed
+// cleanly and introduces nothing new. Values are in [0,1] and non-decreasing
+// from FixCritical → FixAll. Single source of truth for the "headroom" ladder;
+// consumers (e.g. the GitHub Action) must not recompute scoring.
+type ProjectedScores struct {
+	FixCritical float64 `json:"fix_critical"` // resolve all critical findings
+	FixHigh     float64 `json:"fix_high"`     // + all high
+	FixMedium   float64 `json:"fix_medium"`   // + all medium
+	FixLow      float64 `json:"fix_low"`      // + all low
+	FixAll      float64 `json:"fix_all"`      // + all info (everything resolved)
+}
+
 // ScanManifest is what the Normalizer produces.
 type ScanManifest struct {
 	RepoRoot               string           `json:"repo_root"`
@@ -265,6 +280,7 @@ type ScanResult struct {
 	Findings            []Finding          `json:"findings"`
 	Surfaces            []SurfaceReadiness `json:"surfaces"`
 	OverallScore        float64            `json:"overall_score"`
+	ProjectedScores     ProjectedScores    `json:"projected_scores"`
 	RulesSource         string             `json:"rules_source"`     // repo the rule pack came from
 	RulesVersion        string             `json:"rules_version"`    // resolved rules commit SHA
 	RulesFromCache      bool               `json:"rules_from_cache"` // true if rules came from cache (network skipped/unreachable)

--- a/internal/sarif/render.go
+++ b/internal/sarif/render.go
@@ -133,7 +133,10 @@ func ruleFromFinding(f models.Finding) ReportingDescriptor {
 		},
 	}
 	// Omit help entirely when there's no fix text — an empty help.text is noise
-	// for SARIF viewers. Mirrors the guard on result.Fixes.
+	// for SARIF viewers. help.text is the SOLE carrier of the suggested fix:
+	// Trustabl fixes are prose advice, not concrete patches, so a per-result
+	// SARIF fixes[] (which the spec requires to carry artifactChanges) would be
+	// both dishonest and rejected by the GitHub Code Scanning schema validator.
 	if f.SuggestedFix != "" {
 		rd.Help = &Message{Text: f.SuggestedFix}
 	}
@@ -160,10 +163,6 @@ func resultFromFinding(f models.Finding, ruleIndex *int, useBase bool) Result {
 	}
 	rank := f.Confidence * 100
 	r.Rank = &rank
-
-	if f.SuggestedFix != "" {
-		r.Fixes = []Fix{{Description: Message{Text: f.SuggestedFix}}}
-	}
 
 	// Locations: physical when we have a file; logical when we have a tool name.
 	if f.FilePath != "" {

--- a/internal/sarif/render_test.go
+++ b/internal/sarif/render_test.go
@@ -150,9 +150,11 @@ func TestResultFromFinding_LocatedToolFinding(t *testing.T) {
 	if loc.LogicalLocations[0].Kind != "function" {
 		t.Errorf("LogicalLocation Kind = %q", loc.LogicalLocations[0].Kind)
 	}
-	if len(r.Fixes) != 1 || r.Fixes[0].Description.Text != f.SuggestedFix {
-		t.Errorf("Fixes = %+v", r.Fixes)
-	}
+	// Suggested-fix text is intentionally NOT emitted as a per-result fixes[]
+	// entry: the SARIF spec requires fixes[] to carry artifactChanges, which
+	// Trustabl's prose advice cannot honestly provide, and GitHub Code Scanning
+	// rejects the document otherwise. The fix is carried once at the rule level
+	// via help.text — see TestRuleFromFinding (rd.Help) above.
 	if r.Rank == nil || *r.Rank != 85.0 {
 		t.Errorf("Rank = %v, want 85.0", r.Rank)
 	}

--- a/internal/sarif/testdata/golden.sarif.json
+++ b/internal/sarif/testdata/golden.sarif.json
@@ -169,13 +169,6 @@
               ]
             }
           ],
-          "fixes": [
-            {
-              "description": {
-                "text": "Pass timeout=5 to the request."
-              }
-            }
-          ],
           "rank": 85,
           "partialFingerprints": {
             "primaryLocationLineHash": "80ef6bbb4cfc3b2f7693a435688afc27b72afe9e4aa3b898154c6d751ca037a7"

--- a/internal/sarif/types.go
+++ b/internal/sarif/types.go
@@ -56,7 +56,6 @@ type Result struct {
 	Kind                string            `json:"kind,omitempty"` // omit for default "fail"; set "informational" otherwise
 	Message             Message           `json:"message"`
 	Locations           []Location        `json:"locations,omitempty"`
-	Fixes               []Fix             `json:"fixes,omitempty"`
 	Rank                *float64          `json:"rank,omitempty"`
 	PartialFingerprints map[string]string `json:"partialFingerprints,omitempty"`
 	Properties          map[string]any    `json:"properties,omitempty"`
@@ -84,10 +83,6 @@ type Region struct {
 type LogicalLocation struct {
 	Name string `json:"name"`
 	Kind string `json:"kind,omitempty"`
-}
-
-type Fix struct {
-	Description Message `json:"description"`
 }
 
 type Invocation struct {

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -199,6 +199,7 @@ func Run(cfg Config) (models.ScanResult, error) {
 
 	// Step 5: scoring
 	surfaces, overall := analysis.Score(tools, inventory.Agents, inventory.Subagents, findings)
+	projected := analysis.Project(tools, inventory.Agents, inventory.Subagents, findings)
 
 	// Coverage: how many AST-targeted source files we actually parsed vs. how
 	// many we attempted. Discovery skips files it cannot read or parse (one bad
@@ -233,6 +234,7 @@ func Run(cfg Config) (models.ScanResult, error) {
 		Findings:            findings,
 		Surfaces:            surfaces,
 		OverallScore:        overall,
+		ProjectedScores:     projected,
 		RulesSource:         cfg.RulesSource,
 		RulesVersion:        cfg.RulesVersion,
 		RulesFromCache:      cfg.RulesFromCache,

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -192,6 +192,18 @@ func TestScan_GoogleADKDemoFiresExpectedRules(t *testing.T) {
 	if res.OverallScore >= 1.0 {
 		t.Errorf("OverallScore = %v; want < 1.0 (non-tool rules fired: %v)", res.OverallScore, fired)
 	}
+
+	// projected_scores must be populated by the scanner, monotonic (resolving
+	// more findings never lowers the score), and every tier must sit at or above
+	// the unprojected overall. fix_all resolves everything, so it is the ceiling.
+	p := res.ProjectedScores
+	if !(p.FixCritical >= res.OverallScore && p.FixHigh >= p.FixCritical &&
+		p.FixMedium >= p.FixHigh && p.FixLow >= p.FixMedium && p.FixAll >= p.FixLow) {
+		t.Errorf("projected_scores not monotonic/above overall: overall=%v projected=%+v", res.OverallScore, p)
+	}
+	if p.FixAll < res.OverallScore {
+		t.Errorf("projected_scores.fix_all (%v) must be >= overall (%v)", p.FixAll, res.OverallScore)
+	}
 }
 
 func TestScan_SurfacesNewInventoryFields(t *testing.T) {


### PR DESCRIPTION
## What

Engine support for the trustabl-action v2 rewrite, plus a standalone SARIF fix.

- **SARIF is now Code-Scanning-valid.** Removed the per-result `fixes[]` — it lacked the `artifactChanges` the GitHub Code Scanning schema validator requires. The suggested fix is already carried at the rule level via `help.text`, so nothing is lost. Golden regenerated (diff is exactly the `fixes` removal).
- **`--json-out` / `--sarif-out`.** One scan can write both machine artifacts to files independent of `--format`, byte-identical to the matching stdout output. Lets the action scan once instead of twice.
- **`projected_scores`.** New `ScanResult.projected_scores` (`analysis.Project`): the real `Score()` recomputed with findings resolved cumulatively per severity tier (critical → +high → +medium → +low → +all). Non-decreasing, each ≥ `overall_score`. Single source of truth for the action's headroom ladder (replaces a buggy in-action jq reimplementation).

## Tests
- `go test ./...` green; new `TestProject_*` (monotonicity + tier boundaries) and an end-to-end scanner assertion.
- Manually verified `--json-out`/`--sarif-out` produce byte-identical output to `--format` stdout, and that the SARIF no longer carries `fixes`.

## Notes
- No rule-schema change → no `schema_version` bump.
- After this merges and an engine release is cut, set `MIN_ENGINE_VERSION` in `trustabl-action` to that tag.
