### PR TITLE
Add trustabl-enrich skills to Claude Code plugin documentation

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "trustabl",
   "version": "0.1.2",
-  "description": "Self-audit AI agent, tool, and MCP-server code for security and reliability misconfigurations with Trustabl, the static analyzer for the OpenAI Agents SDK, Claude Agent SDK, Google ADK, and MCP. Ships a skill that runs the trustabl CLI right after you write or change agent code, before you commit.",
+  "description": "Self-audit AI agent, tool, and MCP-server code for security and reliability misconfigurations with Trustabl, the static analyzer for the OpenAI Agents SDK, Claude Agent SDK, Google ADK, and MCP. Ships two skills: trustabl-scan runs the trustabl CLI right after you write or change agent code before you commit, and trustabl-enrich applies the scan findings directly to your source files as targeted code edits.",
   "homepage": "https://github.com/trustabl/trustabl",
   "license": "Apache-2.0"
 }

--- a/README.md
+++ b/README.md
@@ -504,12 +504,20 @@ command-level `--rules-ref` for that call.
 ### Claude Code plugin (self-audit at generation time)
 
 Trustabl ships a Claude Code plugin under [`.claude-plugin/`](.claude-plugin/)
-that exposes a `trustabl-scan` skill ([`skills/trustabl-scan/`](skills/trustabl-scan/)).
-The skill triggers right after agent, tool, subagent, or MCP-server code is
-written or changed and runs `trustabl scan` to self-audit it before committing,
-upstream of CI. It is a thin wrapper around the CLI documented above and runs no
-network service: it shells out to the same `trustabl` binary, so the binary must
-be installed and on `PATH`.
+with two skills that form a scan-and-fix loop:
+
+- **[`trustabl-scan`](skills/trustabl-scan/)** — triggers right after agent,
+  tool, subagent, or MCP-server code is written or changed and runs
+  `trustabl scan` to self-audit it before committing, upstream of CI.
+- **[`trustabl-enrich`](skills/trustabl-enrich/)** — takes the output of a
+  `trustabl scan` run (JSON, SARIF, or pasted terminal text) and applies each
+  finding as a targeted code edit, guided entirely by the scan's own
+  `explanation` and `suggested_fix` fields. It does not re-run the scanner; use
+  `trustabl-scan` first, then invoke `trustabl-enrich` with the results.
+
+Both skills shell out to the same `trustabl` binary, so the binary must be
+installed and on `PATH`. Neither runs a network service or modifies files
+outside the scan target.
 
 ### "no schema-compatible rules available"
 


### PR DESCRIPTION
Update plugin.json description and README to reflect that the plugin now ships two skills — trustabl-scan and trustabl-enrich — forming a scan-and-fix loop. trustabl-scan runs the CLI at generation time; trustabl-enrich applies scan findings as targeted code edits guided by each finding's explanation and suggested_fix fields.

Skills are auto-discovered from skills/ by Claude Code; no skills array is needed in plugin.json.