### PR TITLE
style(analysis): gofmt-clean ts_handler_facts.go

### DIFF
--- a/internal/analysis/ts_handler_facts.go
+++ b/internal/analysis/ts_handler_facts.go
@@ -78,7 +78,7 @@ func tsHandlerFacts(handler *sitter.Node, src []byte) map[string]string {
 //
 // Verified tree-sitter node types (typescript grammar):
 //   - Plain string (`"..."` or `'...'`): type "string".
-//   - Template string (`` `...` ``): type "template_string"; backtick delimiters
+//   - Template string (“ `...` “): type "template_string"; backtick delimiters
 //     are anonymous children, so a plain backtick template with no ${...} has
 //     NamedChildCount() == 0, while one with substitutions has at least one
 //     "template_substitution" named child (NamedChildCount() > 0).


### PR DESCRIPTION
## What

Runs `gofmt -w` on `internal/analysis/ts_handler_facts.go` to clear a pre-existing formatting drift. Before this change, `gofmt -l internal/` listed this one file; after it, `gofmt -l internal/` is empty.

## Why

Standalone formatting hygiene, unrelated to any feature work. Keeps the tree gofmt-clean so the drift doesn't ride along in an unrelated PR.

## The change

A single doc-comment line. gofmt's doc-comment formatter rewrites the legacy doubled-backtick markup into the Unicode left double-quote glyph (`“`). No code or logic change.

Diff: **1 file changed, 1 insertion(+), 1 deletion(-)**.

## Verification

- `gofmt -l internal/` → empty (clean)
- `go test -count=1 ./internal/analysis/` → `ok`