### PR TITLE
fix(rules): accept the mcp policy category

### DIFF
--- a/cmd/trustabl/main.go
+++ b/cmd/trustabl/main.go
@@ -111,7 +111,7 @@ func newScanCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&f.detectors, "detectors", "",
-		"comma-separated detector categories: claude_sdk, openai_sdk, openshell, google_adk (default: all)")
+		"comma-separated detector categories: claude_sdk, openai_sdk, openshell, google_adk, mcp (default: all)")
 	cmd.Flags().StringVar(&f.format, "format", "human",
 		"output format: human|json|sarif")
 	cmd.Flags().BoolVar(&f.strict, "strict", false,
@@ -441,10 +441,10 @@ func parseCategories(s string) ([]models.DetectorCategory, error) {
 		c := models.DetectorCategory(strings.TrimSpace(raw))
 		switch c {
 		case models.CategoryClaudeSDK, models.CategoryOpenAISDK,
-			models.CategoryOpenShell, models.CategoryGoogleADK:
+			models.CategoryOpenShell, models.CategoryGoogleADK, models.CategoryMCP:
 			out = append(out, c)
 		default:
-			return nil, fmt.Errorf("unknown detector category %q (allowed: claude_sdk, openai_sdk, openshell, google_adk)", c)
+			return nil, fmt.Errorf("unknown detector category %q (allowed: claude_sdk, openai_sdk, openshell, google_adk, mcp)", c)
 		}
 	}
 	return out, nil

--- a/internal/rules/loader_test.go
+++ b/internal/rules/loader_test.go
@@ -59,6 +59,42 @@ func TestLoader_ValidFile(t *testing.T) {
 	}
 }
 
+// TestLoader_MCPCategory verifies the mcp policy category loads. The trustabl-rules
+// repo ships an mcp/ pack; the engine must accept category: mcp (regression for the
+// drift where the rules repo shipped mcp rules no engine could load).
+func TestLoader_MCPCategory(t *testing.T) {
+	const mcpYAML = `
+policy:
+  id: mcp_test
+  name: MCP Test
+  category: mcp
+  description: Test mcp policy.
+rules:
+  - id: MCP-999
+    title: An mcp test rule
+    scope: tool
+    severity: low
+    confidence: 0.8
+    applies_to:
+      - mcp_tool
+    match:
+      has_docstring: true
+    explanation: Some explanation.
+    fix: Some fix.
+`
+	fsys := makeFS(map[string]string{"mcp/test.yaml": mcpYAML})
+	policies, err := rules.Load(fsys)
+	if err != nil {
+		t.Fatalf("loading an mcp-category policy should succeed, got: %v", err)
+	}
+	if len(policies) != 1 || len(policies[0].Rules) != 1 {
+		t.Fatalf("expected 1 policy with 1 rule, got %+v", policies)
+	}
+	if string(policies[0].Rules[0].Category) != "mcp" {
+		t.Errorf("rule.Category = %q, want mcp", policies[0].Rules[0].Category)
+	}
+}
+
 func TestLoader_MissingRequiredField(t *testing.T) {
 	const noTitle = `
 policy:


### PR DESCRIPTION
## Problem

`trustabl-rules` ships an `mcp/` pack (`category: mcp`, commit `2d91afa`), but **no engine build can load it** — the loader's `policy.category` switch and the CLI `--detectors` parser only allowed `claude_sdk`, `openai_sdk`, `openshell`, `google_adk`. Any scan against current rules fails:

```
Error: load rules: mcp/code_execution.yaml: unknown category "mcp"
  (allowed: claude_sdk, openai_sdk, openshell, google_adk)
```

Verified against released `v0.1.2`, current `main`, and a fresh local build. This breaks `trustabl scan`, the GitHub Action, and the VS Code extension whenever they fetch the latest rules.

## Fix

`mcp` support was half-wired: `models.SDKMCP` exists, `LoadFor` already maps `SDKMCP → "mcp"` pack, and the `applies_to` / `repo_has_sdk_in_code` validators already accept `mcp`. Only the `DetectorCategory` enum and two `switch`es were missing. This PR adds:

- `models.CategoryMCP = "mcp"`
- the loader `policy.category` switch case (+ error-message update)
- the CLI `parseCategories` case + `--detectors` flag help

## Verification

- `go test ./...` green; new `TestLoader_MCPCategory`.
- Manual: a fresh build scans against the **latest** rules (mcp pack) → exit 0, JSON produced (was exit 2). `--detectors mcp` is accepted.

## Note

This is the engine half of unblocking the trustabl-action v2 CI (the action's selftest currently fails because the released engine can't load current rules). Once an engine release ships this, the action can drop its temporary stopgap pin.