### PR TITLE
feat: add LangChain / LangGraph SDK coverage

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -47,11 +47,19 @@ same TS file extensions, gated on imports from `@openai/agents`,
 classes / `subAgents` edges in the same TS file extensions, gated on
 imports from `@google/adk`). MCP-proper servers authored with
 `@modelcontextprotocol/sdk` (`new McpServer(...)` + `registerTool` / `tool`)
-are discovered in TS via `ts_mcp_proper.go`. TypeScript rule packs now ship for
-all four SDK surfaces: Claude SDK (CSDK-010/011/012/013/014/016 tool rules,
+are discovered in TS via `ts_mcp_proper.go`. LangChain / LangGraph is discovered
+in both Python (the `@tool` decorator — import-routed to disambiguate from the
+Claude SDK's `@tool` — plus `StructuredTool` / `Tool` factories,
+`create_react_agent` / `create_agent` / `AgentExecutor`, and the `PythonREPLTool`
+/ `ShellTool` built-ins) and TypeScript (the `tool(fn, {...})` factory,
+`DynamicStructuredTool` / `DynamicTool`, and `createReactAgent` / `createAgent` /
+`AgentExecutor`), import-gated to the `@langchain/*` / `langchain` / `langgraph`
+ecosystem. TypeScript rule packs now ship for
+all five SDK surfaces: Claude SDK (CSDK-010/011/012/013/014/016 tool rules,
 CSDK-120/130/131 agent rules), OpenAI Agents (OAI-016/017/019/022/024 tool
 rules, OAI-105 agent rule), Google ADK (ADK-013/015/016 tool rules, ADK-109
-agent rule), and MCP (MCP-011/012/013/014 tool rules). A TS
+agent rule), MCP (MCP-011/012/013/014 tool rules), and LangChain
+(LC-010/011/012/013/014 tool rules, LC-111 agent rule). A TS
 repo for any of these no longer produces a blanket META-004; the full
 per-SDK/language matrix lives in COVERAGE.md. The scanner
 can also recognize JavaScript and Go *files* (they appear in
@@ -432,6 +440,28 @@ For each language recon cleared, do the AST work and produce a `RepoInventory`:
   pre-resolve hosted-tool class instantiations against
   `TSADKHostedToolClasses` (13 entries); leaves identifier-valued refs in
   `tools` / `subAgents` for `ResolveEdges` to wire by binding name.
+- **DiscoverLangChainTools / DiscoverLangChainAgents** (`langchain_tools.go`,
+  `langchain_agents.go`) — Python LangChain / LangGraph. The `@tool` decorator
+  (shared with the Claude SDK) is routed in `discovery.go`'s `kindFromDecorators`
+  by the **import binding** of the `tool` symbol (`collectToolImports`): `tool`
+  bound from a langchain module → `KindLangChainTool`, from `claude_agent_sdk` →
+  Claude, last-binding-wins on shadowing — correct for any mix of the two SDKs. A
+  file-level import-presence check is the fallback for the unresolvable case (a
+  star-import or a locally defined `tool`). `StructuredTool` / `Tool` factories
+  (and `.from_function`) are recognized here, with the wrapped function resolved so
+  body predicates scan the implementation. Agents: `create_react_agent` /
+  `create_agent` / `AgentExecutor` → normalized Class `ReactAgent` / `CreateAgent`
+  / `AgentExecutor`; the positional `tools` argument (index 1) is captured as a
+  synthetic kwarg. `langchain_hosted_tools.go` classifies the `PythonREPLTool` /
+  `PythonAstREPLTool` / `ShellTool` / `Requests*` built-ins in an agent's tool list
+  as `HostedToolDef`s (SDK `langchain`).
+- **DiscoverTSLangChainTools / DiscoverTSLangChainAgents** (`ts_langchain_tools.go`,
+  `ts_langchain_agents.go`) — TS LangChain. Tools: `tool(fn, {...})` (config at
+  arg 1, unlike OpenAI's arg-0), `new DynamicStructuredTool({...})`,
+  `new DynamicTool({...})`; the import gate is prefix-matched via
+  `astutil.TSImportAliasesMatch` to cover the many `@langchain/*` subpaths. Agents:
+  `createReactAgent` / `createAgent` / `new AgentExecutor`. Reuses
+  `tsZodParamNames` / `tsHandlerFacts`.
 - **ResolveEdges** — links agent `tools=`, `handoffs=`, `input_guardrails=`
   references to discovered definitions in the same repo; cross-module resolution
   uses import statements; unresolvable references are flagged `External=true`.
@@ -729,6 +759,21 @@ Shipped rules (one row per YAML rule entry):
 | MCP-012  | tool     | mcp        | high     | `mcp/shell_safety.yaml`            | TypeScript MCP tool spawns a subprocess                                               |
 | MCP-013  | tool     | mcp        | high     | `mcp/ssrf.yaml`                    | TypeScript MCP tool fetches a caller-controlled URL (SSRF)                            |
 | MCP-014  | tool     | mcp        | high     | `mcp/code_execution.yaml`          | TypeScript MCP tool evaluates dynamic code (eval / new Function)                      |
+| LC-001   | tool     | langchain  | low      | `langchain/tool_definition.yaml`   | LangChain tool has no description                                                     |
+| LC-002   | tool     | langchain  | medium   | `langchain/tool_definition.yaml`   | LangChain tool parameters are not type-annotated                                      |
+| LC-003   | tool     | langchain  | high     | `langchain/shell_safety.yaml`      | LangChain tool body spawns a subprocess                                               |
+| LC-004   | tool     | langchain  | high     | `langchain/code_execution.yaml`    | LangChain tool body evaluates dynamic code                                            |
+| LC-005   | tool     | langchain  | high     | `langchain/ssrf.yaml`              | LangChain tool fetches a caller-controlled URL (SSRF)                                 |
+| LC-006   | tool     | langchain  | medium   | `langchain/tool_behavior.yaml`     | LangChain tool returns output directly (`return_direct`)                              |
+| LC-010   | tool     | langchain  | low      | `langchain/tool_definition.yaml`   | TypeScript LangChain tool has no description                                          |
+| LC-011   | tool     | langchain  | high     | `langchain/shell_safety.yaml`      | TypeScript LangChain tool body spawns a subprocess                                    |
+| LC-012   | tool     | langchain  | high     | `langchain/code_execution.yaml`    | TypeScript LangChain tool evaluates dynamic code                                      |
+| LC-013   | tool     | langchain  | high     | `langchain/ssrf.yaml`              | TypeScript LangChain tool fetches a caller-controlled URL (SSRF)                      |
+| LC-014   | tool     | langchain  | medium   | `langchain/tool_behavior.yaml`     | TypeScript LangChain tool returns output directly (`returnDirect`)                    |
+| LC-101   | agent    | langchain  | high     | `langchain/agent_safety.yaml`      | LangChain agent wires a code-execution or shell built-in tool                         |
+| LC-102   | agent    | langchain  | medium   | `langchain/agent_safety.yaml`      | LangChain AgentExecutor has no max_iterations limit                                   |
+| LC-111   | agent    | langchain  | medium   | `langchain/agent_safety.yaml`      | TypeScript LangChain AgentExecutor has no maxIterations limit                         |
+| LC-201   | repo     | langchain  | low      | `langchain/repo_hygiene.yaml`      | LangChain project with no agent-guidance doc (AGENTS.md/CLAUDE.md)                     |
 
 > **MCP-tool coverage moved to a dedicated `mcp` category (2026-06-03).** The
 > Python CSDK rules CSDK-001/002/003/004/005/006/007/009/107/108 previously

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,11 +323,12 @@ When changing a rule (add / remove / edit severity, confidence, match, text):
 6. Commit and push the rules repo **and** the rulebook (the user pushes engine
    commits manually; confirm before pushing any of the three).
 
-> **Known live gap (2026-06-04):** the rulebook documents 88 rules but
-> production ships 102 — the 14 MCP rules (MCP-001..014, the standalone `mcp/`
-> category) have no rationale doc yet, so `check_rulebook.py` would fail against
-> the live pack. Backfilling these is the standing first task before any rule
-> expansion.
+> **Rulebook status (2026-06-04):** the rulebook documents all shipped rules —
+> production ships **117** rules (the 102-rule pack plus the 15 LangChain LC-*
+> rules) across the four SDK categories plus `langchain`, and the rulebook carries
+> a rationale doc for every one (52 docs). `check_rulebook.py --strict` and
+> `gen_index.py --check` both pass against the live pack with zero warnings. The
+> earlier MCP-doc backfill gap is closed.
 
 The rule-authoring contract (required fields, ID conventions, per-scope
 `applies_to` values, framing discipline) lives in

--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -4,7 +4,7 @@ Coverage matrix for Trustabl's static analysis: which agent SDKs (and which
 languages) we currently scan, analyse, and detect against. This file is the
 at-a-glance reference; `ARCHITECTURE.md` has the implementation detail.
 
-_Last reviewed: 2026-06-04 (HEAD `8e0d94f`)._
+_Last reviewed: 2026-06-04 (LangChain / LangGraph SDK row added)._
 
 > **Note:** Detection rules are not shipped in the binary. They live in the
 > separate `trustabl-rules` git repository
@@ -30,6 +30,8 @@ Legend: ✅ full · ◐ partial · ❌ none · — N/A
 | **Google ADK** | Python | ✅ dep-scan (`google-adk`) + file inventory | ✅ LlmAgent (+ Agent alias), SequentialAgent, ParallelAgent, LoopAgent, LanggraphAgent; FunctionTool wrapping; 13 built-in hosted tools; sub_agents edges | ✅ tool ADK-001..007, 009..012 (009 = print to stdout, 010 = subprocess, 011 = eval/exec/compile, 012 = SSRF); agent ADK-008, 101..108, 110; repo ADK-201 (SDK code without an agent-guidance doc: AGENTS.md/CLAUDE.md) |
 | **Google ADK** | TypeScript | ✅ dep-scan (`@google/adk`) + file inventory | ✅ tools (`new FunctionTool({...})`), agents (5 constructors: LlmAgent + SequentialAgent + ParallelAgent + LoopAgent + RoutedAgent), hosted tools (13 classes), subAgents edges | ◐ tool ADK-013 (no description), 015 (eval / new Function), 016 (SSRF / dynamic URL); agent ADK-109 (LlmAgent no description); first ADK TS pack; META-004 no longer fires |
 | **Google ADK** | Go / Java / Kotlin | ❌ | ❌ | ❌ |
+| **LangChain / LangGraph** | Python | ✅ dep-scan (`langchain` / `langgraph` needles, all manifests) + file inventory | ✅ tools (`@tool` decorator — import-gated to disambiguate from the Claude SDK's `@tool`; `StructuredTool` / `Tool` factories + `.from_function`), agents (`create_react_agent`, `create_agent`, `AgentExecutor`; positional `tools` captured), dangerous built-ins (`PythonREPLTool` / `PythonAstREPLTool` / `ShellTool` / `Requests*` → `HostedToolDef` edges) | ✅ tool LC-001 (no description), LC-002 (untyped params), LC-003 (shell), LC-004 (code-exec), LC-005 (SSRF), LC-006 (`return_direct`); agent LC-101 (code-exec/shell built-in), LC-102 (AgentExecutor no `max_iterations`); repo LC-201 (no agent-guidance doc) |
+| **LangChain / LangGraph** | TypeScript | ✅ dep-scan (`@langchain/*` / `langchain` / `langgraph`) + file inventory | ✅ tools (`tool(fn, {...})` factory — import-gated, config from arg 1; `DynamicStructuredTool` / `DynamicTool`), agents (`createReactAgent`, `createAgent`, `new AgentExecutor`) | ◐ tool LC-010 (no description), LC-011 (shell), LC-012 (code-exec), LC-013 (SSRF), LC-014 (`returnDirect`); agent LC-111 (AgentExecutor no `maxIterations`). Provider hosted tools (`shell()` / `bash_*` / `applyPatch`) and the raw `StateGraph` graph agent are documented gaps |
 | **OpenShell** | Python | ✅ shell-invocation discovery + `openshell/*.yaml` policy files surfaced | ✅ `KindShellInvocation` tools → `RepoInventory.HasShellInvocations` (the "openshell" risk surface; not an SDK, never in `SDKsDetected`) | ❌ rules moved to closed-source companion project (no rule fires; no META finding — openshell is not treated as an unaudited SDK) |
 
 ## What we parse exactly (per SDK)
@@ -145,6 +147,45 @@ only files importing from `@google/adk` are processed (handled by the
 **Limitation:** `AgentTool` wraps another agent — same transitive-analysis caveat as Python ADK applies.
 **v1 limitation:** only bare-identifier constructors are recognized; namespace-import constructors like `new ns.LlmAgent({...})` (a member_expression) are not handled.
 
+### LangChain / LangGraph — Python
+
+Discovery sources: `internal/analysis/discovery.go` (the `@tool` decorator,
+import-routed), `langchain_tools.go`, `langchain_agents.go`,
+`langchain_hosted_tools.go`. Import gate (AST-based): a file is in scope when it
+imports the langchain ecosystem (`langchain`, `langchain_core`, `langgraph`,
+`langchain_community`, `langchain_experimental`, `langchain_classic`, the
+`langchain-*` provider packages).
+
+| Construct | Recognition |
+|---|---|
+| Tools (`@tool`) | The `@tool` decorator (shared with the Claude SDK), classified in `kindFromDecorators` by the **import binding** of the `tool` symbol (`collectToolImports`): `tool` bound from a langchain module → `KindLangChainTool`, from `claude_agent_sdk` → Claude, last-binding-wins on shadowing — so it attributes correctly even when a file imports both SDKs. A file-level import-presence check is the fallback for a star-import / locally defined `tool`. Captures name, docstring → Description, typed-params, decorator kwargs (incl. `return_direct`) → Config |
+| Tools (factories) | `StructuredTool(...)` / `StructuredTool.from_function(fn)` / `Tool(...)` / `Tool.from_function(fn)`. Resolves the wrapped function (first positional arg, or `func=`) to a same-file def and points the ToolDef at its body so the shell/code/SSRF predicates scan the implementation; explicit `name=` / `description=` / `args_schema=` override. `class X(BaseTool)` is a documented gap |
+| Agents | `create_react_agent(...)` / `create_agent(...)` / `AgentExecutor(...)` → `AgentDef` with normalized Class `ReactAgent` / `CreateAgent` / `AgentExecutor`. All kwargs captured; the positional `tools` argument (index 1) of the two factories is captured as a synthetic `tools` kwarg so edge + hosted-tool resolution sees it |
+| Dangerous built-ins | `PythonREPLTool`, `PythonAstREPLTool`, `ShellTool`, and the `Requests*` family inside an agent's resolved `tools` list → `HostedToolDef` (SDK `langchain`), consumed by agent rule LC-101 |
+
+**Limitation:** the raw `StateGraph` → `.add_node` → `.compile()` graph agent is
+not modeled (it is emergent across many call sites). Tool-edge / hosted-tool
+resolution requires `tools` to be a kwarg or the captured positional; a
+`ToolNode`-indirected or fully dynamic tool list is left unresolved.
+
+### LangChain / LangGraph — TypeScript
+
+Discovery sources: `internal/analysis/ts_langchain_tools.go`,
+`ts_langchain_agents.go`, plus the shared `ts_handler_facts.go`. Import gate:
+prefix-matched (`astutil.TSImportAliasesMatch`) so the many subpaths
+(`@langchain/core/tools`, `@langchain/langgraph/prebuilt`, `langchain`,
+`langgraph`, any `@langchain/*`) are all in scope.
+
+| Construct | Recognition |
+|---|---|
+| Tools | `tool(fn, { name, description, schema })` (config is arg 1, unlike OpenAI's arg-0 — the import gate keeps the shared `tool()` name from cross-firing with the Claude/OpenAI passes), `new DynamicStructuredTool({...})`, `new DynamicTool({...})`. Name/description/`schema` (Zod or literal) → typed-params; handler body facts (`shells_out`, `code_exec`, `dynamic_url`) via `tsHandlerFacts`; `returnDirect` → Config |
+| Agents | `createReactAgent({...})` / `createAgent({...})` / `new AgentExecutor({...})` → `AgentDef` with normalized Class `ReactAgent` / `CreateAgent` / `AgentExecutor`. Kwargs captured; identifier `tools` refs wired as ToolRefs; an inline or `ToolNode` tool list marks the agent `Opaque` |
+
+**Limitation:** provider-package hosted tools (`@langchain/openai` `shell()` /
+`localShell()`, `@langchain/anthropic` `bash_*` — date-stamped names) and
+class-based tools (`extends StructuredTool`) are documented gaps; the raw
+`StateGraph` graph agent is not modeled.
+
 ### OpenShell — Python
 
 | Construct | Recognition |
@@ -175,6 +216,7 @@ not fire for it.
 | **Claude SDK TypeScript rules** (`@anthropic-ai/claude-agent-sdk`) | Shipped: tool CSDK-010 (shell), 011 (eval/new Function), 012 (fs-write), 013 (SSRF/dynamic URL), 014 (no description), 016 (mutating tool no idempotency key); agent CSDK-120 (permissionMode bypass), 130/131 (`query()` main-thread agent grants Bash / write-fetch built-ins). The TS predicate machinery is in place (structural `shells_out`/`writes_fs`/`dynamic_url`/`code_exec` facts read by `has_shell_call`/`has_write_call`/`has_dynamic_url_call`/`has_code_exec_call` language branches, plus a `has_body_text` line-span substring fallback kept only for inherently *textual-absence* checks) and covered by the per-rule fire/silent harness. CSDK-010 (shell) and CSDK-012 (fs-write) now match structurally, not by substring. Remaining breadth-parity gaps vs the Python CSDK set: typed-params (no viable TS predicate today, see note), network timeout and idempotency (intentionally still `has_body_text` — they test for the *absence* of a textual marker, which has no call-shape), error-handling. The `query()` main-thread agent surface (`claude_query_main`) is now audited by 130/131, which nothing previously checked |
 | **MCP cross-language** (TS, Rust, Go) | Two prerequisites are missing today: (1) MCP dep-scan needles in `internal/ingestion/normalizer.go` — currently only `claude-agent-sdk` / `claude_agent_sdk` / `openai-agents` / `@openai/agents` / `google-adk` / `@google/adk` are matched; there is no `@modelcontextprotocol/sdk` (npm), no `rmcp` / `anthropic-mcp` (Cargo), no Go MCP module needle. (2) per-language AST parsers and discovery for the SDK shapes (`Server.tool()` factory in TS, `#[tool]` macros in Rust, etc.). File paths are recorded by the generic walk but no MCP-specific extraction happens against them |
 | **MCP server-side completeness** | We discover tools registered with `@server.tool` etc., but don't extract `Prompt`, `Resource`, `Sampling` registrations — those exist in the spec and would be a small additional pass |
+| **LangChain class tools + raw `StateGraph` + TS provider hosted tools** | Three additive discovery gaps in the LangChain pack: `class X(BaseTool)` / `extends StructuredTool` (a class shape, not a call); the raw `StateGraph` → `.compile()` graph agent (emergent across call sites — needs data-flow from the `StateGraph` var through `add_node` / `ToolNode` / `compile`, not a single-call capture); and the date-stamped TS provider hosted tools (`shell()` / `bash_*` / `applyPatch`). Each is discovery-only, no schema change |
 
 ## Recommended next moves
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 </p>
 
 Trustabl is a static analyzer for agent reliability. It parses an agent-SDK
-repository (Claude Agent SDK, OpenAI Agents SDK, Google ADK, MCP), models the
+repository (Claude Agent SDK, OpenAI Agents SDK, Google ADK, MCP, LangChain /
+LangGraph), models the
 tools, agents, subagents, skills, slash commands, and plugin manifests it
 declares, and checks them against a catalog of reliability and safety rules. It reports the weaknesses it finds — each
 with an explanation, a suggested fix, and a confidence score — as a

--- a/internal/analysis/agents.go
+++ b/internal/analysis/agents.go
@@ -146,6 +146,8 @@ func ResolveEdges(inv *models.RepoInventory, parsed []ParsedFile) {
 					switch a.SDK {
 					case models.SDKGoogleADK:
 						h, isHT = classifyADKHostedToolCall(item, a.FilePath)
+					case models.SDKLangChain:
+						h, isHT = classifyLangChainHostedToolCall(item, a.FilePath)
 					default:
 						h, isHT = classifyHostedToolCall(item, a.FilePath)
 					}

--- a/internal/analysis/astutil/ts.go
+++ b/internal/analysis/astutil/ts.go
@@ -52,6 +52,15 @@ func ParserKindForExtension(path string) string {
 // (`import { tool }`) maps "tool" -> "tool". Imports from any module other
 // than `module` are ignored.
 func TSImportAliases(root *sitter.Node, src []byte, module string) map[string]string {
+	return TSImportAliasesMatch(root, src, func(mod string) bool { return mod == module })
+}
+
+// TSImportAliasesMatch generalizes TSImportAliases to an arbitrary module
+// matcher. It exists for ecosystems whose imports use many subpaths — e.g.
+// LangChain's "@langchain/core/tools", "@langchain/langgraph/prebuilt",
+// "@langchain/community/tools/shell" — where an exact module list would be
+// brittle. The matcher receives the unquoted module specifier.
+func TSImportAliasesMatch(root *sitter.Node, src []byte, match func(mod string) bool) map[string]string {
 	out := make(map[string]string)
 	if root == nil {
 		return out
@@ -71,7 +80,7 @@ func TSImportAliases(root *sitter.Node, src []byte, module string) map[string]st
 		}
 		// Strip surrounding quotes.
 		mod := raw[1 : len(raw)-1]
-		if mod != module {
+		if !match(mod) {
 			return true
 		}
 		// Walk children for import_clause(s): named_imports / namespace_import / identifier

--- a/internal/analysis/discovery.go
+++ b/internal/analysis/discovery.go
@@ -90,13 +90,24 @@ func toolsInFile(pf ParsedFile) []models.ToolDef {
 	root := pf.Tree.RootNode()
 	var out []models.ToolDef
 
+	// `@tool` is exported by BOTH the Claude Agent SDK and LangChain. Resolve each
+	// decorator by the import binding of the exact name it uses — `tool` from a
+	// langchain module is a LangChain tool, `tool` from `claude_agent_sdk` is a
+	// Claude tool — which is correct for any mix of the two SDKs and follows
+	// Python's last-binding-wins shadowing. The file-level flags are only a
+	// fallback for the unresolvable case (a star-import or a locally-defined
+	// `tool`). Computed once per file.
+	toolImports := collectToolImports(pf)
+	lcImport := fileImportsLangChain(pf)
+	claudeImport := fileImportsClaudeSDK(pf)
+
 	// Pass 1: decorated functions.
 	for _, dec := range astutil.FindAll(root, "decorated_definition") {
 		fn := astutil.FunctionDef(dec)
 		if fn == nil {
 			continue
 		}
-		kind := kindFromDecorators(astutil.Decorators(dec), pf.Source)
+		kind := kindFromDecorators(astutil.Decorators(dec), pf.Source, toolImports, lcImport, claudeImport)
 		if kind == models.KindUnknown {
 			continue
 		}
@@ -135,7 +146,7 @@ func toolsInFile(pf ParsedFile) []models.ToolDef {
 // Order matters: @function_tool is OpenAI Agents SDK and is checked before
 // the more permissive "@tool" Claude SDK match (which would otherwise swallow
 // "@function_tool" via substring).
-func kindFromDecorators(decs []*sitter.Node, src []byte) models.ToolKind {
+func kindFromDecorators(decs []*sitter.Node, src []byte, toolImports map[string]models.ToolKind, lcImport, claudeImport bool) models.ToolKind {
 	for _, d := range decs {
 		// Match on the decorator's resolved callee path (e.g. "function_tool",
 		// "agent.tool", "server.tool", "app.register_tool"), not a substring of
@@ -151,6 +162,17 @@ func kindFromDecorators(decs []*sitter.Node, src []byte) models.ToolKind {
 		if i := strings.LastIndex(callee, "."); i >= 0 {
 			last = callee[i+1:]
 		}
+		// Precise resolution first: an UNQUALIFIED decorator name that was bound by
+		// an explicit import resolves to that import's SDK. This is the exact
+		// signal for the otherwise-ambiguous `@tool` (shared by the Claude SDK and
+		// LangChain) and works regardless of how many SDKs the file imports. Only
+		// bare names are resolved this way; qualified callees (`server.tool`,
+		// `agent.tool`) keep their dedicated handling in the switch below.
+		if !strings.Contains(callee, ".") {
+			if sdk, ok := toolImports[callee]; ok {
+				return sdk
+			}
+		}
 		switch {
 		// OpenAI Agents SDK — `@function_tool` / `@function_tool(...)`, bare or
 		// module-qualified (`agents.function_tool`).
@@ -158,7 +180,16 @@ func kindFromDecorators(decs []*sitter.Node, src []byte) models.ToolKind {
 			return models.KindOpenAITool
 		// Claude Agent SDK conventions. Real names are still in flux — CSDK is
 		// pre-1.0. Expand this list as the SDK stabilizes.
-		case callee == "tool" || callee == "claude_tool" || last == "claude_tool",
+		case callee == "tool":
+			// Bare @tool that no import resolved (a star-import or a locally
+			// defined `tool`): fall back to file-level presence — a
+			// langchain-importing file that does not import the Claude SDK routes
+			// to LangChain; otherwise the historical Claude default holds.
+			if lcImport && !claudeImport {
+				return models.KindLangChainTool
+			}
+			return models.KindClaudeSDKTool
+		case callee == "claude_tool" || last == "claude_tool",
 			callee == "agent.tool",
 			strings.Contains(callee, "claude_agent_sdk"):
 			return models.KindClaudeSDKTool
@@ -169,6 +200,55 @@ func kindFromDecorators(decs []*sitter.Node, src []byte) models.ToolKind {
 		}
 	}
 	return models.KindUnknown
+}
+
+// trackedToolDecoratorNames are the unqualified tool-decorator names whose owning
+// SDK cannot be told from the name alone: `tool` is exported by both the Claude
+// Agent SDK and LangChain, so it MUST be resolved by import binding.
+// `claude_tool` is Claude-only but tracked so an aliased import still resolves.
+var trackedToolDecoratorNames = map[string]bool{"tool": true, "claude_tool": true}
+
+// collectToolImports maps a file's locally-bound tool-decorator names to the SDK
+// that exported them, by inspecting `from <module> import <name> [as <alias>]`
+// statements. Only the ambiguous names in trackedToolDecoratorNames are recorded.
+// When the same name is imported from two SDKs in one file, the last import wins
+// — matching Python's runtime binding. Used by kindFromDecorators to disambiguate
+// `@tool` between the Claude SDK and LangChain regardless of what else the file
+// imports.
+func collectToolImports(pf ParsedFile) map[string]models.ToolKind {
+	out := map[string]models.ToolKind{}
+	astutil.Walk(pf.Tree.RootNode(), func(n *sitter.Node) bool {
+		if n.Type() != "import_from_statement" {
+			return true
+		}
+		module := astutil.NodeText(n.ChildByFieldName("module_name"), pf.Source)
+		var sdk models.ToolKind
+		switch {
+		case isLangChainModule(module):
+			sdk = models.KindLangChainTool
+		case module == "claude_agent_sdk" || strings.HasPrefix(module, "claude_agent_sdk."):
+			sdk = models.KindClaudeSDKTool
+		default:
+			return true
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			c := n.Child(i)
+			switch c.Type() {
+			case "dotted_name":
+				if name := astutil.NodeText(c, pf.Source); trackedToolDecoratorNames[name] {
+					out[name] = sdk
+				}
+			case "aliased_import":
+				imported := astutil.NodeText(c.ChildByFieldName("name"), pf.Source)
+				alias := astutil.NodeText(c.ChildByFieldName("alias"), pf.Source)
+				if trackedToolDecoratorNames[imported] && alias != "" {
+					out[alias] = sdk
+				}
+			}
+		}
+		return true
+	})
+	return out
 }
 
 // decoratorCallee returns the dotted callee path of a decorator, stripped of any

--- a/internal/analysis/langchain_agents.go
+++ b/internal/analysis/langchain_agents.go
@@ -1,0 +1,122 @@
+package analysis
+
+import (
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/trustabl/trustabl/internal/analysis/astutil"
+	"github.com/trustabl/trustabl/internal/models"
+)
+
+// LangChain / LangGraph Python agent discovery.
+//
+// Three constructor-shaped agent forms are recognized (the raw StateGraph graph
+// agent is a documented gap — it is emergent across many call sites and does not
+// fit the one-call-site = one-agent model):
+//
+//	create_react_agent(model, tools, prompt=...)   # langgraph.prebuilt (and the
+//	                                                 # legacy langchain.agents one)
+//	create_agent(model, tools=..., system_prompt=...)  # langchain v1
+//	AgentExecutor(agent=..., tools=..., max_iterations=...)
+//
+// The callee is normalized to a language-agnostic Class (see agentKindMatches in
+// internal/rules): "ReactAgent", "CreateAgent", "AgentExecutor". All discovery
+// is import-gated to the langchain ecosystem.
+var langChainAgentClasses = map[string]string{
+	"create_react_agent":                 "ReactAgent",
+	"create_agent":                       "CreateAgent",
+	"AgentExecutor":                      "AgentExecutor",
+	"AgentExecutor.from_agent_and_tools": "AgentExecutor",
+}
+
+// DiscoverLangChainAgents walks each ParsedFile and emits one AgentDef per
+// recognized LangChain/LangGraph agent constructor call. Only files importing
+// the langchain ecosystem are considered.
+func DiscoverLangChainAgents(files []ParsedFile) []models.AgentDef {
+	var out []models.AgentDef
+	for _, pf := range files {
+		if !fileImportsLangChain(pf) {
+			continue
+		}
+		out = append(out, discoverLangChainAgentsInFile(pf)...)
+	}
+	return out
+}
+
+func discoverLangChainAgentsInFile(pf ParsedFile) []models.AgentDef {
+	var out []models.AgentDef
+	astutil.Walk(pf.Tree.RootNode(), func(n *sitter.Node) bool {
+		if n.Type() != "call" {
+			return true
+		}
+		callee := astutil.NodeText(n.ChildByFieldName("function"), pf.Source)
+		class, ok := langChainAgentClasses[callee]
+		if !ok {
+			return true
+		}
+		kwargs, opaque := extractCallKwargs(n, pf.Source)
+
+		// create_react_agent(model, tools, ...) and create_agent(model, tools=...)
+		// commonly pass the tool list positionally (index 1, after the model).
+		// Capture it as a synthetic "tools" kwarg so ResolveEdges and hosted-tool
+		// detection see it. AgentExecutor takes tools as a keyword, so it is
+		// excluded here. Positional capture beyond index 1 is out of scope.
+		if class == "ReactAgent" || class == "CreateAgent" {
+			if kwargs == nil || kwargs.Children["tools"] == nil {
+				if pos := positionalArgNode(n, 1); pos != nil {
+					if kwargs == nil {
+						kwargs = &models.KwargTree{Children: map[string]*models.KwargTree{}}
+					}
+					kwargs.Children["tools"] = exprFromNode(pos, pf.Source)
+				}
+			}
+		}
+
+		a := models.AgentDef{
+			SDK:      models.SDKLangChain,
+			Class:    class,
+			Language: models.LanguagePython,
+			Location: models.Location{
+				FilePath: pf.RelPath,
+				Line:     int(n.StartPoint().Row) + 1,
+				EndLine:  int(n.EndPoint().Row) + 1,
+			},
+			Kwargs: kwargs,
+			Opaque: opaque,
+		}
+		if nm := kwargStringLiteral(kwargs, "name"); nm != "" {
+			a.Name = nm
+		}
+		// Capture the assignment-target identifier (agent = create_react_agent(...))
+		// for handoff/edge resolution by variable name.
+		if p := n.Parent(); p != nil && p.Type() == "assignment" {
+			if l := p.ChildByFieldName("left"); l != nil && l.Type() == "identifier" {
+				a.VarName = astutil.NodeText(l, pf.Source)
+			}
+		}
+		out = append(out, a)
+		return true
+	})
+	return out
+}
+
+// positionalArgNode returns the index-th positional argument node of a call
+// (skipping keyword args, comments, and * / ** splats), or nil if absent.
+func positionalArgNode(call *sitter.Node, index int) *sitter.Node {
+	args := call.ChildByFieldName("arguments")
+	if args == nil {
+		return nil
+	}
+	pos := 0
+	for i := 0; i < int(args.NamedChildCount()); i++ {
+		c := args.NamedChild(i)
+		switch c.Type() {
+		case "keyword_argument", "comment", "dictionary_splat", "list_splat":
+			continue
+		}
+		if pos == index {
+			return c
+		}
+		pos++
+	}
+	return nil
+}

--- a/internal/analysis/langchain_agents_test.go
+++ b/internal/analysis/langchain_agents_test.go
@@ -1,0 +1,139 @@
+package analysis_test
+
+import (
+	"testing"
+
+	"github.com/trustabl/trustabl/internal/analysis"
+	"github.com/trustabl/trustabl/internal/models"
+)
+
+func TestLangChainAgent_CreateReactAgentPositionalTools(t *testing.T) {
+	src := `from langgraph.prebuilt import create_react_agent
+
+agent = create_react_agent(model, [search, calculator], prompt="Be helpful.")
+`
+	pf := parsePyFile(t, "agent.py", src)
+	agents := analysis.DiscoverLangChainAgents([]analysis.ParsedFile{pf})
+	if len(agents) != 1 {
+		t.Fatalf("got %d agents, want 1", len(agents))
+	}
+	a := agents[0]
+	if a.SDK != models.SDKLangChain {
+		t.Errorf("SDK: got %q, want %q", a.SDK, models.SDKLangChain)
+	}
+	if a.Class != "ReactAgent" {
+		t.Errorf("Class: got %q, want ReactAgent", a.Class)
+	}
+	if a.VarName != "agent" {
+		t.Errorf("VarName: got %q, want agent", a.VarName)
+	}
+	// Positional tools (index 1, after the model) must be captured so edge
+	// resolution and hosted-tool detection can see them.
+	tools := a.Kwargs.Children["tools"]
+	if tools == nil || tools.Value == nil || tools.Value.Kind != models.ExprList {
+		t.Fatalf("positional tools not captured as a list: %+v", a.Kwargs)
+	}
+}
+
+func TestLangChainAgent_CreateAgentKwargs(t *testing.T) {
+	src := `from langchain.agents import create_agent
+
+agent = create_agent(model="openai:gpt-4o", tools=[search], system_prompt="You help.")
+`
+	pf := parsePyFile(t, "ca.py", src)
+	agents := analysis.DiscoverLangChainAgents([]analysis.ParsedFile{pf})
+	if len(agents) != 1 {
+		t.Fatalf("got %d agents, want 1", len(agents))
+	}
+	a := agents[0]
+	if a.Class != "CreateAgent" {
+		t.Errorf("Class: got %q, want CreateAgent", a.Class)
+	}
+	if a.Kwargs.Children["system_prompt"] == nil {
+		t.Errorf("system_prompt kwarg not captured")
+	}
+}
+
+func TestLangChainAgent_AgentExecutor(t *testing.T) {
+	src := `from langchain.agents import AgentExecutor
+
+ex = AgentExecutor(agent=a, tools=[search], max_iterations=5)
+`
+	pf := parsePyFile(t, "ex.py", src)
+	agents := analysis.DiscoverLangChainAgents([]analysis.ParsedFile{pf})
+	if len(agents) != 1 {
+		t.Fatalf("got %d agents, want 1", len(agents))
+	}
+	a := agents[0]
+	if a.Class != "AgentExecutor" {
+		t.Errorf("Class: got %q, want AgentExecutor", a.Class)
+	}
+	if a.Kwargs.Children["max_iterations"] == nil {
+		t.Errorf("max_iterations kwarg not captured")
+	}
+}
+
+func TestLangChainAgent_GateExcludesNonLangChain(t *testing.T) {
+	src := `def create_agent(**kw):
+    return kw
+
+x = create_agent(model="m")
+`
+	pf := parsePyFile(t, "no_lc.py", src)
+	agents := analysis.DiscoverLangChainAgents([]analysis.ParsedFile{pf})
+	if len(agents) != 0 {
+		t.Errorf("non-langchain create_agent should not be discovered; got %+v", agents)
+	}
+}
+
+// A dangerous built-in (PythonREPLTool) passed positionally to create_react_agent
+// must resolve to a HostedToolDef edge with SDK=langchain (not fall through to
+// the OpenAI classifier or to an External ToolRef).
+func TestLangChainAgent_HostedToolResolution(t *testing.T) {
+	src := `from langgraph.prebuilt import create_react_agent
+from langchain_experimental.tools import PythonREPLTool
+
+agent = create_react_agent(model, [PythonREPLTool()])
+`
+	pf := parsePyFile(t, "danger.py", src)
+	inv := models.RepoInventory{Agents: analysis.DiscoverLangChainAgents([]analysis.ParsedFile{pf})}
+	analysis.ResolveEdges(&inv, []analysis.ParsedFile{pf})
+	if len(inv.Agents) != 1 {
+		t.Fatalf("got %d agents, want 1", len(inv.Agents))
+	}
+	a := inv.Agents[0]
+	if len(a.HostedToolRefs) != 1 || a.HostedToolRefs[0].Class != "PythonREPLTool" {
+		t.Fatalf("HostedToolRefs: got %+v, want [PythonREPLTool]", a.HostedToolRefs)
+	}
+	if len(inv.HostedTools) != 1 || inv.HostedTools[0].SDK != models.SDKLangChain {
+		t.Errorf("inv.HostedTools: got %+v, want one with SDK=langchain", inv.HostedTools)
+	}
+}
+
+// A LangChain tool referenced by identifier in an agent's tools list resolves to
+// the discovered ToolDef.
+func TestLangChainAgent_ResolvesToolEdges(t *testing.T) {
+	src := `from langchain_core.tools import tool
+from langgraph.prebuilt import create_react_agent
+
+@tool
+def search(q: str) -> str:
+    """Search."""
+    return q
+
+agent = create_react_agent(model, [search])
+`
+	pf := parsePyFile(t, "wired.py", src)
+	inv := models.RepoInventory{
+		Tools:  analysis.DiscoverToolsFromParsed([]analysis.ParsedFile{pf}),
+		Agents: analysis.DiscoverLangChainAgents([]analysis.ParsedFile{pf}),
+	}
+	analysis.ResolveEdges(&inv, []analysis.ParsedFile{pf})
+	a := inv.Agents[0]
+	if len(a.ToolRefs) != 1 {
+		t.Fatalf("ToolRefs: got %+v, want 1", a.ToolRefs)
+	}
+	if a.ToolRefs[0].Resolved == nil || a.ToolRefs[0].Resolved.Name != "search" {
+		t.Errorf("tool edge not resolved to 'search': %+v", a.ToolRefs[0])
+	}
+}

--- a/internal/analysis/langchain_hosted_tools.go
+++ b/internal/analysis/langchain_hosted_tools.go
@@ -1,0 +1,52 @@
+package analysis
+
+import "github.com/trustabl/trustabl/internal/models"
+
+// LangChainHostedToolClasses is the set of LangChain / LangGraph built-in tool
+// classes that represent high-risk capabilities: code execution (PythonREPLTool,
+// PythonAstREPLTool from langchain_experimental), shell (ShellTool), and raw
+// outbound HTTP (the Requests* family) from langchain_community. Benign built-ins
+// are intentionally omitted so a match is always a meaningful security signal.
+//
+// They are recognized when they appear in an agent's resolved tools list and
+// emitted as HostedToolDef edges, so agent-scope rules can flag the capability.
+var LangChainHostedToolClasses = map[string]bool{
+	"PythonREPLTool":     true,
+	"PythonAstREPLTool":  true,
+	"ShellTool":          true,
+	"RequestsGetTool":    true,
+	"RequestsPostTool":   true,
+	"RequestsPatchTool":  true,
+	"RequestsPutTool":    true,
+	"RequestsDeleteTool": true,
+}
+
+// IsLangChainHostedToolClass reports whether className is a recognized
+// high-risk LangChain built-in tool class.
+func IsLangChainHostedToolClass(className string) bool {
+	return LangChainHostedToolClasses[className]
+}
+
+// classifyLangChainHostedToolCall inspects an ExprCall item from a LangChain
+// agent's tools=[...] list and returns a HostedToolDef + true when the callee
+// names a recognized high-risk built-in tool class. Mirrors
+// classifyADKHostedToolCall.
+func classifyLangChainHostedToolCall(callItem models.Expr, filePath string) (models.HostedToolDef, bool) {
+	if callItem.Kind != models.ExprCall {
+		return models.HostedToolDef{}, false
+	}
+	name := calleeName(callItem.Text)
+	if !IsLangChainHostedToolClass(name) {
+		return models.HostedToolDef{}, false
+	}
+	return models.HostedToolDef{
+		Class: name,
+		SDK:   models.SDKLangChain,
+		Location: models.Location{
+			FilePath: filePath,
+			Line:     callItem.Line,
+			EndLine:  callItem.EndLine,
+		},
+		Kwargs: hostedKwargTree(callItem),
+	}, true
+}

--- a/internal/analysis/langchain_tools.go
+++ b/internal/analysis/langchain_tools.go
@@ -1,0 +1,290 @@
+package analysis
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/trustabl/trustabl/internal/analysis/astutil"
+	"github.com/trustabl/trustabl/internal/models"
+)
+
+// LangChain / LangGraph Python tool discovery.
+//
+// The @tool decorator is handled in discovery.go's kindFromDecorators: it shares
+// the decorated_definition shape with the Claude/OpenAI/MCP decorators and is
+// routed there, import-gated to disambiguate from the Claude SDK's own @tool.
+// This file handles the NON-decorator LangChain tool builders, which are plain
+// call expressions:
+//
+//	StructuredTool.from_function(fn, name=..., description=..., args_schema=...)
+//	StructuredTool(name=..., description=..., func=fn, args_schema=...)
+//	Tool.from_function(fn, name=..., description=...)
+//	Tool(name=..., description=..., func=fn)
+//
+// All are import-gated to files that import the langchain ecosystem, so a
+// user-defined Tool(...) in a non-langchain file is not swept up. Class-based
+// tools (`class X(BaseTool)`) are a documented gap — the least common shape.
+
+// langChainToolFactories is the closed set of call callees that build a
+// LangChain tool, keyed by the resolved callee path.
+var langChainToolFactories = map[string]bool{
+	"StructuredTool":               true,
+	"StructuredTool.from_function": true,
+	"Tool":                         true,
+	"Tool.from_function":           true,
+}
+
+// isLangChainModule reports whether a dotted module path belongs to the
+// LangChain / LangGraph ecosystem: langchain, langchain_core, langchain_community,
+// langchain_experimental, langchain_classic, the langchain-* provider packages,
+// langgraph, and langgraph_* (supervisor / swarm). The dot/underscore boundary
+// keeps an unrelated package that merely shares the prefix text (e.g.
+// "langchainx") from matching, mirroring isGoogleADKModule's discipline.
+func isLangChainModule(mod string) bool {
+	return mod == "langchain" || strings.HasPrefix(mod, "langchain.") ||
+		strings.HasPrefix(mod, "langchain_") ||
+		mod == "langgraph" || strings.HasPrefix(mod, "langgraph.") ||
+		strings.HasPrefix(mod, "langgraph_")
+}
+
+// fileImportsLangChain reports whether pf imports the LangChain / LangGraph
+// ecosystem via a real import statement (AST-based, not a source substring — a
+// comment that merely mentions langchain must not trip the gate).
+func fileImportsLangChain(pf ParsedFile) bool {
+	return fileImportsModule(pf, isLangChainModule)
+}
+
+// fileImportsClaudeSDK reports whether pf imports the Claude Agent SDK. Used to
+// resolve the @tool decorator collision: an @tool in a file that imports the
+// Claude SDK stays Claude even if the file also imports langchain.
+func fileImportsClaudeSDK(pf ParsedFile) bool {
+	return fileImportsModule(pf, func(mod string) bool {
+		return mod == "claude_agent_sdk" || strings.HasPrefix(mod, "claude_agent_sdk.")
+	})
+}
+
+// fileImportsModule walks pf's import statements and reports whether any imported
+// module satisfies match. Parameterized sibling of fileImportsGoogleADK.
+func fileImportsModule(pf ParsedFile, match func(string) bool) bool {
+	found := false
+	astutil.Walk(pf.Tree.RootNode(), func(n *sitter.Node) bool {
+		if found {
+			return false
+		}
+		switch n.Type() {
+		case "import_from_statement":
+			if match(astutil.NodeText(n.ChildByFieldName("module_name"), pf.Source)) {
+				found = true
+			}
+		case "import_statement":
+			for i := 0; i < int(n.ChildCount()); i++ {
+				c := n.Child(i)
+				switch c.Type() {
+				case "dotted_name":
+					if match(astutil.NodeText(c, pf.Source)) {
+						found = true
+					}
+				case "aliased_import":
+					if match(astutil.NodeText(c.ChildByFieldName("name"), pf.Source)) {
+						found = true
+					}
+				}
+			}
+		}
+		return true
+	})
+	return found
+}
+
+// DiscoverLangChainTools walks each ParsedFile and emits one ToolDef per
+// recognized non-decorator LangChain tool builder. Only files importing the
+// langchain ecosystem are considered.
+func DiscoverLangChainTools(files []ParsedFile) []models.ToolDef {
+	var out []models.ToolDef
+	for _, pf := range files {
+		if !fileImportsLangChain(pf) {
+			continue
+		}
+		out = append(out, discoverLangChainToolsInFile(pf)...)
+	}
+	return out
+}
+
+func discoverLangChainToolsInFile(pf ParsedFile) []models.ToolDef {
+	root := pf.Tree.RootNode()
+	funcs := indexTopLevelFunctions(root, pf.Source)
+
+	var out []models.ToolDef
+	astutil.Walk(root, func(n *sitter.Node) bool {
+		if n.Type() != "call" {
+			return true
+		}
+		callee := astutil.NodeText(n.ChildByFieldName("function"), pf.Source)
+		if !langChainToolFactories[callee] {
+			return true
+		}
+		if tool, ok := buildLangChainTool(n, callee, pf, funcs); ok {
+			out = append(out, tool)
+		}
+		return true
+	})
+	return out
+}
+
+// buildLangChainTool extracts a ToolDef from a StructuredTool/Tool factory call.
+// It resolves a same-file wrapped function — the first positional arg for the
+// from_function form, or the func= kwarg for the constructor form — to recover
+// the docstring, parameter typing, and shell-out fact; explicit name= /
+// description= / args_schema= kwargs override the wrapped function's values.
+// Returns ok=false when no tool name can be determined.
+func buildLangChainTool(n *sitter.Node, callee string, pf ParsedFile, funcs map[string]*sitter.Node) (models.ToolDef, bool) {
+	kwargs, _ := extractCallKwargs(n, pf.Source)
+
+	// Resolve the wrapped function symbol.
+	var wrappedName string
+	if strings.HasSuffix(callee, ".from_function") {
+		wrappedName = firstPositionalIdent(n, pf.Source)
+	}
+	if wrappedName == "" && kwargs != nil {
+		if fk := kwargs.Children["func"]; fk != nil && fk.Value != nil && fk.Value.Kind == models.ExprNameRef {
+			wrappedName = fk.Value.Text
+		}
+	}
+	var fnDef *sitter.Node
+	if wrappedName != "" {
+		fnDef = funcs[wrappedName]
+	}
+
+	// Name: explicit name= kwarg > wrapped function name.
+	name := kwargStringLiteral(kwargs, "name")
+	if name == "" {
+		name = wrappedName
+	}
+	if name == "" {
+		return models.ToolDef{}, false
+	}
+
+	// Description: explicit description= kwarg > wrapped function docstring.
+	description := kwargStringLiteral(kwargs, "description")
+	if description == "" && fnDef != nil {
+		description = astutil.FunctionDocstring(fnDef, pf.Source)
+	}
+
+	// Typed params: an args_schema (a Pydantic model) is a typed contract; else
+	// fall back to the wrapped function's signature typing.
+	hasTyped := kwargs != nil && kwargs.Children["args_schema"] != nil
+	if !hasTyped && fnDef != nil {
+		hasTyped = astutil.FunctionHasTypedParams(fnDef, pf.Source)
+	}
+
+	var params []string
+	facts := map[string]string{}
+	if fnDef != nil {
+		params = toolParamNames(fnDef, pf.Source)
+		if pythonBodyShellsOut(fnDef, pf.Source) {
+			facts["shells_out"] = "true"
+		}
+	}
+
+	// Point the location at the wrapped function body when resolved (mirrors ADK
+	// FunctionTool) so the AST-walking predicates (has_shell_call /
+	// has_code_exec_call / has_dynamic_url_call) find the body to scan.
+	// FindFunctionNode matches on (line, name), so this is effective only when the
+	// tool Name is the wrapped function's name — i.e. no name= override. With a
+	// name= override the tool keeps full field-based coverage (description, typed
+	// params, return_direct) but not the AST-walked body checks.
+	line, endLine := int(n.StartPoint().Row)+1, int(n.EndPoint().Row)+1
+	if fnDef != nil {
+		line, endLine = int(fnDef.StartPoint().Row)+1, int(fnDef.EndPoint().Row)+1
+	}
+	tool := models.ToolDef{
+		Name:     name,
+		Kind:     models.KindLangChainTool,
+		Language: models.LanguagePython,
+		Location: models.Location{
+			FilePath: pf.RelPath,
+			Line:     line,
+			EndLine:  endLine,
+		},
+		Description:    description,
+		HasTypedParams: hasTyped,
+		ParamNames:     params,
+		Facts:          facts,
+	}
+	// Capture remaining constructor kwargs (e.g. return_direct=True) into Config so
+	// tool_decorator_kwarg_value rules can read them. The @tool decorator form
+	// gets Config via extractDecoratorKwargs in discovery.go; this is the
+	// constructor-form equivalent.
+	if kwargs != nil {
+		cfg := map[string]string{}
+		for k, child := range kwargs.Children {
+			switch k {
+			case "name", "description", "func", "args_schema":
+				continue
+			}
+			if child.Value != nil {
+				cfg[k] = child.Value.Text
+			}
+		}
+		if len(cfg) > 0 {
+			tool.Config = cfg
+		}
+	}
+	// Capture the assignment-target identifier (my_tool = StructuredTool(...)) so
+	// agent tools=[my_tool] references resolve by variable name.
+	if p := n.Parent(); p != nil && p.Type() == "assignment" {
+		if l := p.ChildByFieldName("left"); l != nil && l.Type() == "identifier" {
+			tool.VarName = astutil.NodeText(l, pf.Source)
+		}
+	}
+	return tool, true
+}
+
+// indexTopLevelFunctions maps top-level function names to their definition nodes.
+func indexTopLevelFunctions(root *sitter.Node, src []byte) map[string]*sitter.Node {
+	funcs := map[string]*sitter.Node{}
+	for i := 0; i < int(root.NamedChildCount()); i++ {
+		c := root.NamedChild(i)
+		if c.Type() != "function_definition" {
+			continue
+		}
+		if name := astutil.FunctionName(c, src); name != "" {
+			funcs[name] = c
+		}
+	}
+	return funcs
+}
+
+// firstPositionalIdent returns the text of the first positional identifier arg of
+// a call, or "" if the first positional arg is not a bare identifier (e.g. a
+// lambda or a nested call, which cannot be resolved to a same-file definition).
+func firstPositionalIdent(n *sitter.Node, src []byte) string {
+	args := n.ChildByFieldName("arguments")
+	if args == nil {
+		return ""
+	}
+	for i := 0; i < int(args.NamedChildCount()); i++ {
+		c := args.NamedChild(i)
+		if c.Type() == "keyword_argument" || c.Type() == "comment" {
+			continue
+		}
+		if c.Type() == "identifier" {
+			return astutil.NodeText(c, src)
+		}
+		return ""
+	}
+	return ""
+}
+
+// kwargStringLiteral returns the unquoted value of a string-literal kwarg, or "".
+func kwargStringLiteral(kwargs *models.KwargTree, key string) string {
+	if kwargs == nil {
+		return ""
+	}
+	c := kwargs.Children[key]
+	if c == nil || c.Value == nil || c.Value.Kind != models.ExprLiteralString {
+		return ""
+	}
+	return strings.Trim(c.Value.Text, `"'`)
+}

--- a/internal/analysis/langchain_tools_test.go
+++ b/internal/analysis/langchain_tools_test.go
@@ -1,0 +1,243 @@
+package analysis_test
+
+import (
+	"testing"
+
+	"github.com/trustabl/trustabl/internal/analysis"
+	"github.com/trustabl/trustabl/internal/models"
+)
+
+func lcFindTool(tools []models.ToolDef, name string) (models.ToolDef, bool) {
+	for _, t := range tools {
+		if t.Name == name {
+			return t, true
+		}
+	}
+	return models.ToolDef{}, false
+}
+
+// The headline collision test: bare @tool is shared by LangChain and the Claude
+// SDK. A langchain-importing file must route it to LangChain.
+func TestLangChain_ToolDecorator_RoutesToLangChain(t *testing.T) {
+	src := `from langchain_core.tools import tool
+
+@tool
+def search(query: str) -> str:
+    """Search the web."""
+    return do_search(query)
+`
+	pf := parsePyFile(t, "tools.py", src)
+	tools := analysis.DiscoverToolsFromParsed([]analysis.ParsedFile{pf})
+	tl, ok := lcFindTool(tools, "search")
+	if !ok {
+		t.Fatalf("tool 'search' not discovered; got %+v", tools)
+	}
+	if tl.Kind != models.KindLangChainTool {
+		t.Errorf("Kind: got %q, want %q", tl.Kind, models.KindLangChainTool)
+	}
+	if tl.Language != models.LanguagePython {
+		t.Errorf("Language: got %q, want python", tl.Language)
+	}
+}
+
+// A Claude-SDK @tool must NOT be reclassified — the historical default holds
+// when langchain is not imported.
+func TestLangChain_ToolDecorator_ClaudeStaysClaude(t *testing.T) {
+	src := `from claude_agent_sdk import tool
+
+@tool
+def read_file(path: str) -> str:
+    """Read a file."""
+    return open(path).read()
+`
+	pf := parsePyFile(t, "claude_tools.py", src)
+	tools := analysis.DiscoverToolsFromParsed([]analysis.ParsedFile{pf})
+	tl, ok := lcFindTool(tools, "read_file")
+	if !ok {
+		t.Fatalf("tool 'read_file' not discovered")
+	}
+	if tl.Kind != models.KindClaudeSDKTool {
+		t.Errorf("Kind: got %q, want %q (Claude must not be reclassified)", tl.Kind, models.KindClaudeSDKTool)
+	}
+}
+
+// @tool is resolved by the import binding of the `tool` symbol, not by
+// file-level import presence — so it attributes correctly no matter what else
+// the file imports. The cases below pin both directions and the shadowing rule.
+
+// LangChain provides `tool` while the Claude SDK is imported for something else
+// → LangChain. (A file-level "claude is imported, so Claude wins" heuristic gets
+// this wrong; binding resolution fixes it.)
+func TestLangChain_ToolBinding_LangChainToolWithClaudeImport(t *testing.T) {
+	src := `from claude_agent_sdk import AgentDefinition
+from langchain_core.tools import tool
+
+@tool
+def amb(q: str) -> str:
+    """Ambiguous name, langchain binding."""
+    return q
+`
+	pf := parsePyFile(t, "mixed_lc.py", src)
+	tl, ok := lcFindTool(analysis.DiscoverToolsFromParsed([]analysis.ParsedFile{pf}), "amb")
+	if !ok {
+		t.Fatalf("tool 'amb' not discovered")
+	}
+	if tl.Kind != models.KindLangChainTool {
+		t.Errorf("got %q, want langchain_tool (tool bound to langchain)", tl.Kind)
+	}
+}
+
+// Claude provides `tool` while langchain is imported for something else → Claude.
+func TestLangChain_ToolBinding_ClaudeToolWithLangChainImport(t *testing.T) {
+	src := `from langchain_core.tools import StructuredTool
+from claude_agent_sdk import tool
+
+@tool
+def amb(q: str) -> str:
+    """Ambiguous name, claude binding."""
+    return q
+`
+	pf := parsePyFile(t, "mixed_claude.py", src)
+	tl, ok := lcFindTool(analysis.DiscoverToolsFromParsed([]analysis.ParsedFile{pf}), "amb")
+	if !ok {
+		t.Fatalf("tool 'amb' not discovered")
+	}
+	if tl.Kind != models.KindClaudeSDKTool {
+		t.Errorf("got %q, want claude_sdk_tool (tool bound to claude)", tl.Kind)
+	}
+}
+
+// Shadowing: both import bare `tool`; the last import binds (Python semantics).
+func TestLangChain_ToolBinding_ShadowLastWins(t *testing.T) {
+	lcLast := `from claude_agent_sdk import tool
+from langchain_core.tools import tool
+
+@tool
+def amb(q: str) -> str:
+    """x."""
+    return q
+`
+	pf := parsePyFile(t, "shadow_lc.py", lcLast)
+	tl, _ := lcFindTool(analysis.DiscoverToolsFromParsed([]analysis.ParsedFile{pf}), "amb")
+	if tl.Kind != models.KindLangChainTool {
+		t.Errorf("langchain-imported-last: got %q, want langchain_tool", tl.Kind)
+	}
+
+	claudeLast := `from langchain_core.tools import tool
+from claude_agent_sdk import tool
+
+@tool
+def amb(q: str) -> str:
+    """x."""
+    return q
+`
+	pf2 := parsePyFile(t, "shadow_claude.py", claudeLast)
+	tl2, _ := lcFindTool(analysis.DiscoverToolsFromParsed([]analysis.ParsedFile{pf2}), "amb")
+	if tl2.Kind != models.KindClaudeSDKTool {
+		t.Errorf("claude-imported-last: got %q, want claude_sdk_tool", tl2.Kind)
+	}
+}
+
+// An aliased import resolves by the local alias name.
+func TestLangChain_ToolBinding_Aliased(t *testing.T) {
+	src := `from claude_agent_sdk import tool
+from langchain_core.tools import tool as lc_tool
+
+@lc_tool
+def amb(q: str) -> str:
+    """x."""
+    return q
+`
+	pf := parsePyFile(t, "aliased.py", src)
+	tl, ok := lcFindTool(analysis.DiscoverToolsFromParsed([]analysis.ParsedFile{pf}), "amb")
+	if !ok {
+		t.Fatalf("tool 'amb' not discovered")
+	}
+	if tl.Kind != models.KindLangChainTool {
+		t.Errorf("aliased @lc_tool: got %q, want langchain_tool", tl.Kind)
+	}
+}
+
+func TestLangChain_StructuredToolFromFunction(t *testing.T) {
+	src := `from langchain_core.tools import StructuredTool
+
+def add(a: int, b: int) -> int:
+    """Add two numbers."""
+    return a + b
+
+calc = StructuredTool.from_function(add)
+`
+	pf := parsePyFile(t, "calc.py", src)
+	tools := analysis.DiscoverLangChainTools([]analysis.ParsedFile{pf})
+	tl, ok := lcFindTool(tools, "add")
+	if !ok {
+		t.Fatalf("StructuredTool.from_function not discovered; got %+v", tools)
+	}
+	if tl.Kind != models.KindLangChainTool {
+		t.Errorf("Kind: got %q, want %q", tl.Kind, models.KindLangChainTool)
+	}
+	if tl.Description != "Add two numbers." {
+		t.Errorf("Description: got %q, want %q", tl.Description, "Add two numbers.")
+	}
+	if !tl.HasTypedParams {
+		t.Errorf("HasTypedParams: got false, want true (typed signature)")
+	}
+	if tl.VarName != "calc" {
+		t.Errorf("VarName: got %q, want %q", tl.VarName, "calc")
+	}
+}
+
+func TestLangChain_ConstructorsExplicitName(t *testing.T) {
+	src := `from langchain.tools import StructuredTool, Tool
+
+def _impl(x):
+    return x
+
+t1 = StructuredTool(name="lookup", description="Look it up.", func=_impl)
+t2 = Tool(name="legacy", description="Legacy tool.", func=_impl)
+`
+	pf := parsePyFile(t, "ctors.py", src)
+	tools := analysis.DiscoverLangChainTools([]analysis.ParsedFile{pf})
+	if _, ok := lcFindTool(tools, "lookup"); !ok {
+		t.Errorf("StructuredTool(name=lookup) not discovered; got %+v", tools)
+	}
+	if _, ok := lcFindTool(tools, "legacy"); !ok {
+		t.Errorf("Tool(name=legacy) not discovered; got %+v", tools)
+	}
+}
+
+// The import gate must keep a user-defined Tool(...) in a non-langchain file
+// from being swept up.
+func TestLangChain_GateExcludesNonLangChain(t *testing.T) {
+	src := `class Tool:
+    def __init__(self, **kw): pass
+
+x = Tool(name="not_a_langchain_tool")
+`
+	pf := parsePyFile(t, "unrelated.py", src)
+	tools := analysis.DiscoverLangChainTools([]analysis.ParsedFile{pf})
+	if len(tools) != 0 {
+		t.Errorf("non-langchain Tool() should not be discovered; got %+v", tools)
+	}
+}
+
+func TestLangChain_StructuredToolShellFact(t *testing.T) {
+	src := `import subprocess
+from langchain_core.tools import StructuredTool
+
+def run_cmd(cmd: str) -> str:
+    """Run a command."""
+    return subprocess.run(cmd, shell=True, capture_output=True).stdout.decode()
+
+danger = StructuredTool.from_function(run_cmd)
+`
+	pf := parsePyFile(t, "shell.py", src)
+	tools := analysis.DiscoverLangChainTools([]analysis.ParsedFile{pf})
+	tl, ok := lcFindTool(tools, "run_cmd")
+	if !ok {
+		t.Fatalf("tool 'run_cmd' not discovered")
+	}
+	if tl.Facts["shells_out"] != "true" {
+		t.Errorf("shells_out fact: got %q, want \"true\"", tl.Facts["shells_out"])
+	}
+}

--- a/internal/analysis/ts_langchain_agents.go
+++ b/internal/analysis/ts_langchain_agents.go
@@ -1,0 +1,128 @@
+package analysis
+
+import (
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/trustabl/trustabl/internal/analysis/astutil"
+	"github.com/trustabl/trustabl/internal/models"
+)
+
+// LangChain.js / LangGraph.js TypeScript agent discovery.
+//
+//	createReactAgent({ llm, tools, prompt })            // @langchain/langgraph/prebuilt (deprecated, dominant)
+//	createAgent({ model, tools, systemPrompt, middleware })  // langchain v1
+//	new AgentExecutor({ agent, tools, maxIterations })   // @langchain/classic, legacy
+//
+// Class is normalized to the language-agnostic "ReactAgent" / "CreateAgent" /
+// "AgentExecutor" (see agentKindMatches). The raw StateGraph graph agent is a
+// documented gap — it is emergent across many call sites and does not fit the
+// one-call-site = one-agent model. Provider-package hosted tools (date-stamped
+// shell()/bash_*/computer_* from @langchain/openai|anthropic) are also a
+// documented gap for v1.
+
+// tsLangChainAgentFactories maps a factory call name to its normalized Class.
+var tsLangChainAgentFactories = map[string]string{
+	"createReactAgent": "ReactAgent",
+	"createAgent":      "CreateAgent",
+}
+
+// tsLangChainAgentCtors maps a `new X({...})` constructor to its normalized Class.
+var tsLangChainAgentCtors = map[string]string{
+	"AgentExecutor": "AgentExecutor",
+}
+
+// DiscoverTSLangChainAgents walks each parsed TS file and emits an AgentDef per
+// recognized LangChain/LangGraph agent. Import-gated to the langchain ecosystem.
+func DiscoverTSLangChainAgents(files []ParsedFile, onFile func(string)) []models.AgentDef {
+	var out []models.AgentDef
+	for _, pf := range files {
+		if onFile != nil {
+			onFile(pf.RelPath)
+		}
+		out = append(out, discoverTSLangChainAgentsInFile(pf)...)
+	}
+	return out
+}
+
+func discoverTSLangChainAgentsInFile(pf ParsedFile) []models.AgentDef {
+	if pf.Tree == nil {
+		return nil
+	}
+	aliases := astutil.TSImportAliasesMatch(pf.Tree.RootNode(), pf.Source, isTSLangChainModule)
+	if len(aliases) == 0 {
+		return nil
+	}
+	var out []models.AgentDef
+	astutil.Walk(pf.Tree.RootNode(), func(n *sitter.Node) bool {
+		switch n.Type() {
+		case "call_expression":
+			if class, ok := tsLangChainAgentFactories[astutil.TSCalleeText(n, pf.Source, aliases)]; ok {
+				out = append(out, buildTSLangChainAgent(n, pf, class))
+			}
+		case "new_expression":
+			ctor := n.ChildByFieldName("constructor")
+			if ctor == nil || ctor.Type() != "identifier" {
+				return true
+			}
+			if class, ok := tsLangChainAgentCtors[aliases[astutil.NodeText(ctor, pf.Source)]]; ok {
+				out = append(out, buildTSLangChainAgent(n, pf, class))
+			}
+		}
+		return true
+	})
+	return out
+}
+
+func buildTSLangChainAgent(n *sitter.Node, pf ParsedFile, class string) models.AgentDef {
+	a := models.AgentDef{
+		SDK:      models.SDKLangChain,
+		Class:    class,
+		Language: models.LanguageTypeScript,
+		Location: models.Location{
+			FilePath: pf.RelPath,
+			Line:     int(n.StartPoint().Row) + 1,
+			EndLine:  int(n.EndPoint().Row) + 1,
+		},
+		VarName: directAssignmentName(n, pf.Source),
+	}
+	args := n.ChildByFieldName("arguments")
+	if args == nil || args.NamedChildCount() == 0 {
+		a.Opaque = true
+		return a
+	}
+	opts := args.NamedChild(0)
+	if opts.Type() != "object" {
+		a.Opaque = true
+		return a
+	}
+	// A spread (...rest) means the captured kwarg view may be incomplete.
+	for i := 0; i < int(opts.NamedChildCount()); i++ {
+		if opts.NamedChild(i).Type() == "spread_element" {
+			a.Opaque = true
+			break
+		}
+	}
+	a.Kwargs = astutil.TSObjectKwargs(opts, pf.Source)
+	if nameNode := getObjectProperty(opts, "name", pf.Source); nameNode != nil && nameNode.Type() == "string" {
+		a.Name = unquote(astutil.NodeText(nameNode, pf.Source))
+	}
+	// tools=[...] identifier refs for edge resolution. An inline tool, a ToolNode
+	// (new/call expression), or a non-array tools value cannot be enumerated by
+	// symbol — mark Opaque so "agent has no tools" rules do not false-fire.
+	if tools := getObjectProperty(opts, "tools", pf.Source); tools != nil {
+		if tools.Type() != "array" {
+			a.Opaque = true
+		} else {
+			for i := 0; i < int(tools.NamedChildCount()); i++ {
+				item := tools.NamedChild(i)
+				switch item.Type() {
+				case "identifier":
+					a.ToolRefs = append(a.ToolRefs, models.ToolRef{Name: astutil.NodeText(item, pf.Source)})
+				case "new_expression", "call_expression":
+					a.Opaque = true
+				}
+			}
+		}
+	}
+	return a
+}

--- a/internal/analysis/ts_langchain_agents_test.go
+++ b/internal/analysis/ts_langchain_agents_test.go
@@ -1,0 +1,79 @@
+package analysis_test
+
+import (
+	"testing"
+
+	"github.com/trustabl/trustabl/internal/analysis"
+	"github.com/trustabl/trustabl/internal/models"
+)
+
+func lcFindAgent(agents []models.AgentDef, class string) (models.AgentDef, bool) {
+	for _, a := range agents {
+		if a.Class == class {
+			return a, true
+		}
+	}
+	return models.AgentDef{}, false
+}
+
+func TestTSLangChainAgent_CreateReactAgent(t *testing.T) {
+	src := `import { createReactAgent } from "@langchain/langgraph/prebuilt";
+const agent = createReactAgent({ llm: model, tools: [searchTool], prompt: "Be helpful." });
+`
+	pf := parseTSForTest(t, "agent.ts", src)
+	agents := analysis.DiscoverTSLangChainAgents([]analysis.ParsedFile{pf}, nil)
+	a, ok := lcFindAgent(agents, "ReactAgent")
+	if !ok {
+		t.Fatalf("createReactAgent not discovered; got %+v", agents)
+	}
+	if a.SDK != models.SDKLangChain {
+		t.Errorf("SDK: got %q", a.SDK)
+	}
+	if a.VarName != "agent" {
+		t.Errorf("VarName: got %q, want agent", a.VarName)
+	}
+	if len(a.ToolRefs) != 1 || a.ToolRefs[0].Name != "searchTool" {
+		t.Errorf("ToolRefs: got %+v, want [searchTool]", a.ToolRefs)
+	}
+}
+
+func TestTSLangChainAgent_CreateAgent(t *testing.T) {
+	src := `import { createAgent } from "langchain";
+const agent = createAgent({ model: "openai:gpt-4o", tools: [searchTool], systemPrompt: "You help." });
+`
+	pf := parseTSForTest(t, "ca.ts", src)
+	agents := analysis.DiscoverTSLangChainAgents([]analysis.ParsedFile{pf}, nil)
+	a, ok := lcFindAgent(agents, "CreateAgent")
+	if !ok {
+		t.Fatalf("createAgent not discovered; got %+v", agents)
+	}
+	if a.Kwargs == nil || a.Kwargs.Children["systemPrompt"] == nil {
+		t.Errorf("systemPrompt kwarg not captured: %+v", a.Kwargs)
+	}
+}
+
+func TestTSLangChainAgent_AgentExecutor(t *testing.T) {
+	src := `import { AgentExecutor } from "@langchain/classic/agents";
+const ex = new AgentExecutor({ agent: a, tools: [searchTool], maxIterations: 5 });
+`
+	pf := parseTSForTest(t, "ex.ts", src)
+	agents := analysis.DiscoverTSLangChainAgents([]analysis.ParsedFile{pf}, nil)
+	a, ok := lcFindAgent(agents, "AgentExecutor")
+	if !ok {
+		t.Fatalf("new AgentExecutor not discovered; got %+v", agents)
+	}
+	if a.Kwargs == nil || a.Kwargs.Children["maxIterations"] == nil {
+		t.Errorf("maxIterations kwarg not captured: %+v", a.Kwargs)
+	}
+}
+
+func TestTSLangChainAgent_GateExcludesNonLangChain(t *testing.T) {
+	src := `function createReactAgent(x) { return x; }
+const a = createReactAgent({ llm: m, tools: [] });
+`
+	pf := parseTSForTest(t, "no_lc.ts", src)
+	agents := analysis.DiscoverTSLangChainAgents([]analysis.ParsedFile{pf}, nil)
+	if len(agents) != 0 {
+		t.Errorf("non-langchain createReactAgent should not be discovered; got %+v", agents)
+	}
+}

--- a/internal/analysis/ts_langchain_tools.go
+++ b/internal/analysis/ts_langchain_tools.go
@@ -1,0 +1,158 @@
+package analysis
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/trustabl/trustabl/internal/analysis/astutil"
+	"github.com/trustabl/trustabl/internal/models"
+)
+
+// LangChain.js / LangGraph.js TypeScript tool discovery.
+//
+// Recognized shapes (import-gated to the langchain ecosystem):
+//
+//	tool(fn, { name, description, schema })            // @langchain/core/tools or langchain
+//	new DynamicStructuredTool({ name, description, schema, func })
+//	new DynamicTool({ name, description, func })        // no schema (string in / out)
+//
+// Class-based tools (`class X extends StructuredTool`) are a documented gap.
+//
+// Collision note: the bare tool(...) factory is shared with the Claude SDK and
+// the OpenAI Agents SDK. The import gate (isTSLangChainModule) is what keeps the
+// three apart — a langchain-importing file routes tool() here, while the Claude
+// and OpenAI passes gate on their own imports and skip langchain files.
+
+// isTSLangChainModule reports whether a TS import specifier belongs to the
+// LangChain / LangGraph ecosystem. Prefix-based because real code imports from
+// many subpaths (@langchain/core/tools, @langchain/langgraph/prebuilt, …).
+func isTSLangChainModule(mod string) bool {
+	return mod == "langchain" || strings.HasPrefix(mod, "langchain/") ||
+		mod == "langgraph" || strings.HasPrefix(mod, "langgraph/") ||
+		strings.HasPrefix(mod, "@langchain/")
+}
+
+// tsLangChainToolCtors is the set of `new X({...})` tool constructors.
+var tsLangChainToolCtors = map[string]bool{
+	"DynamicStructuredTool": true,
+	"DynamicTool":           true,
+}
+
+// DiscoverTSLangChainTools walks each parsed TS file and emits a ToolDef per
+// recognized LangChain tool builder. Import-gated to the langchain ecosystem.
+func DiscoverTSLangChainTools(files []ParsedFile, onFile func(string)) []models.ToolDef {
+	var out []models.ToolDef
+	for _, pf := range files {
+		if onFile != nil {
+			onFile(pf.RelPath)
+		}
+		out = append(out, discoverTSLangChainToolsInFile(pf)...)
+	}
+	return out
+}
+
+func discoverTSLangChainToolsInFile(pf ParsedFile) []models.ToolDef {
+	if pf.Tree == nil {
+		return nil
+	}
+	aliases := astutil.TSImportAliasesMatch(pf.Tree.RootNode(), pf.Source, isTSLangChainModule)
+	if len(aliases) == 0 {
+		return nil
+	}
+	var out []models.ToolDef
+	astutil.Walk(pf.Tree.RootNode(), func(n *sitter.Node) bool {
+		switch n.Type() {
+		case "call_expression":
+			if astutil.TSCalleeText(n, pf.Source, aliases) != "tool" {
+				return true
+			}
+			// tool(fn, { ...config }) — config is arg 1, the handler fn is arg 0.
+			args := n.ChildByFieldName("arguments")
+			if args == nil || args.NamedChildCount() < 2 {
+				return true
+			}
+			if td, ok := buildTSLangChainTool(n, args.NamedChild(1), args.NamedChild(0), pf); ok {
+				out = append(out, td)
+			}
+		case "new_expression":
+			ctor := n.ChildByFieldName("constructor")
+			if ctor == nil || ctor.Type() != "identifier" {
+				return true
+			}
+			if !tsLangChainToolCtors[aliases[astutil.NodeText(ctor, pf.Source)]] {
+				return true
+			}
+			// new DynamicStructuredTool({ ...config, func }) — config is arg 0.
+			args := n.ChildByFieldName("arguments")
+			if args == nil || args.NamedChildCount() == 0 {
+				return true
+			}
+			if td, ok := buildTSLangChainTool(n, args.NamedChild(0), nil, pf); ok {
+				out = append(out, td)
+			}
+		}
+		return true
+	})
+	return out
+}
+
+// buildTSLangChainTool builds a ToolDef from a config object literal. funcNode,
+// when non-nil, is an external handler node (the tool() factory's arg 0) walked
+// for body facts; otherwise the config's own `func` property is the handler.
+func buildTSLangChainTool(node, optsObj, funcNode *sitter.Node, pf ParsedFile) (models.ToolDef, bool) {
+	if optsObj == nil || optsObj.Type() != "object" {
+		return models.ToolDef{}, false
+	}
+	kt := astutil.TSObjectKwargs(optsObj, pf.Source)
+	td := models.ToolDef{
+		Kind:     models.KindLangChainTool,
+		Language: models.LanguageTypeScript,
+		Location: models.Location{
+			FilePath: pf.RelPath,
+			Line:     int(node.StartPoint().Row) + 1,
+			EndLine:  int(node.EndPoint().Row) + 1,
+		},
+		VarName: directAssignmentName(node, pf.Source),
+	}
+	if c := kt.Children["name"]; c != nil && c.Value != nil && c.Value.Kind == models.ExprLiteralString {
+		td.Name = unquote(c.Value.Text)
+	}
+	if c := kt.Children["description"]; c != nil && c.Value != nil && c.Value.Kind == models.ExprLiteralString {
+		td.Description = unquote(c.Value.Text)
+	}
+	// schema → typed params (Zod object or inline literal). LangChain uses
+	// `schema`, not OpenAI/ADK's `parameters`.
+	if s := getObjectProperty(optsObj, "schema", pf.Source); s != nil {
+		if names, typed := tsZodParamNames(s, pf.Source); typed {
+			td.HasTypedParams = true
+			td.ParamNames = names
+		}
+	}
+	// Body facts: prefer the external handler (tool() arg 0); else the func: prop.
+	handler := funcNode
+	if handler == nil {
+		handler = getObjectProperty(optsObj, "func", pf.Source)
+	}
+	if handler != nil {
+		if facts := tsHandlerFacts(handler, pf.Source); len(facts) > 0 {
+			td.Facts = facts
+		}
+	}
+	consumed := map[string]bool{"name": true, "description": true, "schema": true, "func": true}
+	cfg := map[string]string{}
+	for k, child := range kt.Children {
+		if consumed[k] {
+			continue
+		}
+		if child.Value != nil {
+			cfg[k] = child.Value.Text
+		} else {
+			flattenKwargs(k, child, cfg)
+		}
+	}
+	if len(cfg) > 0 {
+		td.Config = cfg
+	}
+	return td, true
+}

--- a/internal/analysis/ts_langchain_tools_test.go
+++ b/internal/analysis/ts_langchain_tools_test.go
@@ -1,0 +1,125 @@
+package analysis_test
+
+import (
+	"testing"
+
+	"github.com/trustabl/trustabl/internal/analysis"
+	"github.com/trustabl/trustabl/internal/models"
+)
+
+func TestTSLangChain_ToolFactory(t *testing.T) {
+	src := `import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+
+const getWeather = tool(
+  async (input) => { return "sunny in " + input.city; },
+  { name: "get_weather", description: "Get the weather.", schema: z.object({ city: z.string() }) }
+);
+`
+	pf := parseTSForTest(t, "tools.ts", src)
+	tools := analysis.DiscoverTSLangChainTools([]analysis.ParsedFile{pf}, nil)
+	tl, ok := lcFindTool(tools, "get_weather")
+	if !ok {
+		t.Fatalf("tool 'get_weather' not discovered; got %+v", tools)
+	}
+	if tl.Kind != models.KindLangChainTool {
+		t.Errorf("Kind: got %q, want %q", tl.Kind, models.KindLangChainTool)
+	}
+	if tl.Language != models.LanguageTypeScript {
+		t.Errorf("Language: got %q, want typescript", tl.Language)
+	}
+	if tl.Description != "Get the weather." {
+		t.Errorf("Description: got %q", tl.Description)
+	}
+	if !tl.HasTypedParams {
+		t.Errorf("HasTypedParams: got false, want true (zod schema)")
+	}
+	if tl.VarName != "getWeather" {
+		t.Errorf("VarName: got %q, want getWeather", tl.VarName)
+	}
+}
+
+func TestTSLangChain_DynamicStructuredTool(t *testing.T) {
+	src := `import { DynamicStructuredTool } from "@langchain/core/tools";
+import { z } from "zod";
+const look = new DynamicStructuredTool({ name: "lookup", description: "Look up.", schema: z.object({ q: z.string() }), func: async (i) => i.q });
+`
+	pf := parseTSForTest(t, "dst.ts", src)
+	tools := analysis.DiscoverTSLangChainTools([]analysis.ParsedFile{pf}, nil)
+	if _, ok := lcFindTool(tools, "lookup"); !ok {
+		t.Fatalf("DynamicStructuredTool not discovered; got %+v", tools)
+	}
+}
+
+func TestTSLangChain_DynamicTool(t *testing.T) {
+	src := `import { DynamicTool } from "@langchain/core/tools";
+const echo = new DynamicTool({ name: "echo", description: "Echo.", func: async (i) => i });
+`
+	pf := parseTSForTest(t, "dt.ts", src)
+	tools := analysis.DiscoverTSLangChainTools([]analysis.ParsedFile{pf}, nil)
+	tl, ok := lcFindTool(tools, "echo")
+	if !ok {
+		t.Fatalf("DynamicTool not discovered; got %+v", tools)
+	}
+	if tl.HasTypedParams {
+		t.Errorf("DynamicTool has no schema; HasTypedParams should be false")
+	}
+}
+
+// The strongest collision proof: a LangChain tool() must be found by the
+// LangChain pass and NOT by the OpenAI pass (and vice versa), purely via the
+// import gate.
+func TestTSLangChain_NoCrossFireWithOpenAI(t *testing.T) {
+	src := `import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+const t = tool(async (i) => "", { name: "lc_tool", description: "x", schema: z.object({}) });
+`
+	pf := parseTSForTest(t, "lc.ts", src)
+	lc := analysis.DiscoverTSLangChainTools([]analysis.ParsedFile{pf}, nil)
+	oai := analysis.DiscoverTSOpenAITools([]analysis.ParsedFile{pf}, nil)
+	if len(lc) != 1 {
+		t.Errorf("LangChain pass: got %d tools, want 1", len(lc))
+	}
+	if len(oai) != 0 {
+		t.Errorf("OpenAI pass must not discover a LangChain tool; got %d (%+v)", len(oai), oai)
+	}
+}
+
+func TestTSLangChain_ToolShellFact(t *testing.T) {
+	src := `import { tool } from "@langchain/core/tools";
+import { execSync } from "child_process";
+import { z } from "zod";
+const run = tool(
+  async (i) => { return execSync(i.cmd).toString(); },
+  { name: "run_cmd", description: "Run.", schema: z.object({ cmd: z.string() }) }
+);
+`
+	pf := parseTSForTest(t, "shell.ts", src)
+	tools := analysis.DiscoverTSLangChainTools([]analysis.ParsedFile{pf}, nil)
+	tl, ok := lcFindTool(tools, "run_cmd")
+	if !ok {
+		t.Fatalf("tool 'run_cmd' not discovered")
+	}
+	if tl.Facts["shells_out"] != "true" {
+		t.Errorf("shells_out: got %q, want \"true\"; facts=%v", tl.Facts["shells_out"], tl.Facts)
+	}
+}
+
+func TestTSLangChain_ToolSSRFFact(t *testing.T) {
+	src := `import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+const fetchUrl = tool(
+  async (i) => { const r = await fetch(i.url); return r.text(); },
+  { name: "fetch_url", description: "Fetch.", schema: z.object({ url: z.string() }) }
+);
+`
+	pf := parseTSForTest(t, "ssrf.ts", src)
+	tools := analysis.DiscoverTSLangChainTools([]analysis.ParsedFile{pf}, nil)
+	tl, ok := lcFindTool(tools, "fetch_url")
+	if !ok {
+		t.Fatalf("tool 'fetch_url' not discovered")
+	}
+	if tl.Facts["dynamic_url"] != "true" {
+		t.Errorf("dynamic_url: got %q, want \"true\"; facts=%v", tl.Facts["dynamic_url"], tl.Facts)
+	}
+}

--- a/internal/ingestion/normalizer.go
+++ b/internal/ingestion/normalizer.go
@@ -81,6 +81,17 @@ func detectSDKDeps(root string) []models.SDKDep {
 		// discovery, not this needle.
 		{Name: "mcp", Pattern: "@modelcontextprotocol/sdk",
 			Manifests: []string{"package.json"}},
+		// LangChain + LangGraph — one ecosystem, one SDK row (SDKLangChain). The
+		// "langchain" pattern matches the umbrella plus every langchain-* /
+		// @langchain/* distribution (langchain-core, langchain_community,
+		// @langchain/langgraph, …); "langgraph" catches the graph runtime when it
+		// is pulled in on its own. Both map to Name "langchain". This needle only
+		// feeds the declared-vs-used drift signal — pack loading is gated on
+		// observed code via deriveSDKsDetected, not on this dependency scan.
+		{Name: "langchain", Pattern: "langchain",
+			Manifests: []string{"pyproject.toml", "requirements.txt", "Pipfile", "poetry.lock", "package.json"}},
+		{Name: "langchain", Pattern: "langgraph",
+			Manifests: []string{"pyproject.toml", "requirements.txt", "Pipfile", "poetry.lock", "package.json"}},
 	}
 	seen := make(map[string]bool)
 	var out []models.SDKDep

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -60,6 +60,7 @@ const (
 	CategoryOpenShell DetectorCategory = "openshell"
 	CategoryGoogleADK DetectorCategory = "google_adk"
 	CategoryMCP       DetectorCategory = "mcp"
+	CategoryLangChain DetectorCategory = "langchain"
 )
 
 // ToolKind drives detector applicability.
@@ -72,6 +73,12 @@ const (
 	KindShellInvocation ToolKind = "shell_invocation"
 	KindUnknown         ToolKind = "unknown"
 	KindADKFunctionTool ToolKind = "adk_function_tool"
+	// KindLangChainTool is a LangChain / LangGraph tool: the @tool decorator,
+	// a StructuredTool/Tool factory or constructor (Python), or the tool()
+	// factory / DynamicStructuredTool / DynamicTool (TypeScript). Discovery is
+	// import-gated so it does not collide with the Claude-SDK @tool / tool()
+	// shapes that share the same callee name.
+	KindLangChainTool ToolKind = "langchain_tool"
 )
 
 // Language identifies the source language of a discovered tool. Rules
@@ -203,6 +210,7 @@ const (
 	SDKOpenAIAgents   SDK = "openai_agents"
 	SDKMCP            SDK = "mcp"
 	SDKGoogleADK      SDK = "google_adk"
+	SDKLangChain      SDK = "langchain" // LangChain + LangGraph (one ecosystem, one SDK row)
 )
 
 // "openshell" is intentionally NOT in the SDK enum: it is not a library

--- a/internal/rules/loader.go
+++ b/internal/rules/loader.go
@@ -74,10 +74,10 @@ func Load(fsys fs.FS) ([]PolicyFile, error) {
 			switch pf.Policy.Category {
 			case models.CategoryClaudeSDK, models.CategoryOpenAISDK,
 				models.CategoryOpenShell, models.CategoryGoogleADK,
-				models.CategoryMCP:
+				models.CategoryMCP, models.CategoryLangChain:
 				// valid
 			default:
-				errs = append(errs, fmt.Errorf("%s: unknown category %q (allowed: claude_sdk, openai_sdk, openshell, google_adk, mcp)", name, pf.Policy.Category))
+				errs = append(errs, fmt.Errorf("%s: unknown category %q (allowed: claude_sdk, openai_sdk, openshell, google_adk, mcp, langchain)", name, pf.Policy.Category))
 			}
 		}
 		if len(errs) > policyErrCount {
@@ -185,7 +185,7 @@ func Load(fsys fs.FS) ([]PolicyFile, error) {
 			// token here silently never matches, so the rule never fires.
 			for _, sdk := range rule.Match.repoSDKInCodeValues() {
 				if !validRepoHasSDKInCode(sdk) {
-					errs = append(errs, fmt.Errorf("%s: repo_has_sdk_in_code value %q is not a known SDK token (want one of: claude_agent_sdk, openai_agents, google_adk, mcp, openshell)", tag, sdk))
+					errs = append(errs, fmt.Errorf("%s: repo_has_sdk_in_code value %q is not a known SDK token (want one of: claude_agent_sdk, openai_agents, google_adk, mcp, langchain, openshell)", tag, sdk))
 				}
 			}
 			// A degenerate combinator (empty any/all list, or not: over an empty
@@ -220,7 +220,8 @@ func Load(fsys fs.FS) ([]PolicyFile, error) {
 func validRepoHasSDKInCode(tok string) bool {
 	switch tok {
 	case string(models.SDKClaudeAgentSDK), string(models.SDKOpenAIAgents),
-		string(models.SDKGoogleADK), string(models.SDKMCP), "openshell":
+		string(models.SDKGoogleADK), string(models.SDKMCP),
+		string(models.SDKLangChain), "openshell":
 		return true
 	}
 	return false
@@ -231,7 +232,8 @@ func validAppliesToForScope(scope models.Scope, kind string) bool {
 	case models.ScopeTool:
 		switch kind {
 		case "claude_sdk_tool", "openai_tool", "mcp_tool",
-			"shell_invocation", "unknown", "adk_function_tool":
+			"shell_invocation", "unknown", "adk_function_tool",
+			"langchain_tool":
 			return true
 		}
 	case models.ScopeAgent:
@@ -239,12 +241,14 @@ func validAppliesToForScope(scope models.Scope, kind string) bool {
 		case "openai_agent", "openai_sandbox_agent", "claude_agent_definition",
 			"claude_query_main",
 			"adk_llm_agent", "adk_sequential_agent", "adk_parallel_agent",
-			"adk_loop_agent", "adk_langgraph_agent":
+			"adk_loop_agent", "adk_langgraph_agent",
+			"langchain_agent", "langchain_agent_executor", "langchain_state_graph":
 			return true
 		}
 	case models.ScopeRepo:
 		switch kind {
-		case "claude_sdk", "openai_agents", "openshell", "mcp", "google_adk":
+		case "claude_sdk", "openai_agents", "openshell", "mcp", "google_adk",
+			"langchain":
 			return true
 		}
 	case models.ScopeSubagent:

--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -134,6 +134,133 @@ type policySubagentCase struct {
 }
 
 var policyRuleCases = []policyRuleCase{
+	// ─── LangChain tool rules (LC-*) ────────────────────────────────────────
+	{name: "LC-001 fires on tool with no docstring", ruleID: "LC-001", kind: models.KindLangChainTool, src: `
+def search(q: str) -> str:
+    return q
+`, wantFires: true},
+	{name: "LC-001 silent with docstring", ruleID: "LC-001", kind: models.KindLangChainTool, src: `
+def search(q: str) -> str:
+    """Search the web."""
+    return q
+`, wantFires: false},
+
+	{name: "LC-002 fires on untyped params", ruleID: "LC-002", kind: models.KindLangChainTool, src: `
+def search(q):
+    """Search."""
+    return q
+`, wantFires: true},
+	{name: "LC-002 silent with typed params", ruleID: "LC-002", kind: models.KindLangChainTool, src: `
+def search(q: str) -> str:
+    """Search."""
+    return q
+`, wantFires: false},
+
+	{name: "LC-003 fires on subprocess", ruleID: "LC-003", kind: models.KindLangChainTool, src: `
+def run(cmd: str) -> str:
+    """Run a command."""
+    import subprocess
+    return subprocess.run(cmd, shell=True)
+`, wantFires: true},
+	{name: "LC-003 silent without shell", ruleID: "LC-003", kind: models.KindLangChainTool, src: `
+def run(cmd: str) -> str:
+    """Run."""
+    return cmd
+`, wantFires: false},
+
+	{name: "LC-004 fires on eval", ruleID: "LC-004", kind: models.KindLangChainTool, src: `
+def calc(expr: str) -> str:
+    """Calculate."""
+    return eval(expr)
+`, wantFires: true},
+	{name: "LC-004 silent without eval", ruleID: "LC-004", kind: models.KindLangChainTool, src: `
+def calc(expr: str) -> str:
+    """Calculate."""
+    return expr
+`, wantFires: false},
+
+	{name: "LC-005 fires on dynamic URL", ruleID: "LC-005", kind: models.KindLangChainTool, src: `
+def fetch(url: str) -> str:
+    """Fetch a URL."""
+    import requests
+    return requests.get(url).text
+`, wantFires: true},
+	{name: "LC-005 silent on literal URL", ruleID: "LC-005", kind: models.KindLangChainTool, src: `
+def fetch(q: str) -> str:
+    """Fetch."""
+    import requests
+    return requests.get("https://api.example.com/data").text
+`, wantFires: false},
+
+	{name: "LC-006 fires on return_direct=True", ruleID: "LC-006", kind: models.KindLangChainTool, src: `
+def f(x: str) -> str:
+    """Doc."""
+    return x
+`, toolConfig: map[string]string{"return_direct": "True"}, wantFires: true},
+	{name: "LC-006 silent without return_direct", ruleID: "LC-006", kind: models.KindLangChainTool, src: `
+def f(x: str) -> str:
+    """Doc."""
+    return x
+`, toolConfig: map[string]string{}, wantFires: false},
+
+	// LangChain TypeScript tool rules — parseTSTool runs DiscoverTSLangChainTools,
+	// so each snippet must import from the langchain ecosystem to be discovered.
+	{name: "LC-010 fires on TS tool with no description", ruleID: "LC-010", kind: models.KindLangChainTool, lang: models.LanguageTypeScript, wantFires: true, src: `
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+export const t = tool(async (i) => i.q, { name: "search", schema: z.object({ q: z.string() }) });
+`},
+	{name: "LC-010 silent with description", ruleID: "LC-010", kind: models.KindLangChainTool, lang: models.LanguageTypeScript, wantFires: false, src: `
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+export const t = tool(async (i) => i.q, { name: "search", description: "Search the web.", schema: z.object({ q: z.string() }) });
+`},
+
+	{name: "LC-011 fires on TS subprocess", ruleID: "LC-011", kind: models.KindLangChainTool, lang: models.LanguageTypeScript, wantFires: true, src: `
+import { tool } from "@langchain/core/tools";
+import { execSync } from "child_process";
+import { z } from "zod";
+export const t = tool(async (i) => { return execSync(i.cmd).toString(); }, { name: "run", description: "Run.", schema: z.object({ cmd: z.string() }) });
+`},
+	{name: "LC-011 silent without TS shell", ruleID: "LC-011", kind: models.KindLangChainTool, lang: models.LanguageTypeScript, wantFires: false, src: `
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+export const t = tool(async (i) => i.cmd, { name: "run", description: "Run.", schema: z.object({ cmd: z.string() }) });
+`},
+
+	{name: "LC-012 fires on TS eval", ruleID: "LC-012", kind: models.KindLangChainTool, lang: models.LanguageTypeScript, wantFires: true, src: `
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+export const t = tool(async (i) => { return eval(i.code); }, { name: "calc", description: "Calc.", schema: z.object({ code: z.string() }) });
+`},
+	{name: "LC-012 silent without TS eval", ruleID: "LC-012", kind: models.KindLangChainTool, lang: models.LanguageTypeScript, wantFires: false, src: `
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+export const t = tool(async (i) => { return i.code; }, { name: "calc", description: "Calc.", schema: z.object({ code: z.string() }) });
+`},
+
+	{name: "LC-013 fires on TS dynamic URL", ruleID: "LC-013", kind: models.KindLangChainTool, lang: models.LanguageTypeScript, wantFires: true, src: `
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+export const t = tool(async (i) => { const r = await fetch(i.url); return r.text(); }, { name: "fetch", description: "Fetch.", schema: z.object({ url: z.string() }) });
+`},
+	{name: "LC-013 silent on TS literal URL", ruleID: "LC-013", kind: models.KindLangChainTool, lang: models.LanguageTypeScript, wantFires: false, src: `
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+export const t = tool(async (i) => { const r = await fetch("https://api.example.com/data"); return r.text(); }, { name: "fetch", description: "Fetch.", schema: z.object({ q: z.string() }) });
+`},
+
+	{name: "LC-014 fires on TS returnDirect", ruleID: "LC-014", kind: models.KindLangChainTool, lang: models.LanguageTypeScript, wantFires: true, src: `
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+export const t = tool(async (i) => i.q, { name: "x", description: "X.", schema: z.object({ q: z.string() }), returnDirect: true });
+`},
+	{name: "LC-014 silent without TS returnDirect", ruleID: "LC-014", kind: models.KindLangChainTool, lang: models.LanguageTypeScript, wantFires: false, src: `
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+export const t = tool(async (i) => i.q, { name: "x", description: "X.", schema: z.object({ q: z.string() }) });
+`},
+
 	// ─── CSDK-001 missing docstring ─────────────────────────────────────────
 	{name: "CSDK-001 fires on missing docstring", ruleID: "CSDK-001", kind: models.KindClaudeSDKTool, src: `
 def fetch_data(x: str) -> dict:
@@ -1315,6 +1442,18 @@ def calc(expr: str) -> int:
 
 // policyRepoRuleCases covers repo-scoped rules.
 var policyRepoRuleCases = []policyRepoCase{
+	// ─── LangChain repo rule (LC-201) ───────────────────────────────────────
+	{"LC-201 fires when LangChain code has no agent-guidance doc", "LC-201",
+		models.RepoProfile{Languages: []models.Language{models.LanguagePython}},
+		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKLangChain}},
+		true},
+	{"LC-201 silent when AGENTS.md present", "LC-201",
+		models.RepoProfile{
+			Languages: []models.Language{models.LanguagePython},
+			Manifest:  models.ScanManifest{Components: []models.AgentComponent{{Kind: models.ComponentAgentsMd}}},
+		},
+		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKLangChain}},
+		false},
 	// ─── OAI-201 default tracing (repo-scoped) ───────────────────────────────
 	{"OAI-201 fires when using default tracing", "OAI-201",
 		models.RepoProfile{Languages: []models.Language{models.LanguagePython}},
@@ -1496,6 +1635,36 @@ var policySubagentRuleCases = []policySubagentCase{
 
 // policyAgentRuleCases covers agent-scoped rules.
 var policyAgentRuleCases = []policyAgentCase{
+	// ─── LangChain agent rules (LC-*) ───────────────────────────────────────
+	{"LC-101 fires when agent wires PythonREPLTool", "LC-101",
+		models.AgentDef{
+			SDK: models.SDKLangChain, Class: "ReactAgent", Language: models.LanguagePython,
+			HostedToolRefs: []models.HostedToolRef{{Class: "PythonREPLTool"}},
+		},
+		models.RepoInventory{}, true},
+	{"LC-101 silent without a dangerous builtin", "LC-101",
+		models.AgentDef{SDK: models.SDKLangChain, Class: "ReactAgent", Language: models.LanguagePython},
+		models.RepoInventory{}, false},
+
+	{"LC-102 fires when AgentExecutor has no max_iterations", "LC-102",
+		models.AgentDef{SDK: models.SDKLangChain, Class: "AgentExecutor", Language: models.LanguagePython},
+		models.RepoInventory{}, true},
+	{"LC-102 silent when max_iterations set", "LC-102",
+		models.AgentDef{SDK: models.SDKLangChain, Class: "AgentExecutor", Language: models.LanguagePython,
+			Kwargs: &models.KwargTree{Children: map[string]*models.KwargTree{
+				"max_iterations": {Value: &models.Expr{Kind: models.ExprLiteralInt, Text: "5"}},
+			}}},
+		models.RepoInventory{}, false},
+
+	{"LC-111 fires when TS AgentExecutor has no maxIterations", "LC-111",
+		models.AgentDef{SDK: models.SDKLangChain, Class: "AgentExecutor", Language: models.LanguageTypeScript},
+		models.RepoInventory{}, true},
+	{"LC-111 silent when maxIterations set", "LC-111",
+		models.AgentDef{SDK: models.SDKLangChain, Class: "AgentExecutor", Language: models.LanguageTypeScript,
+			Kwargs: &models.KwargTree{Children: map[string]*models.KwargTree{
+				"maxIterations": {Value: &models.Expr{Kind: models.ExprLiteralInt, Text: "5"}},
+			}}},
+		models.RepoInventory{}, false},
 	// ─── OAI-101 no input_guardrails + shell tools ────────────────────────────
 	{"OAI-101 fires when no guardrails and has shell tool", "OAI-101",
 		models.AgentDef{

--- a/internal/rules/predicates_test.go
+++ b/internal/rules/predicates_test.go
@@ -74,6 +74,8 @@ func parseTSTool(t *testing.T, src string, kind models.ToolKind) (models.ToolDef
 		tools = analysis.DiscoverTSADKTools([]analysis.ParsedFile{pf}, func(string) {})
 	case models.KindMCPTool:
 		tools = analysis.DiscoverTSMCPProper([]analysis.ParsedFile{pf}, func(string) {})
+	case models.KindLangChainTool:
+		tools = analysis.DiscoverTSLangChainTools([]analysis.ParsedFile{pf}, func(string) {})
 	default:
 		t.Fatalf("parseTSTool: unsupported kind %q", kind)
 	}

--- a/internal/rules/rule_detector.go
+++ b/internal/rules/rule_detector.go
@@ -141,6 +141,16 @@ func agentKindMatches(kind string, a models.AgentDef) bool {
 		return a.SDK == models.SDKGoogleADK && a.Class == "LoopAgent"
 	case "adk_langgraph_agent":
 		return a.SDK == models.SDKGoogleADK && a.Class == "LanggraphAgent"
+	// LangChain / LangGraph. Class values are normalized canonical names
+	// (language-agnostic): "ReactAgent" (create_react_agent / createReactAgent),
+	// "CreateAgent" (create_agent / createAgent), "AgentExecutor", "StateGraph".
+	// The a.Language field distinguishes the Python vs TypeScript shapes.
+	case "langchain_agent":
+		return a.SDK == models.SDKLangChain && (a.Class == "ReactAgent" || a.Class == "CreateAgent")
+	case "langchain_agent_executor":
+		return a.SDK == models.SDKLangChain && a.Class == "AgentExecutor"
+	case "langchain_state_graph":
+		return a.SDK == models.SDKLangChain && a.Class == "StateGraph"
 	}
 	return false
 }
@@ -216,6 +226,8 @@ func LoadFor(fsys fs.FS, sdks []models.SDK) (*detectors.Registry, error) {
 			wanted["mcp"] = true
 		case models.SDKGoogleADK:
 			wanted["google_adk"] = true
+		case models.SDKLangChain:
+			wanted["langchain"] = true
 		}
 	}
 	all, err := Load(fsys)

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -135,7 +135,9 @@ func Run(cfg Config) (models.ScanResult, error) {
 	}
 	agents := analysis.DiscoverAgents(parsed)
 	agents = append(agents, analysis.DiscoverADKAgents(parsed)...)
+	agents = append(agents, analysis.DiscoverLangChainAgents(parsed)...)
 	tools = append(tools, analysis.DiscoverADKTools(parsed)...)
+	tools = append(tools, analysis.DiscoverLangChainTools(parsed)...)
 	guardrails := analysis.DiscoverGuardrails(parsed)
 	sessions := analysis.DiscoverSessions(parsed)
 
@@ -176,6 +178,9 @@ func Run(cfg Config) (models.ScanResult, error) {
 	// Google ADK TS
 	tools = append(tools, analysis.DiscoverTSADKTools(tsFiles, nil)...)
 	agents = append(agents, analysis.DiscoverTSADKAgents(tsFiles, nil)...)
+	// LangChain / LangGraph TS
+	tools = append(tools, analysis.DiscoverTSLangChainTools(tsFiles, nil)...)
+	agents = append(agents, analysis.DiscoverTSLangChainAgents(tsFiles, nil)...)
 	// MCP server authoring (@modelcontextprotocol/sdk) TS — registerTool/tool.
 	// Emits KindMCPTool, so deriveSDKsDetected stamps SDKMCP and the mcp pack
 	// loads automatically (same path as the Python MCP tools).
@@ -334,6 +339,8 @@ func deriveSDKsDetected(tools []models.ToolDef, agents []models.AgentDef, subage
 			seen[models.SDKMCP] = true
 		case models.KindADKFunctionTool:
 			seen[models.SDKGoogleADK] = true
+		case models.KindLangChainTool:
+			seen[models.SDKLangChain] = true
 		}
 	}
 	for _, a := range agents {

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -206,6 +206,38 @@ func TestScan_GoogleADKDemoFiresExpectedRules(t *testing.T) {
 	}
 }
 
+func TestScan_LangChainDemoFiresExpectedRules(t *testing.T) {
+	_, thisFile, _, _ := runtime.Caller(0)
+	target := filepath.Join(filepath.Dir(thisFile), "..", "..", "testdata", "corpus", "langchain-demo")
+	res, err := scanner.Run(scanner.Config{Target: target, RulesFS: rulesFixture(t)})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+
+	var sawLC bool
+	for _, s := range res.SDKs {
+		if s == models.SDKLangChain {
+			sawLC = true
+		}
+	}
+	if !sawLC {
+		t.Errorf("expected langchain in ScanResult.SDKs, got %+v", res.SDKs)
+	}
+
+	fired := map[string]bool{}
+	for _, f := range res.Findings {
+		fired[f.RuleID] = true
+	}
+	// Tool no-docstring (LC-001), tool shell-out (LC-003), agent code-exec
+	// built-in (LC-101), and the repo missing-guidance-doc rule (LC-201) all have
+	// triggers in agent.py, exercising tool + agent + repo scopes end-to-end.
+	for _, want := range []string{"LC-001", "LC-003", "LC-101", "LC-201"} {
+		if !fired[want] {
+			t.Errorf("expected rule %s to fire on langchain-demo; fired set: %v", want, fired)
+		}
+	}
+}
+
 func TestScan_SurfacesNewInventoryFields(t *testing.T) {
 	_, thisFile, _, _ := runtime.Caller(0)
 	target := filepath.Join(filepath.Dir(thisFile), "..", "..", "testdata", "corpus", "financial_research_agent")

--- a/testdata/corpus/PROVENANCE.md
+++ b/testdata/corpus/PROVENANCE.md
@@ -20,6 +20,7 @@ These were authored in this repository as test fixtures.
 | `claude-settings-fixture/` | Minimal `.claude/settings.json` fixture for the settings discovery + permission-parser tests |
 | `google-adk-demo/` | Hand-written Google ADK demo exercising `LlmAgent` / `SequentialAgent` / `ParallelAgent` / `LoopAgent` / `LanggraphAgent` shapes for the ADK-* rule tests |
 | `ts-claude-sdk-min/` | Minimal TypeScript Claude Agent SDK fixture exercising `tool()` / inline-`query()` agents / typed-const `AgentDefinition` / `createSdkMcpServer` for the TS discovery tests |
+| `langchain-demo/` | Hand-written LangChain / LangGraph demo exercising the `@tool` decorator, a `StructuredTool` shell-out, and `create_react_agent` wiring `PythonREPLTool` for the LC-* rule tests |
 
 ## Vendored from `openai/openai-agents-python` (MIT)
 

--- a/testdata/corpus/langchain-demo/agent.py
+++ b/testdata/corpus/langchain-demo/agent.py
@@ -1,0 +1,24 @@
+"""Minimal hand-authored LangChain / LangGraph sample for end-to-end scanner
+tests. Not a third-party repo — authored for this corpus."""
+
+from langchain_core.tools import tool, StructuredTool
+from langgraph.prebuilt import create_react_agent
+from langchain_experimental.tools import PythonREPLTool
+
+
+@tool
+def lookup(q):
+    return q
+
+
+def run_cmd(cmd: str) -> str:
+    """Run a shell command and return its output."""
+    import subprocess
+
+    return subprocess.run(cmd, shell=True, capture_output=True).stdout.decode()
+
+
+shell_tool = StructuredTool.from_function(run_cmd)
+
+# Positional model + tools list, wiring a code-execution built-in.
+agent = create_react_agent("openai:gpt-4o", [lookup, shell_tool, PythonREPLTool()])

--- a/testdata/rules-fixture/langchain/agent_safety.yaml
+++ b/testdata/rules-fixture/langchain/agent_safety.yaml
@@ -1,0 +1,80 @@
+policy:
+  id: langchain_agent_safety
+  name: LangChain agent safety
+  category: langchain
+  description: >
+    Agent-scope safety and reliability rules for LangChain / LangGraph agents
+    (create_react_agent, create_agent, AgentExecutor).
+
+rules:
+  - id: LC-101
+    title: LangChain agent wires a code-execution or shell built-in tool
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - langchain_agent
+      - langchain_agent_executor
+    scope: agent
+    match:
+      agent_uses_hosted_tool_class:
+        - PythonREPLTool
+        - PythonAstREPLTool
+        - ShellTool
+    explanation: >
+      This agent's tools list includes a LangChain built-in that executes code or
+      shell commands chosen by the model: PythonREPLTool / PythonAstREPLTool run
+      arbitrary Python, and ShellTool runs arbitrary shell commands. Once such a
+      tool is wired, a prompt injection or a confused model has a direct path to
+      arbitrary code execution in the agent process — these built-ins were the
+      vector in multiple published LangChain RCE advisories.
+    fix: >
+      Remove the REPL/shell built-in from production agents. If you genuinely need
+      code execution, run it in an isolated sandbox (no filesystem, no network, no
+      credentials, hard timeout) and gate it behind a human-in-the-loop approval
+      (a LangGraph interrupt_before breakpoint or a tool-approval middleware)
+      rather than letting the model invoke it unattended.
+
+  - id: LC-102
+    title: LangChain AgentExecutor has no max_iterations limit
+    severity: medium
+    confidence: 0.8
+    language: python
+    applies_to:
+      - langchain_agent_executor
+    scope: agent
+    match:
+      agent_kwarg_missing:
+        - max_iterations
+    explanation: >
+      This AgentExecutor sets no max_iterations, so a model that never emits a
+      final answer (it loops calling tools, or oscillates between two) runs until
+      it exhausts the API budget or wall-clock — there is no built-in ceiling. A
+      runaway tool-calling loop is a cost incident and, when the tools have side
+      effects, a correctness and safety one.
+    fix: >
+      Pass max_iterations= (and optionally max_execution_time=) to AgentExecutor,
+      sized to the task. Also set handle_parsing_errors= so a malformed model step
+      is surfaced rather than retried indefinitely.
+
+  - id: LC-111
+    title: TypeScript LangChain AgentExecutor has no maxIterations limit
+    severity: medium
+    confidence: 0.8
+    language: typescript
+    applies_to:
+      - langchain_agent_executor
+    scope: agent
+    match:
+      agent_kwarg_missing:
+        - maxIterations
+    explanation: >
+      This AgentExecutor sets no maxIterations, so a model that never returns a
+      final answer (it loops calling tools, or oscillates) runs until it exhausts
+      the API budget or wall-clock — there is no built-in ceiling. A runaway loop
+      is a cost incident and, when the tools have side effects, a correctness and
+      safety one.
+    fix: >
+      Pass maxIterations to the AgentExecutor options, sized to the task, and set
+      handleParsingErrors so a malformed step is surfaced rather than retried
+      indefinitely.

--- a/testdata/rules-fixture/langchain/code_execution.yaml
+++ b/testdata/rules-fixture/langchain/code_execution.yaml
@@ -1,0 +1,52 @@
+policy:
+  id: langchain_code_execution
+  name: LangChain dynamic-code-execution safety
+  category: langchain
+  description: >
+    Flags LangChain tools whose body evaluates code at runtime. Model-selected
+    code evaluation is a direct arbitrary-execution path.
+
+rules:
+  - id: LC-004
+    title: LangChain tool body evaluates dynamic code
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      has_code_exec_call: true
+    explanation: >
+      This LangChain tool's body calls eval(), exec(), or compile() — Python's
+      dynamic-code-execution builtins. A model-callable tool that evaluates a
+      string can be steered by prompt injection to run attacker-chosen code in the
+      agent process. This is the same mechanism behind LangChain's own
+      PythonREPLTool; hand-rolling it in a tool body carries the identical risk.
+    fix: >
+      Remove eval/exec/compile from agent-callable tool bodies. If the tool must
+      compute over structured input, parse it with a real parser (ast.literal_eval
+      for data, a typed schema for arguments). If code execution is genuinely the
+      product, run it in a locked-down sandbox with no filesystem or network and a
+      hard timeout.
+
+  - id: LC-012
+    title: TypeScript LangChain tool evaluates dynamic code
+    severity: high
+    confidence: 0.85
+    language: typescript
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      has_code_exec_call: true
+    explanation: >
+      This LangChain.js tool's handler calls eval() or constructs a new Function()
+      — both evaluate a string as code. A model-callable tool that evaluates its
+      input can be steered by prompt injection to execute attacker-chosen code in
+      the Node process.
+    fix: >
+      Remove eval / new Function from agent-callable tool handlers. Parse
+      structured input with JSON.parse or a typed schema instead. If code
+      execution is the product, run it in an isolated sandbox (a Worker with no
+      module access, or an external sandbox service) with a hard timeout.

--- a/testdata/rules-fixture/langchain/repo_hygiene.yaml
+++ b/testdata/rules-fixture/langchain/repo_hygiene.yaml
@@ -1,0 +1,40 @@
+policy:
+  id: langchain_repo_hygiene
+  name: LangChain repo hygiene
+  category: langchain
+  description: >
+    Repo-scoped hygiene rules for projects that use LangChain / LangGraph. Fire
+    once per scan against the repo manifest and inventory.
+
+rules:
+  - id: LC-201
+    title: LangChain project ships no agent-guidance doc (AGENTS.md/CLAUDE.md)
+    severity: low
+    confidence: 0.9
+    applies_to:
+      - langchain
+    scope: repo
+    match:
+      all:
+        - repo_has_sdk_in_code:
+            - langchain
+        - not:
+            repo_component_present:
+              - agents_md
+              - claude_md
+    explanation: >
+      The project uses LangChain / LangGraph in code but ships no agent-guidance
+      doc (AGENTS.md or CLAUDE.md) at the repo root. AGENTS.md is the cross-vendor
+      convention an editing coding agent reads before it acts; with neither file
+      present, any agent that opens this repo has no project-specific guidance on
+      which agent constructor to use (create_react_agent vs create_agent vs a raw
+      StateGraph), how tools must be defined and guarded, whether the REPL/shell
+      built-ins are permitted, or the local test and build commands. The likely
+      consequence is generated code that violates the project's tool and agent
+      contracts because nothing in-tree teaches the agent the local rules.
+    fix: >
+      Add an AGENTS.md at the repo root (a CLAUDE.md also satisfies this rule).
+      State which LangChain agent constructors the project uses and why, how tools
+      must be defined and guarded, any required human-in-the-loop gates, and the
+      exact test, lint, and build commands. Keep it short and concrete so an
+      editing agent can act on it without re-deriving the conventions.

--- a/testdata/rules-fixture/langchain/shell_safety.yaml
+++ b/testdata/rules-fixture/langchain/shell_safety.yaml
@@ -1,0 +1,54 @@
+policy:
+  id: langchain_shell_safety
+  name: LangChain shell-execution safety
+  category: langchain
+  description: >
+    Flags LangChain tools whose body shells out to the operating system. A
+    model-callable tool that runs shell commands is a prompt-injection path to
+    arbitrary code execution.
+
+rules:
+  - id: LC-003
+    title: LangChain tool body spawns a subprocess
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      has_shell_call: true
+    explanation: >
+      This LangChain tool's body invokes a shell primitive (subprocess.*,
+      os.system, os.popen, or os.spawn*). Because the tool is exposed to the
+      model, a prompt-injected or confused model can drive it to run arbitrary
+      commands with the agent process's privileges. Shell execution selected by
+      model output is the most direct path from prompt injection to remote code
+      execution.
+    fix: >
+      Do not let model-controlled input reach a shell. Replace shell-outs with a
+      typed library call; if a subprocess is unavoidable, pass an argument list
+      (never shell=True), allow-list the exact commands, and run it in a sandbox
+      with no ambient credentials. Keep shell logic out of any agent-callable tool.
+
+  - id: LC-011
+    title: TypeScript LangChain tool body spawns a subprocess
+    severity: high
+    confidence: 0.85
+    language: typescript
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      has_shell_call: true
+    explanation: >
+      This LangChain.js tool's handler calls a child_process primitive (exec,
+      execSync, spawn, fork, …). Because the tool is exposed to the model, a
+      prompt-injected or confused model can drive it to run arbitrary shell
+      commands with the Node process's privileges — the most direct path from
+      prompt injection to remote code execution.
+    fix: >
+      Do not let model-controlled input reach a shell. Prefer a typed library
+      call; if a subprocess is unavoidable use execFile/spawn with an argument
+      array (never a shell string), allow-list the exact commands, and sandbox the
+      execution. Keep shell logic out of any agent-callable tool.

--- a/testdata/rules-fixture/langchain/ssrf.yaml
+++ b/testdata/rules-fixture/langchain/ssrf.yaml
@@ -1,0 +1,55 @@
+policy:
+  id: langchain_ssrf
+  name: LangChain SSRF safety
+  category: langchain
+  description: >
+    Flags LangChain tools that issue an outbound HTTP request to a
+    caller-controlled (non-literal) URL — the server-side request forgery surface.
+
+rules:
+  - id: LC-005
+    title: LangChain tool fetches a caller-controlled URL (SSRF)
+    severity: high
+    confidence: 0.8
+    language: python
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      has_dynamic_url_call: true
+    explanation: >
+      This LangChain tool issues an HTTP request whose URL is built from a
+      parameter or interpolated value rather than a fixed literal. Because the
+      tool is model-callable, the model (or a prompt injection) controls the
+      destination — it can reach internal services, the cloud metadata endpoint
+      (169.254.169.254), or localhost admin ports the agent host can see but an
+      external caller cannot. This is a classic server-side request forgery
+      primitive handed to the model.
+    fix: >
+      Constrain the destination: validate the URL against an allow-list of hosts,
+      reject private and link-local IP ranges (and redirects into them), and
+      forbid raw model-supplied URLs. If the tool only ever talks to one service,
+      hard-code the base URL and accept only a path/query from the model.
+
+  - id: LC-013
+    title: TypeScript LangChain tool fetches a caller-controlled URL (SSRF)
+    severity: high
+    confidence: 0.8
+    language: typescript
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      has_dynamic_url_call: true
+    explanation: >
+      This LangChain.js tool calls fetch/axios/got with a URL built from a
+      non-literal value (a parameter, template string, or concatenation). Because
+      the tool is model-callable, the model or a prompt injection controls the
+      destination and can reach internal services, the cloud metadata endpoint, or
+      localhost admin ports visible to the Node host — a server-side request
+      forgery primitive.
+    fix: >
+      Validate the URL against an allow-list of hosts, reject private and
+      link-local ranges (and redirects into them), and never pass a raw
+      model-supplied URL to fetch. If the tool talks to one service, hard-code the
+      base URL and accept only a path from the model.

--- a/testdata/rules-fixture/langchain/tool_behavior.yaml
+++ b/testdata/rules-fixture/langchain/tool_behavior.yaml
@@ -1,0 +1,57 @@
+policy:
+  id: langchain_tool_behavior
+  name: LangChain tool behavior safety
+  category: langchain
+  description: >
+    Flags LangChain tool configuration that alters the agent's control flow in
+    ways that bypass the model's reasoning and any post-tool guardrails.
+
+rules:
+  - id: LC-006
+    title: LangChain tool returns its output directly, bypassing the model
+    severity: medium
+    confidence: 0.8
+    language: python
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      tool_decorator_kwarg_value:
+        kwarg: return_direct
+        value: "True"
+    explanation: >
+      This tool sets return_direct=True, so LangChain returns the tool's raw
+      output straight to the caller and stops the agent loop — the model never
+      sees the result, cannot validate or summarize it, and any output guardrail
+      or post-processing step is skipped. Raw tool output (which may include
+      errors, secrets, or unsanitized external content) is handed to the user
+      verbatim, and multi-step plans that expect the model to act on the tool
+      result silently break.
+    fix: >
+      Leave return_direct at its default (False) unless you specifically intend to
+      short-circuit the agent. If you do, sanitize and shape the tool's output
+      yourself, since no model step or guardrail runs after it.
+
+  - id: LC-014
+    title: TypeScript LangChain tool returns its output directly, bypassing the model
+    severity: medium
+    confidence: 0.8
+    language: typescript
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      tool_decorator_kwarg_value:
+        kwarg: returnDirect
+        value: "true"
+    explanation: >
+      This tool sets returnDirect: true, so LangChain.js returns the tool's raw
+      output straight to the caller and halts the agent loop — the model never
+      sees the result and any post-tool guardrail or formatting step is skipped.
+      Unsanitized tool output (errors, secrets, external content) reaches the user
+      verbatim, and multi-step plans that depend on the model reacting to the
+      result break.
+    fix: >
+      Leave returnDirect at its default (false) unless you deliberately intend to
+      short-circuit the agent. If you do, sanitize and shape the output in the
+      handler, because no model step or guardrail runs after it.

--- a/testdata/rules-fixture/langchain/tool_definition.yaml
+++ b/testdata/rules-fixture/langchain/tool_definition.yaml
@@ -1,0 +1,79 @@
+policy:
+  id: langchain_tool_definition
+  name: LangChain tool definition hygiene
+  category: langchain
+  description: >
+    Hygiene rules for LangChain / LangGraph tools — the @tool decorator and
+    StructuredTool / Tool factories (Python), and the tool() factory /
+    DynamicStructuredTool / DynamicTool (TypeScript). These surfaces drive
+    whether the model can reason about a tool and call it correctly.
+
+rules:
+  - id: LC-001
+    title: LangChain tool has no description
+    severity: low
+    confidence: 0.8
+    language: python
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      has_docstring: false
+    explanation: >
+      LangChain exposes a tool to the model through its description: for an
+      @tool-decorated function or a StructuredTool, the description defaults to
+      the wrapped function's docstring. A tool with no docstring (and no explicit
+      description=) reaches the model as a bare name, so the model cannot tell
+      what the tool does or when to call it — it will skip the tool or invoke it
+      with the wrong arguments. This is the single highest-leverage authoring fix.
+    fix: >
+      Add a one-paragraph docstring to the wrapped function describing what the
+      tool does, the inputs it expects, and what it returns — or pass an explicit
+      description= to StructuredTool/Tool. The model reads this string verbatim.
+
+  - id: LC-002
+    title: LangChain tool parameters are not type-annotated
+    severity: medium
+    confidence: 0.85
+    language: python
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      all:
+        - has_params: true
+        - has_typed_params: false
+    explanation: >
+      LangChain builds a tool's argument schema from the wrapped function's type
+      hints (or an explicit args_schema Pydantic model). A tool whose parameters
+      carry no annotations produces an underspecified schema: the model gets no
+      type guidance and passes arguments of the wrong shape, which LangChain then
+      rejects at validation time — a silent reliability tax on every call.
+    fix: >
+      Annotate every parameter with a concrete type (str, int, list[str], a
+      Pydantic model, etc.), or pass an args_schema= to StructuredTool. LangChain
+      propagates these into the JSON schema the model sees.
+
+  - id: LC-010
+    title: TypeScript LangChain tool has no description
+    severity: low
+    confidence: 0.8
+    language: typescript
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      has_docstring: false
+    explanation: >
+      LangChain.js exposes a tool to the model through the description field in
+      its config object (the second argument to tool(), or the options for
+      DynamicStructuredTool / DynamicTool). The model reads that string verbatim
+      to decide whether and how to call the tool. A tool built with no description
+      gives the model no signal about its purpose, so it under-calls the tool or
+      calls it with the wrong arguments. Unlike Python, where the docstring is a
+      fallback, the JS SDK takes the description as an explicit field — omitting it
+      is a silent gap.
+    fix: >
+      Pass a one-sentence description in the tool() config (or the
+      DynamicStructuredTool options) naming what the tool does, the inputs it
+      expects, and what it returns. Write it for the model, not a human reader.


### PR DESCRIPTION
## Summary

Adds **LangChain / LangGraph** as a first-class SDK row in Trustabl's coverage matrix, across **Python and TypeScript** — discovery, 15 detection rules, tests, and docs.

This is a coordinated **3-repo change**; the three PRs should merge together:
- **engine** (this PR) — discovery + loader wiring + fixture rules + tests + docs
- **trustabl-rules** — the production `langchain/` rule pack — trustabl/trustabl-rules#7
- **trustabl-rulebook** — rationale docs for all 15 `LC-*` rules — trustabl/trustabl-rulebook#4

## What's covered

- **Tools** — Python `@tool` (import-binding-resolved vs the Claude SDK's `@tool`), `StructuredTool` / `Tool` factories; TS `tool(fn, {…})`, `DynamicStructuredTool` / `DynamicTool`.
- **Agents** — `create_react_agent` / `create_agent` / `AgentExecutor` (Python + TypeScript).
- **Dangerous built-ins** — `PythonREPLTool` / `PythonAstREPLTool` / `ShellTool` / `Requests*` → hosted-tool edges.
- **15 rules** (`LC-001..201`): tool no-description / untyped-params / shell / code-exec / SSRF / `return_direct`; agent code-exec-or-shell built-in + `AgentExecutor` iteration-limit; repo missing-guidance-doc.

## Notable design point

`@tool` is shared with the Claude Agent SDK. Classification resolves the **import binding** of the `tool` symbol (a langchain module → LangChain, `claude_agent_sdk` → Claude, last-binding-wins on shadowing), so attribution is correct even when a file imports both SDKs. TypeScript needs no equivalent — each per-SDK pass resolves against its own import-alias map, and JS forbids importing the same name from two modules.

## Schema

No rule-schema change — only existing predicates are used, so `manifest.yaml` `schema_version` stays at **8**.

## Verification

`gofmt` clean · `go vet` clean · `go build ./...` · `go test ./...` (all packages) green. New coverage: discovery unit tests (including the cross-SDK collision in both directions), per-rule fire/silent cases, and an end-to-end `langchain-demo` corpus scan that exercises tool + agent + repo scopes.

## Deferred (documented gaps in COVERAGE.md)

The raw `StateGraph` graph agent (emergent across many call sites), `class X(BaseTool)` / `extends StructuredTool`, and the date-stamped TS provider hosted tools (`shell()` / `bash_*` / `applyPatch`).
