### PR TITLE
docs: reconcile engine docs with the 102-rule pack and current state

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1354,8 +1354,8 @@ rules:
 
 ### Adding a rule
 
-1. Pick the right category subdirectory (`claude_sdk/` or `openai_sdk/`) in
-   the rules repository.
+1. Pick the right category subdirectory (`claude_sdk/`, `openai_sdk/`,
+   `google_adk/`, or `mcp/`) in the rules repository.
 2. Either append to an existing topic file or create a new `<topic>.yaml`
    file — the loader walks the rules FS recursively, so new files are picked
    up automatically with no engine change.
@@ -1658,12 +1658,13 @@ take it absent a concrete distribution requirement.
   model), `ValidateKey`, and `MaskKey`. A `defaultModels` map supplies
   fast/cheap defaults per known provider (`anthropic → claude-haiku-4-5`,
   `openai → gpt-4.1-nano`, `google → gemini-2.5-flash-lite`).
-  `internal/inference/router.go` defines the BYOK call interface;
-  `Call()` returns `ErrLLMDisabled` when no key is configured.
-  Rule-based detection runs fully without a key and makes no network
-  call without one. The first planned enrichment target is upgrading
-  low-confidence rule-based hits to confirmed findings (CSDK-005 is
-  the highest-leverage rule for this).
+  `internal/inference/router.go` defines the BYOK call interface, but it is
+  a non-functional placeholder today: `Call()` returns `ErrLLMDisabled` with
+  no key and a "not implemented" error with one, and the `Router` is never
+  instantiated by the scan pipeline. Rule-based detection is therefore the
+  entire scan and makes no network call at all, with or without a key. The
+  first planned enrichment target is upgrading low-confidence rule-based hits
+  to confirmed findings (CSDK-005 is the highest-leverage rule for this).
 - **No corpus-eval benchmark.** Detection quality measured on a 20–40
   real-agent-repo corpus is the detection-quality target. The shipped
   rule-based detectors carry three-layer test coverage (see §6) — that is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,10 +323,11 @@ When changing a rule (add / remove / edit severity, confidence, match, text):
 6. Commit and push the rules repo **and** the rulebook (the user pushes engine
    commits manually; confirm before pushing any of the three).
 
-> **Known live gap (2026-06-03):** the rulebook documents 72 rules but
-> production ships 77 — the 5 Claude TS rules (CSDK-010/011/012/013/120) have
-> no rationale doc yet, so `check_rulebook.py` would fail against the live pack.
-> Backfilling these is the standing first task before any rule expansion.
+> **Known live gap (2026-06-04):** the rulebook documents 88 rules but
+> production ships 102 — the 14 MCP rules (MCP-001..014, the standalone `mcp/`
+> category) have no rationale doc yet, so `check_rulebook.py` would fail against
+> the live pack. Backfilling these is the standing first task before any rule
+> expansion.
 
 The rule-authoring contract (required fields, ID conventions, per-scope
 `applies_to` values, framing discipline) lives in

--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -4,7 +4,7 @@ Coverage matrix for Trustabl's static analysis: which agent SDKs (and which
 languages) we currently scan, analyse, and detect against. This file is the
 at-a-glance reference; `ARCHITECTURE.md` has the implementation detail.
 
-_Last reviewed: 2026-06-03 (HEAD `870bac3`)._
+_Last reviewed: 2026-06-04 (HEAD `8e0d94f`)._
 
 > **Note:** Detection rules are not shipped in the binary. They live in the
 > separate `trustabl-rules` git repository
@@ -204,10 +204,13 @@ rationale, not as a binding roadmap.
    (typed-params, callback-gated agent rules) still need new TS predicates: ADK
    JS agent callback kwarg names need verification before porting
    ADK-102/105..107.
-4. **MCP rule pack** would be a small detection win — we already discover
-   MCP tools, but no rules target them. Useful checks include "MCP tool
-   without input schema" and "stdio MCP server with absolute path to a
-   binary outside the repo."
+4. **MCP rule pack** has **landed** — the dedicated `mcp/` pack now ships 14
+   rules: tool MCP-001..010 (Python: no description, untyped params, ambiguous
+   name, network timeout, path safety, error contract, idempotency, SSRF,
+   code-exec, shell) and MCP-011..014 (TypeScript: no description, shell, SSRF,
+   eval / new Function). `mcp_tool` coverage now lives only in this pack. Still
+   open: server-side completeness (Prompt/Resource/Sampling registrations) and
+   MCP discovery for Rust/Go (see the gaps table above).
 
 ## Sources
 

--- a/README.md
+++ b/README.md
@@ -197,11 +197,12 @@ schema's `language:` field is in place for when those parsers ship.
 
 ### Scope boundaries
 
-- **LLM enrichment is opt-in.** Rule-based detection runs fully without a
-  key and makes no network call without one. Use `trustabl llm key set` to
-  configure a provider key (`~/.config/trustabl/keys.json`, mode 0600);
-  `internal/inference/router.go` is the BYOK interface the enrichment path
-  will call.
+- **LLM enrichment is not wired yet.** Rule-based detection is the whole
+  scan today and makes no network call at all — there is no LLM-backed
+  enrichment path, with or without a key. `trustabl llm key set` only stores
+  a provider key (`~/.config/trustabl/keys.json`, mode 0600) for that future
+  path; `internal/inference/router.go` is the BYOK interface it will call
+  once implemented (today it is a non-functional placeholder).
 - **Confidence scores are heuristic**, not LLM-judged, and not yet
   calibrated against a labelled real-agent corpus — treat findings as
   signal to investigate.
@@ -392,7 +393,7 @@ trustabl scan ./repo --no-progress   # disable progress entirely
 # Desktop) can scan code an agent just wrote (see "Run as an MCP server" below)
 trustabl mcp
 
-# Configure LLM provider for enrichment (prerequisite for trustabl enrich)
+# Configure LLM provider for enrichment (stores the key; the enrichment path is not yet wired)
 trustabl llm list                          # show configured providers with masked keys
 trustabl llm key set                       # prompt securely for an API key
 trustabl llm key set sk-ant-api03-...      # set key non-interactively
@@ -562,10 +563,11 @@ Two fixes:
 | LLM config         | `internal/llm/` (key storage · masking · validation) |
 
 Rule packs live in the separate `trustabl-rules` git repository (grouped
-`{claude_sdk,openai_sdk,google_adk}/`), resolved at scan time rather
+`{claude_sdk,openai_sdk,google_adk,mcp}/`), resolved at scan time rather
 than embedded in the binary. Naming convention: `CSDK-NNN` for Claude
 Agent SDK rules (CSDK-0xx tool-scope, CSDK-1xx agent + subagent-scope),
-`OAI-NNN` for OpenAI Agents SDK rules, `ADK-NNN` for Google ADK rules.
+`OAI-NNN` for OpenAI Agents SDK rules, `ADK-NNN` for Google ADK rules,
+`MCP-NNN` for the dedicated MCP tool-scope pack.
 See
 [ARCHITECTURE.md § 2 — steps 3–4](ARCHITECTURE.md#2-pipeline) for the
 shipped rule table and [COVERAGE.md](COVERAGE.md) for per-SDK

--- a/internal/rules/schema.yaml
+++ b/internal/rules/schema.yaml
@@ -56,10 +56,11 @@ rules:
     language: python                        # OPTIONAL (default: python). Source language this rule
                                             # targets. Allowed: python | typescript | javascript | go.
                                             # A rule only fires against tools whose Language matches.
-                                            # Today only Python tools are discovered (no TS parser
-                                            # plumbed in), so non-python rules will be inert until
-                                            # the corresponding language parser ships. Future TS/JS/Go
-                                            # rules MUST set this explicitly.
+                                            # Python and TypeScript discovery are both plumbed in today,
+                                            # so python and typescript rules fire. JavaScript and Go
+                                            # have no parser yet, so rules in those languages stay inert
+                                            # until the corresponding parser ships. Non-python rules
+                                            # MUST set this explicitly.
 
     applies_to:                             # REQUIRED. Non-empty list of kind strings (tool scope shown):
       - claude_sdk_tool                     #   claude_sdk_tool   — @tool / @claude_tool / claude_agent_sdk

--- a/testdata/rules-fixture/CLAUDE.md
+++ b/testdata/rules-fixture/CLAUDE.md
@@ -43,16 +43,18 @@ Do not skip step 1.
 
 ## Required fields per rule
 
-Every rule MUST set: `id`, `title`, `severity`, `confidence`,
+Every rule MUST set: `id`, `title`, `scope`, `severity`, `confidence`,
 `applies_to`, `match`, `explanation`, `fix`. The loader refuses to start
-the scanner if any are missing — this surfaces as a `scan: ...` error in
-the CLI.
+the scanner if any are missing (`scope` empty is rejected with "scope is
+required") — this surfaces as a `scan: ...` error in the CLI.
 
 `language:` is OPTIONAL but state it explicitly — defaults to `python`
 when omitted. For TypeScript / JavaScript / Go rules, set it explicitly:
-`language: typescript`. Note: only Python tool discovery is plumbed in
-today, so non-python rules will load successfully but never fire until
-the matching parser ships.
+`language: typescript`. Python and TypeScript discovery are both plumbed in
+today (Claude SDK, OpenAI Agents, Google ADK, and MCP all have TS discovery
+and shipped TS rules); JavaScript and Go are recognized by recon but have no
+AST parser, so rules in those languages load but never fire until the
+matching parser ships.
 
 ## Per-scope `applies_to` values
 
@@ -78,6 +80,7 @@ against. Pick values from the table for the scope you're targeting.
 | `openai_agent`            | `Agent(...)` from `openai-agents` SDK                         |
 | `openai_sandbox_agent`    | `SandboxAgent(...)` from `openai-agents` SDK                  |
 | `claude_agent_definition` | `AgentDefinition(...)` from `claude-agent-sdk`                |
+| `claude_query_main`       | `query(...)` main-thread agent (`QueryMainAgent`) from the Claude TS SDK |
 | `adk_llm_agent`           | `LlmAgent(...)` / `Agent(...)` alias from `google-adk`        |
 | `adk_sequential_agent`    | `SequentialAgent(...)` from `google-adk`                      |
 | `adk_parallel_agent`      | `ParallelAgent(...)` from `google-adk`                        |
@@ -123,7 +126,9 @@ Subagent rules use the `subagent_grants_tool` predicate (true when
 `SubagentDef.Tools` contains a listed tool name). They carry **no `language:`
 field** — subagents are markdown frontmatter, not code, and the
 `subagentRuleDetector.Applies` method does not gate on language. The shipped
-rule is CSDK-110 in `claude_sdk/subagent_safety.yaml`.
+rules are CSDK-110 ("Subagent granted the built-in Bash tool") and CSDK-111
+("Subagent granted filesystem-write or web-fetch built-ins"), both in
+`claude_sdk/subagent_safety.yaml`.
 
 ## "Add a rule for X"
 


### PR DESCRIPTION
This PR has two doc commits, both bringing the engine's living docs in line with what the code actually ships today.

## Commit 1 — reconcile docs with the 102-rule pack and current state

Verified against `testdata/rules-fixture/` (102 rules across 45 files, `schema_version: 8`).

- **CLAUDE.md** — refreshed the stale rulebook-coverage gap note. It claimed "72 documented / 77 shipped" and named 5 Claude TS rules as undocumented; reality is **88 documented / 102 shipped**, and those 5 TS rules are now documented. The real outstanding gap is the **14 MCP rules (MCP-001..014)** that still lack rationale docs in `trustabl-rulebook`.
- **COVERAGE.md** — bumped the `_Last reviewed_` line and recorded the landed MCP rule pack.
- **README.md / ARCHITECTURE.md** — added the `mcp` pack to rule-pack listings, removed a dead `trustabl enrich` reference, and corrected LLM wording that implied a network call happens (enrichment is a non-functional placeholder).
- **testdata/rules-fixture/CLAUDE.md** — added the now-required `scope` field and the `claude_query_main` agent token to the rule-authoring contract (two shipped rules depend on it), and corrected the "Python-only discovery" claim to Python + TypeScript.
- **internal/rules/schema.yaml** — aligned the `language` annotation with current TypeScript discovery support. (Human-reference schema doc; `schema.go` remains authoritative.)

## Commit 2 — drop the engine's redundant Code Scanning workflow

`docs/ci/code-scanning.yml` was a full GitHub Actions workflow that docker-ran the scanner and hand-wired `github/codeql-action/upload-sarif`. The first-class [`trustabl/trustabl-action`](https://github.com/trustabl/trustabl-action) now does exactly that with `upload-sarif` on by default (plus inline PR alerts and threshold gating), so the engine's copy was a redundant, inferior path that steered users away from the action and invited drift between the two repos.

- **Deleted** `docs/ci/code-scanning.yml` (git also pruned the now-empty `docs/` tree).
- **Repointed** the README CI section and `ARCHITECTURE.md` at the action as the single source of truth for the GitHub workflow.
- The engine still documents its own SARIF output (`--format sarif --output`) for non-GitHub / no-action CI.

## Reviewer notes

- **Docs-only — no engine behavior change.** No `.go` source, predicate, or schema-grammar change; `schema.yaml` is the human reference, not the authoritative `schema.go`.
- Rule counts verified by walking `testdata/rules-fixture/`: 102 rules (claude_sdk 30, openai_sdk 32, google_adk 26, mcp 14) across 45 policy files; scopes tool 66 / agent 28 / subagent 2 / repo 6.
- **Out of scope (separate follow-up):** authoring the 14 MCP rationale docs in `trustabl-rulebook` — grounded authoring (threat models, OWASP citations), the standing rulebook backfill. The sibling repos (`trustabl-rules`, `trustabl-rulebook`, `trustabl-action`, `trustabl-vscode`) received their own doc corrections in this same audit but are separate repositories and not part of this PR.
