### PR TITLE
fix(cli): reject colliding output paths and unknown llm providers

### DIFF
--- a/cmd/trustabl/llm.go
+++ b/cmd/trustabl/llm.go
@@ -241,6 +241,10 @@ func newLLMProviderSetCommand() *cobra.Command {
 }
 
 func runLLMProviderSet(cmd *cobra.Command, provider string) error {
+	if !llm.IsKnownProvider(provider) {
+		return fmt.Errorf("unknown provider %q (known providers: %s)",
+			provider, strings.Join(llm.KnownProviders(), ", "))
+	}
 	cfg, err := llm.Load()
 	if err != nil {
 		return err

--- a/cmd/trustabl/main.go
+++ b/cmd/trustabl/main.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -141,6 +142,9 @@ func newScanCommand() *cobra.Command {
 }
 
 func runScan(target string, f scanFlags) error {
+	if err := validateOutputFlags(f); err != nil {
+		return err
+	}
 	cfg := scanner.Config{Target: target}
 	if f.detectors != "" {
 		cats, err := parseCategories(f.detectors)
@@ -211,6 +215,26 @@ func runScan(target string, f scanFlags) error {
 	}
 	out := <-done
 	return finishScan(out.result, out.err, f)
+}
+
+// validateOutputFlags rejects output destinations that collide. --output writes
+// the --format report to a file; --json-out/--sarif-out write those formats to
+// files independently. Pointing two of them at one path writes it twice and,
+// across formats, silently clobbers — so require distinct paths.
+func validateOutputFlags(f scanFlags) error {
+	out := filepath.Clean(f.output)
+	jsonOut := filepath.Clean(f.jsonOut)
+	sarifOut := filepath.Clean(f.sarifOut)
+	if f.output != "" && f.jsonOut != "" && out == jsonOut {
+		return fmt.Errorf("--output and --json-out point at the same file (%s); use distinct paths", f.output)
+	}
+	if f.output != "" && f.sarifOut != "" && out == sarifOut {
+		return fmt.Errorf("--output and --sarif-out point at the same file (%s); use distinct paths", f.output)
+	}
+	if f.jsonOut != "" && f.sarifOut != "" && jsonOut == sarifOut {
+		return fmt.Errorf("--json-out and --sarif-out point at the same file (%s); use distinct paths", f.jsonOut)
+	}
+	return nil
 }
 
 // pickScanMode maps flags + stderr TTY state to a progress mode.

--- a/cmd/trustabl/main_test.go
+++ b/cmd/trustabl/main_test.go
@@ -309,3 +309,30 @@ func TestSARIFToFile_RoundTrip(t *testing.T) {
 		t.Errorf("exitCode = %d, want 1 (a high finding present)", exitCode(result, false))
 	}
 }
+
+func TestValidateOutputFlags(t *testing.T) {
+	cases := []struct {
+		name    string
+		f       scanFlags
+		wantErr bool
+	}{
+		{"all empty", scanFlags{}, false},
+		{"output only", scanFlags{output: "r.txt"}, false},
+		{"distinct paths", scanFlags{output: "r.sarif", jsonOut: "r.json", sarifOut: "s.sarif"}, false},
+		{"output == json-out", scanFlags{output: "x.json", jsonOut: "x.json"}, true},
+		{"output == sarif-out", scanFlags{output: "x.sarif", sarifOut: "x.sarif"}, true},
+		{"output == sarif-out via ./", scanFlags{output: "x.sarif", sarifOut: "./x.sarif"}, true},
+		{"json-out == sarif-out", scanFlags{jsonOut: "o.txt", sarifOut: "o.txt"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateOutputFlags(tc.f)
+			if tc.wantErr && err == nil {
+				t.Errorf("validateOutputFlags(%+v) = nil, want error", tc.f)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("validateOutputFlags(%+v) = %v, want nil", tc.f, err)
+			}
+		})
+	}
+}

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 )
 
 const defaultProvider = "anthropic"
@@ -18,6 +19,24 @@ var defaultModels = map[string]string{
 	"anthropic": "claude-haiku-4-5",
 	"openai":    "gpt-4.1-nano",
 	"google":    "gemini-2.5-flash-lite",
+}
+
+// IsKnownProvider reports whether Trustabl ships a default model for provider
+// (the supported provider set is the keys of defaultModels). Setting an unknown
+// provider would create an entry with an empty model, so callers gate on this.
+func IsKnownProvider(provider string) bool {
+	_, ok := defaultModels[provider]
+	return ok
+}
+
+// KnownProviders returns the supported provider names, sorted.
+func KnownProviders() []string {
+	names := make([]string, 0, len(defaultModels))
+	for n := range defaultModels {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
 }
 
 // ConfigDir overrides os.UserConfigDir() when non-empty. Intended for tests only.

--- a/internal/llm/llm_test.go
+++ b/internal/llm/llm_test.go
@@ -279,3 +279,30 @@ func TestLoad_NonDefaultActiveProvider(t *testing.T) {
 		t.Errorf("openai default model = %q, want gpt-4.1-nano", p.Model)
 	}
 }
+
+func TestIsKnownProvider(t *testing.T) {
+	for _, p := range []string{"anthropic", "openai", "google"} {
+		if !llm.IsKnownProvider(p) {
+			t.Errorf("IsKnownProvider(%q) = false, want true", p)
+		}
+	}
+	if llm.IsKnownProvider("anthropc") {
+		t.Error("IsKnownProvider(typo) = true, want false")
+	}
+	if llm.IsKnownProvider("") {
+		t.Error(`IsKnownProvider("") = true, want false`)
+	}
+}
+
+func TestKnownProviders_SortedAndComplete(t *testing.T) {
+	got := llm.KnownProviders()
+	want := []string{"anthropic", "google", "openai"}
+	if len(got) != len(want) {
+		t.Fatalf("KnownProviders() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("KnownProviders()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
Two small CLI correctness fixes from the post-merge review.

## `--output` vs `--json-out`/`--sarif-out` collision (M1)
`--output` writes the `--format` report to a file; `--json-out`/`--sarif-out` write those formats to files independently. Pointing two of them at the same path writes it twice and, across formats, **silently clobbers** (you get only the side-output, not the report you named). `validateOutputFlags` now rejects all three colliding pairs and fails fast in `runScan` before the scan runs. Paths are compared with `filepath.Clean` so `x` vs `./x` is caught.

## `llm provider set <typo>` (M2)
Setting a provider with no shipped default model created an active provider with an empty model and no key (`llm provider set anthropc` "succeeded" into a broken state). It now rejects unknown providers with a helpful message listing the known ones. Adds `llm.IsKnownProvider` / `llm.KnownProviders`.

## Tests
`TestValidateOutputFlags` (collision matrix) and `TestIsKnownProvider` / `TestKnownProviders_SortedAndComplete`. `go test ./...` green; vet + gofmt clean.