### PR TITLE
feat: add CrewAI, AutoGen/AG2, Vercel AI SDK, and Pydantic AI coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,10 +38,28 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # A coordinated rules change ships as paired PRs (one here, one in
+      # trustabl-rules). To let this PR's fixture validate against the matching
+      # production PR before either merges, check out trustabl-rules at a branch
+      # of the SAME name as this PR's head branch when it exists; otherwise fall
+      # back to main. On push to main, head_ref is empty, so this always uses
+      # main — main is still guarded against the real production pack.
+      - name: Resolve trustabl-rules ref
+        id: rulesref
+        run: |
+          ref="${{ github.head_ref }}"
+          if [ -n "$ref" ] && git ls-remote --exit-code --heads \
+              https://github.com/trustabl/trustabl-rules.git "$ref" >/dev/null 2>&1; then
+            echo "ref=$ref" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=main" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout trustabl-rules
         uses: actions/checkout@v4
         with:
           repository: trustabl/trustabl-rules
+          ref: ${{ steps.rulesref.outputs.ref }}
           path: .rules
 
       - name: Check fixture is in sync with production rules

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -33,8 +33,8 @@ added or changed without rebuilding or redistributing the scanner.
 ## 1.1 Language scope
 
 Trustabl ships with **Python and TypeScript tool/agent discovery** wired
-in. Python covers the OpenAI Agents SDK, Google ADK, and Claude Agent SDK
-(via decorators). TypeScript covers the Claude Agent SDK (via `tool()` /
+in. Python covers the OpenAI Agents SDK, Google ADK, Claude Agent SDK
+(via decorators), CrewAI, AutoGen / AG2, and Pydantic AI. TypeScript covers the Claude Agent SDK (via `tool()` /
 `query()` / `createSdkMcpServer()` / typed-const `AgentDefinition` shapes
 in `.ts`/`.tsx`/`.mts`/`.cts`) and the OpenAI Agents SDK (via `tool({...})`
 / `new Agent({...})` / `Agent.create({...})` / 9 hosted-tool factories
@@ -54,12 +54,28 @@ Claude SDK's `@tool` — plus `StructuredTool` / `Tool` factories,
 / `ShellTool` built-ins) and TypeScript (the `tool(fn, {...})` factory,
 `DynamicStructuredTool` / `DynamicTool`, and `createReactAgent` / `createAgent` /
 `AgentExecutor`), import-gated to the `@langchain/*` / `langchain` / `langgraph`
-ecosystem. TypeScript rule packs now ship for
-all five SDK surfaces: Claude SDK (CSDK-010/011/012/013/014/016 tool rules,
+ecosystem. Four further SDKs are wired in Python and TypeScript: CrewAI (Python —
+`Agent(...)` import-gated to `crewai`, the `@tool` decorator import-routed, the
+`Tool(fn)` factory, and the `CodeInterpreterTool` / `FileReadTool` built-ins),
+AutoGen / AG2 (Python — `ConversableAgent` / `UserProxyAgent` / `AssistantAgent`
+/ `GroupChat` / `GroupChatManager` / `CodeExecutorAgent` across the AG2 `autogen`
+and Microsoft v0.4 `autogen_agentchat` import lines, plus `register_function`
+and `@x.register_for_llm` / `@x.register_for_execution` tool registrations),
+Pydantic AI (Python — `Agent(...)` import-gated to `pydantic_ai`, the
+`@agent.tool` / `@agent.tool_plain` decorators import-routed with the Claude SDK
+winning the collision, the `Tool(fn)` factory, and the `CodeExecutionTool` /
+`WebFetchTool` native tools), and the Vercel AI SDK (TypeScript — the
+`tool({...})` / `dynamicTool({...})` single-object factory, the call-based
+`generateText` / `streamText` / `generateObject` / `streamObject` agents and the
+class `ToolLoopAgent` / `Experimental_Agent`, with `tools` walked as an
+object/record, plus the `<provider>.tools.*()` hosted tools — all gated on the
+bare `ai` import). TypeScript rule packs now ship for
+all six SDK surfaces: Claude SDK (CSDK-010/011/012/013/014/016 tool rules,
 CSDK-120/130/131 agent rules), OpenAI Agents (OAI-016/017/019/022/024 tool
 rules, OAI-105 agent rule), Google ADK (ADK-013/015/016 tool rules, ADK-109
-agent rule), MCP (MCP-011/012/013/014 tool rules), and LangChain
-(LC-010/011/012/013/014 tool rules, LC-111 agent rule). A TS
+agent rule), MCP (MCP-011/012/013/014 tool rules), LangChain
+(LC-010/011/012/013/014 tool rules, LC-111 agent rule), and the Vercel AI SDK
+(VAI-001..005 tool rules, VAI-006/007/008 agent rules, VAI-012 repo rule). A TS
 repo for any of these no longer produces a blanket META-004; the full
 per-SDK/language matrix lives in COVERAGE.md. The scanner
 can also recognize JavaScript and Go *files* (they appear in
@@ -462,14 +478,74 @@ For each language recon cleared, do the AST work and produce a `RepoInventory`:
   `astutil.TSImportAliasesMatch` to cover the many `@langchain/*` subpaths. Agents:
   `createReactAgent` / `createAgent` / `new AgentExecutor`. Reuses
   `tsZodParamNames` / `tsHandlerFacts`.
+- **DiscoverCrewAIAgents** (`crewai_agents.go`) — Python CrewAI `Agent(...)`
+  constructor calls, import-gated (AST-based) to the `crewai` / `crewai_tools`
+  ecosystem so the bare `Agent` name does not collide with the OpenAI Agents SDK
+  or Google ADK classes (`agentKindMatches("crewai_agent")` keys on both SDK and
+  Class). All kwargs captured into a typed `KwargTree`; the label falls back from
+  `name=` to `role=` to the assignment-target variable. CrewAI `@tool` tools are
+  routed in `discovery.go`'s `kindFromDecorators` (import-routed, below); the
+  `Tool(fn)` factory and the `CodeInterpreterTool` / `FileReadTool` built-ins are
+  resolved in `crewai_hosted_tools.go` during `ResolveEdges`. `class X(BaseTool)`
+  and `Crew(...)` are v1 gaps.
+- **DiscoverAutoGenAgents / DiscoverAutoGenTools** (`autogen_agents.go`,
+  `autogen_tools.go`) — Python AutoGen / AG2, import-gated to **either** upstream
+  line (AG2 `autogen` / `autogen.*`; Microsoft v0.4 `autogen_agentchat` /
+  `autogen_core` / `autogen_ext`); `agentKindMatches` keys on both SDK and Class
+  so the colliding `AssistantAgent` / `GroupChat` never cross-match. Agents: the
+  6 constructors `ConversableAgent` / `UserProxyAgent` / `AssistantAgent` /
+  `GroupChat` / `GroupChatManager` / `CodeExecutorAgent`, with the nested
+  `code_execution_config={...}` dict descended so dotted-path lookups reach
+  `code_execution_config.use_docker`. Tools: `register_function(fn, ...)` (a call,
+  not a decorator — resolves the first positional ident to a same-file function)
+  and the stacked attribute decorators `@<x>.register_for_llm` /
+  `@<x>.register_for_execution` (an attribute callee, so `kindFromDecorators` does
+  not classify it — this pass walks `decorated_definition` nodes itself). The
+  v0.4 executor-class surface (AG2-003), the `register_function` caller/executor
+  edge, and an AG2 bare-name `@tool` arm are v1 gaps.
+- **DiscoverPydanticAIAgents / DiscoverPydanticAITools** (`pydantic_ai_agents.go`,
+  `pydantic_ai_tools.go`) — Python Pydantic AI, import-gated to `pydantic_ai` so
+  the bare `Agent` name (normalized to Class `PydanticAgent`) does not collide
+  with OpenAI / ADK / CrewAI. Agents: `Agent(...)` with all kwargs captured;
+  `VarName` captured so the `@agent.tool` owner and `tools=[...]` references
+  resolve. Tools: the `@agent.tool` / `@agent.tool_plain` attribute decorators
+  (routed in `discovery.go`'s `kindFromDecorators`, import-gated and
+  Claude-disambiguated, below) and the `Tool(fn)` factory (gated on `pydantic_ai`
+  AND NOT LangChain, since LangChain ships an identically-named `Tool(...)`). The
+  `CodeExecutionTool` / `WebFetchTool` / `UrlContextTool` / `WebSearchTool` native
+  tools under `capabilities=` / `builtin_tools=` (the modern `NativeTool(...)`
+  wrapper unwrapped one level) are classified in `pydantic_ai_hosted_tools.go`
+  during `ResolveEdges`. PYD-104 (`force_download`), the bare-`tools=[fn]` ToolDef
+  shape, and the `RunContext` param-strip for PYD-002 are v1 gaps.
+- **DiscoverTSVercelTools / DiscoverTSVercelAgents** (`ts_vercel_tools.go`,
+  `ts_vercel_agents.go`, `ts_vercel_hosted_tools.go`) — TS Vercel AI SDK,
+  import-gated to the bare `ai` core module (the disambiguator from the
+  identically-named Claude / OpenAI / LangChain `tool()` factories). Tools: the
+  `tool({...})` / `dynamicTool({...})` single-object factory (arg 0 is the options
+  object, unlike LangChain's arg-1 config); the tool NAME comes from the agent's
+  tools-record key, so `ToolDef.Name` is empty and `VarName` carries the binding.
+  Agents: the call-based `generateText` / `streamText` / `generateObject` /
+  `streamObject` (emitted only when the options object carries a `tools` property)
+  and the class `ToolLoopAgent` / `Experimental_Agent` (often imported `as Agent`).
+  In both forms `tools` is an OBJECT / RECORD walked by property value (not a
+  `[...]` array like every other TS pass): bare identifier → `ToolRef`; inline
+  `tool({...})` / spread / other → agent `Opaque`; `<provider>.tools.<name>()` →
+  `HostedToolRef` (canonicalized in `ts_vercel_hosted_tools.go`). `.js` / `.mjs`
+  apps are inventoried but not AST-parsed; VAI-009/010 (name rules) and VAI-011
+  (TS timeout predicate) are v1 gaps.
 - **ResolveEdges** — links agent `tools=`, `handoffs=`, `input_guardrails=`
   references to discovered definitions in the same repo; cross-module resolution
   uses import statements; unresolvable references are flagged `External=true`.
   Hosted-tool dispatch is SDK-aware: OpenAI agents are matched against
-  `HostedToolClasses` (11 classes); Google ADK agents are matched against
-  `ADKHostedToolClasses` (13 classes, defined in `adk_hosted_tools.go`). Each
-  match emits a `HostedToolDef` record and a parallel `HostedToolRefs` edge on
-  the owning agent. For Google ADK agents, `FunctionTool(symbol)` references
+  `HostedToolClasses` (11 classes); Google ADK agents against
+  `ADKHostedToolClasses` (13 classes, `adk_hosted_tools.go`); CrewAI agents
+  against `CrewAIHostedToolClasses` (13 classes, `crewai_hosted_tools.go`); and
+  Pydantic AI agents against `PydanticAIHostedToolClasses` (4 classes,
+  `pydantic_ai_hosted_tools.go`) — but Pydantic native tools live under the
+  `capabilities=` / `builtin_tools=` kwargs, NOT the generic `tools=` list, so
+  `ResolveEdges` scans those two kwargs for Pydantic agents (unwrapping the modern
+  `NativeTool(...)` wrapper one level). Each match emits a `HostedToolDef` record
+  and a parallel `HostedToolRefs` edge on the owning agent. For Google ADK agents, `FunctionTool(symbol)` references
   inside `tools=[...]` are unwrapped and resolved to same-file `ToolDef`s before
   the hosted-tool check. `sub_agents=[...]` kwargs on ADK agents are resolved
   into `HandoffRefs` pointing to same-file `AgentDef`s. `mcp_servers=[...]` is
@@ -537,7 +613,9 @@ than just text matching.
    | Decorator callee                  | ToolKind              | Notes                       |
    | --------------------------------- | --------------------- | --------------------------- |
    | `function_tool` (any args)        | `KindOpenAITool`      | OpenAI Agents SDK           |
-   | `tool`, `claude_tool`, `agent.tool`, or a callee containing `claude_agent_sdk` | `KindClaudeSDKTool` | Claude Agent SDK (pre-1.0 — names still in flux) |
+   | bare `tool` / `claude_tool` bound by import | resolved SDK | The unqualified `@tool` is shared by the Claude SDK, LangChain, and CrewAI; `collectToolImports` resolves it to `KindClaudeSDKTool` / `KindLangChainTool` / `KindCrewAITool` by the **import binding** of the `tool` symbol (last-binding-wins), with a file-level import-presence fallback for a star-import / locally defined `tool` |
+   | `<agentvar>.tool`, `<agentvar>.tool_plain` (attribute) | `KindPydanticAITool` | Pydantic AI context tools — routed ONLY when the file imports `pydantic_ai` AND does NOT import the Claude SDK (the `&& !claudeImport` guard is load-bearing: the Claude SDK also exposes `@agent.tool`, so a Claude-only file and a both-importing file fall through to the `agent.tool` → Claude case below) |
+   | `agent.tool`, or a callee containing `claude_agent_sdk` | `KindClaudeSDKTool` | Claude Agent SDK (pre-1.0 — names still in flux); wins the `@agent.tool` collision with Pydantic |
    | `server.tool`, `mcp.tool`, `*.register_tool` | `KindMCPTool`  | MCP server registrations    |
    | (none of the above)               | `KindUnknown`         | Falls through to shell pass |
 
@@ -1021,7 +1099,11 @@ AgentDef {
 }
 
 // KwargTree holds a kwarg value as either a leaf or a nested map
-// (e.g. model_settings.tool_choice parses as Children["model_settings"].Children["tool_choice"])
+// (e.g. model_settings.tool_choice parses as Children["model_settings"].Children["tool_choice"]).
+// exprFromNode descends into a nested constructor call's kwargs AND into a dict
+// literal passed as a kwarg value (dictChildren keys by each string-literal pair
+// key), so a dotted-path lookup reaches e.g. AutoGen's
+// code_execution_config.use_docker the same way it reaches a nested call's kwarg.
 KwargTree { Value *Expr; Children map[string]*KwargTree }
 
 ToolDef {
@@ -1346,7 +1428,12 @@ the "Two-repo rule model" section in [`CLAUDE.md`](CLAUDE.md).
 Domain-level utilities the rules package and any future Go-native detector
 need:
 
-- `FindFunctionNode(t, pf)` — relocate a tool's `function_definition` node.
+- `FindFunctionNode(t, pf)` — relocate a tool's `function_definition` node. The
+  line is the primary key (an exact name match on the same line is the confident
+  hit; a name mismatch from a `name=` override — e.g. AutoGen `register_function`
+  or a Pydantic / LangChain factory — still resolves via the line), so the
+  body-scan predicates keep working when the tool's `Name` differs from the
+  wrapped function's.
 - `IsHTTPCall(callee)` — exact-text match against the known HTTP client API
   surface (the direct-call check).
 - `ResolveClientAliases(fn, src)` — walks a function body and maps local

--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -4,7 +4,7 @@ Coverage matrix for Trustabl's static analysis: which agent SDKs (and which
 languages) we currently scan, analyse, and detect against. This file is the
 at-a-glance reference; `ARCHITECTURE.md` has the implementation detail.
 
-_Last reviewed: 2026-06-04 (LangChain / LangGraph SDK row added)._
+_Last reviewed: 2026-06-05 (CrewAI, AutoGen/AG2, Vercel AI SDK, Pydantic AI rows added)._
 
 > **Note:** Detection rules are not shipped in the binary. They live in the
 > separate `trustabl-rules` git repository
@@ -30,8 +30,12 @@ Legend: ✅ full · ◐ partial · ❌ none · — N/A
 | **Google ADK** | Python | ✅ dep-scan (`google-adk`) + file inventory | ✅ LlmAgent (+ Agent alias), SequentialAgent, ParallelAgent, LoopAgent, LanggraphAgent; FunctionTool wrapping; 13 built-in hosted tools; sub_agents edges | ✅ tool ADK-001..007, 009..012 (009 = print to stdout, 010 = subprocess, 011 = eval/exec/compile, 012 = SSRF); agent ADK-008, 101..108, 110; repo ADK-201 (SDK code without an agent-guidance doc: AGENTS.md/CLAUDE.md) |
 | **Google ADK** | TypeScript | ✅ dep-scan (`@google/adk`) + file inventory | ✅ tools (`new FunctionTool({...})`), agents (5 constructors: LlmAgent + SequentialAgent + ParallelAgent + LoopAgent + RoutedAgent), hosted tools (13 classes), subAgents edges | ◐ tool ADK-013 (no description), 015 (eval / new Function), 016 (SSRF / dynamic URL); agent ADK-109 (LlmAgent no description); first ADK TS pack; META-004 no longer fires |
 | **Google ADK** | Go / Java / Kotlin | ❌ | ❌ | ❌ |
-| **LangChain / LangGraph** | Python | ✅ dep-scan (`langchain` / `langgraph` needles, all manifests) + file inventory | ✅ tools (`@tool` decorator — import-gated to disambiguate from the Claude SDK's `@tool`; `StructuredTool` / `Tool` factories + `.from_function`), agents (`create_react_agent`, `create_agent`, `AgentExecutor`; positional `tools` captured), dangerous built-ins (`PythonREPLTool` / `PythonAstREPLTool` / `ShellTool` / `Requests*` → `HostedToolDef` edges) | ✅ tool LC-001 (no description), LC-002 (untyped params), LC-003 (shell), LC-004 (code-exec), LC-005 (SSRF), LC-006 (`return_direct`); agent LC-101 (code-exec/shell built-in), LC-102 (AgentExecutor no `max_iterations`); repo LC-201 (no agent-guidance doc) |
+| **LangChain / LangGraph** | Python | ✅ dep-scan (`langchain` / `langgraph` needles, all manifests) + file inventory | ✅ tools (`@tool` decorator — import-gated to disambiguate from the Claude SDK's `@tool`; `StructuredTool` / `Tool` factories + `.from_function`), agents (`create_react_agent`, `create_agent`, `AgentExecutor` + `AgentExecutor.from_agent_and_tools`; positional `tools` captured), dangerous built-ins (`PythonREPLTool` / `PythonAstREPLTool` / `ShellTool` / `Requests*` → `HostedToolDef` edges) | ✅ tool LC-001 (no description), LC-002 (untyped params), LC-003 (shell), LC-004 (code-exec), LC-005 (SSRF), LC-006 (`return_direct`); agent LC-101 (code-exec/shell built-in), LC-102 (AgentExecutor no `max_iterations`); repo LC-201 (no agent-guidance doc) |
 | **LangChain / LangGraph** | TypeScript | ✅ dep-scan (`@langchain/*` / `langchain` / `langgraph`) + file inventory | ✅ tools (`tool(fn, {...})` factory — import-gated, config from arg 1; `DynamicStructuredTool` / `DynamicTool`), agents (`createReactAgent`, `createAgent`, `new AgentExecutor`) | ◐ tool LC-010 (no description), LC-011 (shell), LC-012 (code-exec), LC-013 (SSRF), LC-014 (`returnDirect`); agent LC-111 (AgentExecutor no `maxIterations`). Provider hosted tools (`shell()` / `bash_*` / `applyPatch`) and the raw `StateGraph` graph agent are documented gaps |
+| **CrewAI** | Python | ✅ dep-scan (`crewai` / `crewai-tools`) + file inventory | ✅ agents (`Agent(...)`, import-gated to `crewai` so it doesn't collide with OpenAI/ADK `Agent`), tools (`@tool` decorator routed in `kindFromDecorators` by import binding; `Tool(fn)` factory), dangerous built-ins (`CodeInterpreterTool` / `FileReadTool` / scrape+RAG tools → `HostedToolDef`) | ✅ tool CREW-001..006 (no-desc, untyped, code-exec, shell, SSRF, idempotency), CREW-108 (`result_as_answer`); agent CREW-101..104 (`allow_code_execution`, `code_execution_mode=unsafe`, wired `CodeInterpreterTool`, `allow_delegation`), CREW-106 (unconstrained `FileReadTool`), CREW-107 (URL-fetching tools); repo CREW-201. `class X(BaseTool)` and `Crew(...)` orchestration are v1 gaps |
+| **AutoGen / AG2** | Python | ✅ dep-scan (`pyautogen` / `ag2` / `autogen-agentchat`) + file inventory | ✅ two import gates (AG2/0.2 `autogen`; Microsoft v0.4 `autogen_agentchat`/`_core`/`_ext`): agents `ConversableAgent` / `UserProxyAgent` / `AssistantAgent` / `GroupChat` / `GroupChatManager` / `CodeExecutorAgent`; tools `register_function(fn,...)` + stacked `@x.register_for_llm` / `@x.register_for_execution` attribute decorators; nested `code_execution_config` dict captured | ✅ agent AG2-001 (`use_docker=False`), 002 (`human_input_mode=NEVER` + code exec), 004 (`GroupChat` no `max_round`), 005 (`AssistantAgent` code exec), 006 (no `max_consecutive_auto_reply`); tool AG2-007..012 (no-desc, untyped, shell, code-exec, SSRF, timeout); repo AG2-201. AG2-003 (v0.4 executor-class), the `register_function` caller/executor edge, and AG2 `@tool` are v1 gaps |
+| **Vercel AI SDK** | TypeScript | ✅ dep-scan (quoted `"ai"` key + `@ai-sdk/`) + file inventory | ✅ tools (`tool({...})` / `dynamicTool({...})` single-object factory, import-gated to `ai`), agents (call-based `generateText` / `streamText` / `generateObject` / `streamObject` carrying a `tools` record + class `ToolLoopAgent` / `Experimental_Agent`; **`tools` is an object/record**, walked by property value, not an array), provider hosted tools (`<provider>.tools.*()` → `HostedToolDef`) | ◐ tool VAI-001..005 (shell, code-exec, SSRF, no-desc, untyped); agent VAI-006 (provider shell/computer/code-exec tool), VAI-007 (no loop bound), VAI-008 (`toolChoice:'required'` + dangerous tool); repo VAI-012. VAI-009/010 (name rules — Vercel tools carry no `Name`) and VAI-011 (needs a TS abort-signal predicate) are gaps; `.js`/`.mjs` apps are recognized but not AST-parsed |
+| **Pydantic AI** | Python | ✅ dep-scan (`pydantic-ai` / `pydantic-ai-slim`) + file inventory | ✅ agents (`Agent(...)` → Class `PydanticAgent`, import-gated to `pydantic_ai`), tools (`@agent.tool` / `@agent.tool_plain` attribute decorators — routed in `kindFromDecorators`, disambiguated from the Claude SDK's `@agent.tool` by import; `Tool(fn)` factory), native tools (`capabilities=[NativeTool(CodeExecutionTool())]` / `builtin_tools=[...]` unwrapped → `HostedToolDef`) | ✅ tool PYD-001..007 (no-desc, untyped, shell, code-exec, SSRF, timeout, idempotency); agent PYD-101 (no `output_type` validation), 102 (`CodeExecutionTool`), 103 (`WebFetchTool` / `UrlContextTool`), 105 (`end_strategy='exhaustive'`); repo PYD-201. PYD-104 (`force_download` — needs a new predicate), the bare-`tools=[fn]` ToolDef shape, and `RunContext` param-strip for PYD-002 are gaps |
 | **OpenShell** | Python | ✅ shell-invocation discovery + `openshell/*.yaml` policy files surfaced | ✅ `KindShellInvocation` tools → `RepoInventory.HasShellInvocations` (the "openshell" risk surface; not an SDK, never in `SDKsDetected`) | ❌ rules moved to closed-source companion project (no rule fires; no META finding — openshell is not treated as an unaudited SDK) |
 
 ## What we parse exactly (per SDK)
@@ -186,6 +190,102 @@ prefix-matched (`astutil.TSImportAliasesMatch`) so the many subpaths
 class-based tools (`extends StructuredTool`) are documented gaps; the raw
 `StateGraph` graph agent is not modeled.
 
+### CrewAI — Python
+
+Discovery sources: `internal/analysis/crewai_agents.go`,
+`crewai_hosted_tools.go`, plus the `@tool` decorator routed in
+`internal/analysis/discovery.go` (`kindFromDecorators`). Import gate
+(AST-based): a file is in scope when it imports the CrewAI ecosystem
+(`crewai`, `crewai.*`, `crewai_tools`, `crewai_tools.*`) — the dot/underscore
+boundary keeps an unrelated `crewaix` from matching. The gate disambiguates the
+bare `Agent` class name from the OpenAI Agents SDK and Google ADK classes of the
+same name.
+
+| Construct | Recognition |
+|---|---|
+| Agents | `Agent(...)` constructor calls. Class is `Agent`; `agentKindMatches("crewai_agent")` keys on BOTH `SDK==crewai` AND Class, so an OpenAI/ADK `Agent` never cross-matches. All kwargs captured into a typed `KwargTree` (`role`, `goal`, `backstory`, `tools`, `allow_code_execution`, `code_execution_mode`, `allow_delegation`, …). CrewAI agents carry no `name=`; the human-facing label falls back to `role=`, then the assignment-target variable. `VarName` from `researcher = Agent(...)` so `tools=[...]` references resolve |
+| Tools (`@tool`) | The `crewai.tools` `@tool` decorator (shared name with the Claude SDK and LangChain), classified in `kindFromDecorators` by the **import binding** of the `tool` symbol (`collectToolImports`): `tool` bound from a crewai module → `KindCrewAITool`. A file-level import-presence check (`crewaiImport && !claudeImport && !lcImport`) is the fallback for a star-import / locally defined `tool`. Captures name, docstring → Description, typed-params, decorator kwargs (incl. `result_as_answer`) → Config |
+| Tools (factory) | `Tool(fn)` factory call — the wrapped first-positional function is resolved to a same-file def so the body predicates scan the implementation |
+| Dangerous built-ins | Closed set of 13 high-risk `crewai_tools` classes inside an agent's resolved `tools=[...]` → `HostedToolDef` (SDK `crewai`): `CodeInterpreterTool` (code exec); `FileReadTool` / `FileWriterTool` / `FileWriteTool` (older spelling) / `DirectoryReadTool` / `DirectorySearchTool` (filesystem); `ScrapeWebsiteTool` / `SeleniumScrapingTool` / `WebsiteSearchTool` / `SerperDevTool` / `JSONSearchTool` / `PDFSearchTool` / `CSVSearchTool` (model-chosen URL fetch). Benign built-ins are intentionally omitted so a match is always a security signal; consumed by agent rules CREW-103 / 106 / 107 |
+
+**v1 gaps:** the `class X(BaseTool)` subclass tool shape (the analog of
+LangChain's class-tool gap) and `Crew(...)` orchestration discovery are not
+modeled.
+
+### AutoGen / AG2 — Python
+
+Discovery sources: `internal/analysis/autogen_agents.go`, `autogen_tools.go`.
+Import gate (AST-based): a file is in scope when it imports **either** upstream
+line. The two lines share class names but live under different roots:
+
+- **AG2 / 0.2** (`autogen`, formerly distributed as `pyautogen` / `ag2`) —
+  matched by `autogen` or `autogen.*`. The dot boundary deliberately excludes
+  the v0.4 roots.
+- **Microsoft v0.4** (`autogen_agentchat`, `autogen_core`, `autogen_ext`) —
+  matched by each root or its dotted submodules.
+
+The union of the two is the discovery gate; `agentKindMatches` keys each
+`applies_to` token on BOTH `SDK==autogen` AND the class name, so a colliding
+`AssistantAgent` / `GroupChat` never produces a cross-SDK match.
+
+| Construct | Recognition |
+|---|---|
+| Agents | Closed set of 6 constructors across both lines: `ConversableAgent`, `UserProxyAgent`, `AssistantAgent`, `GroupChat`, `GroupChatManager`, `CodeExecutorAgent`. `GroupChat` is a config object, not a runtime agent, but it carries the `max_round` speaker-loop bound AG2-004 audits, so it is discovered and `agentKindMatches("autogen_group_chat_manager")` accepts both it and `GroupChatManager`. All kwargs captured; the nested `code_execution_config={...}` dict literal is descended (via `exprFromNode`'s `dictChildren`) so dotted-path lookups reach `code_execution_config.use_docker`. `name=` is the label; `VarName` captured |
+| Tools (`register_function`) | `register_function(fn, caller=, executor=, name=, description=)` call — the first positional ident is resolved to a same-file top-level function so the body predicates scan it. `name=` / `description=` override its metadata; remaining kwargs (e.g. `api_style=`) land in Config. Neither flows through `kindFromDecorators` (it is a call, not a decorator) |
+| Tools (attribute decorators) | Stacked `@<executor>.register_for_execution()` / `@<assistant>.register_for_llm(name=, description=)` decorators. The callee is an **attribute** (`<agentvar>.register_for_llm`), not a bare name, so `kindFromDecorators` does not classify it — this pass walks `decorated_definition` nodes and emits one `KindAutoGenTool` per function whose decorator suffix is `register_for_llm` / `register_for_execution`. `register_for_llm`'s `name=` / `description=` override the function's |
+
+**v1 gaps:** the v0.4 executor-class hosted surface (`CodeExecutorAgent` +
+`LocalCommandLineCodeExecutor`) that AG2-003 would target, the
+`register_function` caller/executor two-agent edge (`VarName` is captured for a
+future pass but not yet resolved), and an AG2 bare-name `@tool` decorator shape
+are not modeled.
+
+### Vercel AI SDK — TypeScript
+
+Discovery sources: `internal/analysis/ts_vercel_tools.go`,
+`ts_vercel_agents.go`, `ts_vercel_hosted_tools.go`, plus the shared
+`ts_handler_facts.go`. Import gate: the bare `ai` core module (matched exactly —
+the `@ai-sdk/*` provider packages are not gated here; their hosted tools are
+recognized structurally in the agent walk). The gate disambiguates the
+identically-named `tool()` factory from the Claude / OpenAI / LangChain passes.
+
+| Construct | Recognition |
+|---|---|
+| Tools | `tool({ description, inputSchema \| parameters, execute })` (v5/v6 `inputSchema`, v4 `parameters`) and `dynamicTool({...})`. Unlike LangChain's `tool(fn, {...})` (handler arg 0, config arg 1), the Vercel factory takes a SINGLE options object (arg 0). A Vercel tool's NAME comes from the agent's tools-record KEY, not the definition, so `ToolDef.Name` is empty and the binding identifier is captured as `VarName`. `description` is the only model-visible signal (no docstring fallback). Params: a typed Zod object → real names + `HasTypedParams`; an OPEN schema (`z.any()` / `z.unknown()` / `z.object({})` / `{}`) or `dynamicTool` → synthetic `"input"` param, `HasTypedParams=false` (the VAI-005 untyped signal); no schema key → empty params. `execute` body facts via `tsHandlerFacts` |
+| Agents (call-based) | `generateText` / `streamText` / `generateObject` / `streamObject` ({ model, system, tools, stopWhen, maxSteps, toolChoice }) — emitted as an `AgentDef` ONLY when the options object carries a `tools` property (a bare completion is not an agent and emitting one would flood findings). Class is the normalized callee (`GenerateText` / `StreamText` / `GenerateObject` / `StreamObject`) |
+| Agents (class-based) | `new ToolLoopAgent({...})` and `new Experimental_Agent({...})` (often imported `as Agent`; alias-resolved via the `ai` import map). Both normalize to Class `ToolLoopAgent`. The system-prompt slot here is `instructions` (vs `system` in the call form); both keys are captured |
+| tools record walk | In BOTH agent forms, `tools` is an OBJECT / RECORD (`{ weather: weatherTool, search: tool({...}) }`), NOT an array — every other TS agent pass reads `tools: [...]` arrays; this walk iterates the object's property **values**. A bare identifier → `ToolRef{Name}` (wired by `ResolveEdges`); an inline `tool({...})` / `dynamicTool({...})` → agent marked `Opaque` (no symbol edge); a `<provider>.tools.<name>()` call → `HostedToolRef`; a spread (`...mcpTools`) or any other value → `Opaque` |
+| Provider hosted tools | Member-call shape `<provider>.tools.<name>()` read directly from the `member_expression` text (`TSCalleeText` cannot resolve it — the provider object is a runtime value, not an import alias). Closed set across `@ai-sdk/anthropic` (`anthropic.tools.bash` / `textEditor` / `computer` / `codeExecution` / `webSearch`), `@ai-sdk/openai` (`openai.tools.localShell` / `computerUsePreview` / `codeInterpreter` / `webSearch` / `webSearchPreview` / `fileSearch`), `@ai-sdk/google` (`google.tools.codeExecution` / `googleSearch` / `urlContext`). A trailing `_<date>` version suffix (e.g. `bash_20250124`) is stripped to a canonical class. The shell / computer / code-exec subset is what VAI-006 flags; web-search / URL-context tools are excluded (SSRF-class, not RCE) |
+
+**v1 gaps:** VAI-009 / 010 (name-quality rules — Vercel tools carry no `Name`,
+so there is nothing to lint) and VAI-011 (network-timeout — needs a TS
+abort-signal predicate) are not shipped; `.js` / `.mjs` apps are recognized in
+the inventory but not AST-parsed (the TS parser only handles `.ts` / `.tsx`).
+
+### Pydantic AI — Python
+
+Discovery sources: `internal/analysis/pydantic_ai_agents.go`,
+`pydantic_ai_tools.go`, `pydantic_ai_hosted_tools.go`, plus the
+`@agent.tool` / `@agent.tool_plain` decorators routed in
+`internal/analysis/discovery.go` (`kindFromDecorators`). Import gate
+(AST-based): a file is in scope when it imports `pydantic_ai` / `pydantic_ai.*`
+(the dot boundary excludes `pydantic_aix`). The gate disambiguates the bare
+`Agent` class name from the OpenAI, ADK, and CrewAI classes of the same name.
+
+| Construct | Recognition |
+|---|---|
+| Agents | `Agent(...)` constructor calls, normalized to Class `PydanticAgent` (the upstream token is `Agent`; the stamped name disambiguates from the other SDKs' `Agent`). `agentKindMatches("pydantic_ai_agent")` keys on BOTH SDK and Class. All kwargs captured (`model`, `output_type`, `system_prompt`, `instructions`, `tools`, `retries`, `end_strategy`, …); optional `name=` is the label; `VarName` captured so the `@agent.tool` decorator owner and `tools=[...]` references resolve |
+| Tools (`@agent.tool` / `@agent.tool_plain`) | Attribute decorators on the agent var (`@agent.tool` takes a leading `RunContext`; `@agent.tool_plain` does not). Routed in `kindFromDecorators` ONLY when the file imports `pydantic_ai` AND does NOT import the Claude SDK — the `&& !claudeImport` guard is load-bearing because the Claude SDK also exposes an `@agent.tool`, so a Claude-only file (and a file importing both) falls through to the Claude case (claude wins the collision). Emits `KindPydanticAITool` |
+| Tools (factory) | `Tool(fn, takes_ctx=, requires_approval=, name=, description=)` call — gated on `pydantic_ai` imported AND NOT LangChain imported (LangChain ships an identically-named `Tool(...)`; LangChain's gate wins, mirroring the Claude `@agent.tool` precedence). First positional ident resolved to a same-file def so the body predicates scan it; `name=` / `description=` override; remaining kwargs land in Config |
+| Native (built-in) tools | The dangerous subset `CodeExecutionTool` (code exec), `WebFetchTool` / `UrlContextTool` / `WebSearchTool` (model-chosen URL fetch). Wired in two shapes under the `capabilities=` / `builtin_tools=` kwargs (NOT the generic `tools=` list, so `ResolveEdges` scans those two kwargs specifically): the modern `capabilities=[NativeTool(CodeExecutionTool())]` wrapper (unwrapped one level to the inner class) and the legacy `builtin_tools=[CodeExecutionTool()]` direct form → `HostedToolDef` (SDK `pydantic_ai`), consumed by agent rules PYD-102 / 103 |
+
+**v1 gaps:** PYD-104 (`force_download` on a native tool — needs a new
+predicate), the bare-function `tools=[fn]` ToolDef-synthesis shape (the agent
+edge still works via the `tools=` kwarg, but no standalone `ToolDef` is
+emitted), and stripping the leading `RunContext` param for PYD-002 (so a
+`@agent.tool` whose only "param" is the injected context is not mis-flagged as
+typed) are not modeled.
+
 ### OpenShell — Python
 
 | Construct | Recognition |
@@ -217,6 +317,10 @@ not fire for it.
 | **MCP cross-language** (TS, Rust, Go) | Two prerequisites are missing today: (1) MCP dep-scan needles in `internal/ingestion/normalizer.go` — currently only `claude-agent-sdk` / `claude_agent_sdk` / `openai-agents` / `@openai/agents` / `google-adk` / `@google/adk` are matched; there is no `@modelcontextprotocol/sdk` (npm), no `rmcp` / `anthropic-mcp` (Cargo), no Go MCP module needle. (2) per-language AST parsers and discovery for the SDK shapes (`Server.tool()` factory in TS, `#[tool]` macros in Rust, etc.). File paths are recorded by the generic walk but no MCP-specific extraction happens against them |
 | **MCP server-side completeness** | We discover tools registered with `@server.tool` etc., but don't extract `Prompt`, `Resource`, `Sampling` registrations — those exist in the spec and would be a small additional pass |
 | **LangChain class tools + raw `StateGraph` + TS provider hosted tools** | Three additive discovery gaps in the LangChain pack: `class X(BaseTool)` / `extends StructuredTool` (a class shape, not a call); the raw `StateGraph` → `.compile()` graph agent (emergent across call sites — needs data-flow from the `StateGraph` var through `add_node` / `ToolNode` / `compile`, not a single-call capture); and the date-stamped TS provider hosted tools (`shell()` / `bash_*` / `applyPatch`). Each is discovery-only, no schema change |
+| **CrewAI class tools + `Crew(...)` orchestration** | Two discovery-only gaps: the `class X(BaseTool)` subclass tool shape (a class, not a call or `@tool` decorator — the same shape missing for LangChain) and the `Crew(...)` orchestration unit (the agent constructor `Agent(...)` is covered; the crew that wires agents + tasks together is not). No schema change |
+| **AutoGen v0.4 executor + caller/executor edge + AG2 `@tool`** | Three additive gaps: the v0.4 executor-class hosted surface (`CodeExecutorAgent` + `LocalCommandLineCodeExecutor`) that an AG2-003 rule would target; resolving the `register_function(caller=, executor=)` two-agent edge (the agents' `VarName`s are already captured, so this is edge-resolution work, not new discovery); and an AG2 bare-name `@tool` decorator arm in `kindFromDecorators`. Discovery / edge-resolution only |
+| **Vercel name rules + TS timeout predicate + `.js` parsing** | VAI-009 / 010 need a tool `Name` to lint, but Vercel tools take their name from the agent's tools-record key, not the definition — closing this means propagating the record key onto the `ToolDef` during edge resolution. VAI-011 (network timeout) needs a new TS abort-signal predicate (the same predicate the Claude/OpenAI TS packs still lack). And `.js` / `.mjs` apps are inventoried but not AST-parsed — the TS parser is gated to `.ts` / `.tsx` |
+| **Pydantic `force_download` predicate + bare-`tools=[fn]` + `RunContext` strip** | PYD-104 needs a new predicate for a native tool's `force_download` kwarg. The bare-function `tools=[fn]` shape resolves the agent edge but emits no standalone `ToolDef` (so tool-scope rules don't fire on it) — closing it means synthesizing a `ToolDef` from each resolved function in `tools=`. And PYD-002 should strip the leading `RunContext` param a `@agent.tool` injects before judging type-annotation coverage, so a ctx-only tool is not mis-read as typed |
 
 ## Recommended next moves
 
@@ -268,6 +372,20 @@ rationale, not as a binding roadmap.
    discovery, not a single-call capture), class-based tools (`class X(BaseTool)`
    / `extends StructuredTool`), and the date-stamped TS provider hosted tools
    (`shell()` / `bash_*` / `applyPatch`).
+6. **Four SDK rows landed 2026-06-05** — CrewAI, AutoGen / AG2, and Pydantic AI
+   (Python) plus the Vercel AI SDK (TypeScript). Each ships discovery in the
+   engine binary and a rule pack in `trustabl-rules`: CrewAI CREW-001..006 / 101..108
+   / 201, AutoGen AG2-001..012 / 201, Vercel VAI-001..008 / 012, Pydantic
+   PYD-001..007 / 101..105 / 201. The bare `Agent` name is import-gated per SDK
+   so CrewAI / Pydantic / OpenAI / ADK never cross-match, and `kindFromDecorators`
+   now also routes CrewAI `@tool` (by import binding) and Pydantic `@agent.tool` /
+   `@agent.tool_plain` (import-gated, with the Claude SDK winning the collision).
+   Remaining per-SDK work is tracked in the gaps table above: CrewAI `class X(BaseTool)`
+   + `Crew(...)`; AutoGen v0.4 executor-class (AG2-003) + the `register_function`
+   caller/executor edge + an AG2 `@tool` arm; Vercel VAI-009/010 name rules +
+   VAI-011 TS-timeout predicate + `.js` parsing; Pydantic PYD-104 `force_download`
+   predicate + bare-`tools=[fn]` synthesis + the `RunContext` param-strip for
+   PYD-002.
 
 ## Sources
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Trustabl is a static analyzer for agent reliability. It parses an agent-SDK
 repository (Claude Agent SDK, OpenAI Agents SDK, Google ADK, MCP, LangChain /
-LangGraph), models the
+LangGraph, CrewAI, AutoGen / AG2, Pydantic AI, and the Vercel AI SDK), models the
 tools, agents, subagents, skills, slash commands, and plugin manifests it
 declares, and checks them against a catalog of reliability and safety rules. It reports the weaknesses it finds — each
 with an explanation, a suggested fix, and a confidence score — as a
@@ -165,8 +165,13 @@ diagram with typed inputs at each step.
 Tool/agent AST discovery is wired for:
 
 - **Python** — Claude Agent SDK (decorators), OpenAI Agents SDK, Google
-  ADK. Discovery extracts tool definitions, agent constructors, hosted
-  tools, MCP servers, guardrails, sessions.
+  ADK, LangChain / LangGraph, CrewAI, AutoGen / AG2, and Pydantic AI.
+  Discovery extracts tool definitions, agent constructors, hosted
+  tools, MCP servers, guardrails, sessions. The bare `Agent(...)`
+  constructor shared by OpenAI / ADK / CrewAI / Pydantic AI is
+  import-gated per SDK so the classes never cross-match, and the
+  shared `@tool` decorator is routed to the owning SDK by its import
+  binding.
 - **TypeScript** — Claude Agent SDK (the `tool()` factory, the
   `query()` main-thread `QueryMainAgent`, inline-in-`query()` sub-agents,
   typed-const `AgentDefinition`s, `createSdkMcpServer` and the four
@@ -181,15 +186,26 @@ Tool/agent AST discovery is wired for:
   `new FunctionTool({...})` constructor, 5 agent constructors —
   `new LlmAgent({...})` / `SequentialAgent` / `ParallelAgent` /
   `LoopAgent` / `RoutedAgent` — 13 hosted-tool classes, and `subAgents`
-  edges — gated on imports from `@google/adk`). Handles
-  `.ts` / `.tsx` / `.mts` / `.cts`
-  with both `tree-sitter-typescript` and `tree-sitter-tsx` grammars.
-  TypeScript rule packs ship for all three SDKs: Claude Agent SDK
+  edges — gated on imports from `@google/adk`), LangChain / LangGraph
+  (the `tool(fn, {...})` factory, `DynamicStructuredTool` / `DynamicTool`,
+  and `createReactAgent` / `createAgent` / `new AgentExecutor` — gated on
+  the `@langchain/*` / `langchain` / `langgraph` ecosystem), and the
+  Vercel AI SDK (the `tool({...})` / `dynamicTool({...})` single-object
+  factory, the call-based `generateText` / `streamText` / `generateObject`
+  / `streamObject` agents and the class `ToolLoopAgent` /
+  `Experimental_Agent`, with `tools` walked as an object/record, plus the
+  `<provider>.tools.*()` hosted tools — gated on the bare `ai` import).
+  Handles `.ts` / `.tsx` / `.mts` / `.cts`
+  with both `tree-sitter-typescript` and `tree-sitter-tsx` grammars
+  (`.js` / `.mjs` are inventoried but not AST-parsed).
+  TypeScript rule packs ship for the Claude Agent SDK
   (CSDK-010/011/012/013/014/016 tool rules; CSDK-120/130/131 agent rules),
   OpenAI Agents SDK (OAI-016/017/019/022/024 tool rules; OAI-105 agent rule),
-  and Google ADK (ADK-013/015/016 tool rules; ADK-109 agent rule). A TS repo
-  for any of the three no longer produces a blanket `META-004`; see
-  `COVERAGE.md` for the full matrix.
+  Google ADK (ADK-013/015/016 tool rules; ADK-109 agent rule), MCP
+  (MCP-011/012/013/014 tool rules), LangChain (LC-010/011/012/013/014 tool
+  rules; LC-111 agent rule), and the Vercel AI SDK (VAI-001..008 tool/agent
+  rules; VAI-012 repo rule). A TS repo for any of these no longer produces a
+  blanket `META-004`; see `COVERAGE.md` for the full matrix.
 
 JavaScript and Go files are recognized by Recon (they appear in the
 file inventory and feed component discovery) but no AST parser for them

--- a/internal/analysis/agents.go
+++ b/internal/analysis/agents.go
@@ -148,6 +148,10 @@ func ResolveEdges(inv *models.RepoInventory, parsed []ParsedFile) {
 						h, isHT = classifyADKHostedToolCall(item, a.FilePath)
 					case models.SDKLangChain:
 						h, isHT = classifyLangChainHostedToolCall(item, a.FilePath)
+					case models.SDKCrewAI:
+						h, isHT = classifyCrewAIHostedToolCall(item, a.FilePath)
+					case models.SDKPydanticAI:
+						h, isHT = classifyPydanticAIHostedToolCall(item, a.FilePath)
 					default:
 						h, isHT = classifyHostedToolCall(item, a.FilePath)
 					}
@@ -191,6 +195,35 @@ func ResolveEdges(inv *models.RepoInventory, parsed []ParsedFile) {
 				}
 			} else if toolsKwarg != nil {
 				a.Opaque = true
+			}
+
+			// Pydantic AI native (built-in) tools live under capabilities= and
+			// builtin_tools=, NOT the generic tools= list scanned above, so the
+			// tools= block never sees CodeExecutionTool()/WebFetchTool(). Scan both
+			// kwargs here for hosted classification (the only thing they hold), so
+			// PYD-102/103 can flag the capability. Scoped to Pydantic agents — other
+			// SDKs do not use these kwargs, and the NativeTool(...) wrapper unwrap
+			// lives in classifyPydanticAIHostedToolCall. A non-list value is ignored
+			// (no Opaque side effect): native-tool opaqueness is orthogonal to the
+			// tools=-list opaqueness the block above tracks.
+			if a.SDK == models.SDKPydanticAI {
+				for _, kwName := range []string{"capabilities", "builtin_tools"} {
+					kw := agentKwarg(a, kwName)
+					if kw == nil || kw.Value == nil || kw.Value.Kind != models.ExprList {
+						continue
+					}
+					for _, item := range kw.Value.List {
+						h, isHT := classifyPydanticAIHostedToolCall(item, a.FilePath)
+						if !isHT {
+							continue
+						}
+						inv.HostedTools = append(inv.HostedTools, h)
+						a.HostedToolRefs = append(a.HostedToolRefs, models.HostedToolRef{
+							Class:    h.Class,
+							DefIndex: len(inv.HostedTools) - 1,
+						})
+					}
+				}
 			}
 		}
 
@@ -371,12 +404,13 @@ func ResolveEdges(inv *models.RepoInventory, parsed []ParsedFile) {
 			}
 		}
 
-		// HostedToolRefs — TS discovery (OpenAI and ADK) sets Class to the
-		// canonical hosted-tool class name and DefIndex=-1. Materialize a
+		// HostedToolRefs — TS discovery (OpenAI, ADK, and Vercel) sets Class to
+		// the canonical hosted-tool class name and DefIndex=-1. Materialize a
 		// matching HostedToolDef in inv.HostedTools so downstream consumers
 		// see a complete hosted-tool inventory. The SDK is stamped from
 		// whichever closed set matched the class name — TSOpenAIHostedToolFactories
-		// → SDKOpenAIAgents, TSADKHostedToolClasses → SDKGoogleADK. Python
+		// → SDKOpenAIAgents, TSADKHostedToolClasses → SDKGoogleADK,
+		// IsVercelHostedTool → SDKVercelAI. Python
 		// hosted-tool refs (handled by the classify block above) carry a
 		// valid DefIndex already and are skipped by the first guard. The
 		// Location is approximated to the agent's call site — the precise
@@ -397,6 +431,8 @@ func ResolveEdges(inv *models.RepoInventory, parsed []ParsedFile) {
 				sdk = models.SDKOpenAIAgents
 			case IsTSADKHostedToolClass(ref.Class):
 				sdk = models.SDKGoogleADK
+			case IsVercelHostedTool(ref.Class):
+				sdk = models.SDKVercelAI
 			default:
 				continue
 			}
@@ -673,7 +709,44 @@ func exprFromNode(n *sitter.Node, src []byte) *models.KwargTree {
 		e.CallKwargs = children
 		return &models.KwargTree{Value: e, Children: children}
 	}
+	// For a dict literal passed as a kwarg value
+	// (e.g. code_execution_config={"use_docker": False}), descend into each
+	// string-keyed pair so dotted-path lookups can reach the nested leaf
+	// (code_execution_config.use_docker). The Expr keeps its opaque Text (the
+	// raw dict source) and ExprUnknown kind; the nested structure lives in
+	// Children, mirroring how a call value carries CallKwargs above. Non-string
+	// keys (a variable or computed key) are skipped — they have no stable
+	// dotted-path name.
+	if n.Type() == "dictionary" {
+		children := dictChildren(n, src)
+		return &models.KwargTree{Value: e, Children: children}
+	}
 	return &models.KwargTree{Value: e}
+}
+
+// dictChildren builds a KwargTree child map from a Python dict literal node,
+// keyed by each pair's string-literal key (quotes stripped). Used so a dict
+// passed as a kwarg value supports the same dotted-path lookups as a nested
+// constructor call.
+func dictChildren(n *sitter.Node, src []byte) map[string]*models.KwargTree {
+	children := map[string]*models.KwargTree{}
+	for i := 0; i < int(n.NamedChildCount()); i++ {
+		pair := n.NamedChild(i)
+		if pair.Type() != "pair" {
+			continue
+		}
+		key := pair.ChildByFieldName("key")
+		val := pair.ChildByFieldName("value")
+		if key == nil || val == nil || key.Type() != "string" {
+			continue
+		}
+		name := strings.Trim(astutil.NodeText(key, src), `"'`)
+		if name == "" {
+			continue
+		}
+		children[name] = exprFromNode(val, src)
+	}
+	return children
 }
 
 func nilToEmpty(t *models.KwargTree) *models.KwargTree {

--- a/internal/analysis/autogen_agents.go
+++ b/internal/analysis/autogen_agents.go
@@ -1,0 +1,137 @@
+package analysis
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/trustabl/trustabl/internal/analysis/astutil"
+	"github.com/trustabl/trustabl/internal/models"
+)
+
+// AutoGen / AG2 Python agent discovery.
+//
+// AutoGen ships across two upstream lines that share class names but live in
+// different import roots:
+//
+//   - The AG2 / 0.2 line (`autogen`, formerly `pyautogen`) exports
+//     ConversableAgent / UserProxyAgent / AssistantAgent / GroupChat /
+//     GroupChatManager.
+//   - Microsoft's v0.4 line (`autogen_agentchat`, `autogen_core`, `autogen_ext`)
+//     exports AssistantAgent and CodeExecutorAgent.
+//
+// Several of these class names (AssistantAgent, GroupChat) collide with other
+// SDKs and with user code, so all discovery is import-gated to files that import
+// either AutoGen line (fileImportsAutoGen). The emitted AgentDef carries
+// SDK=SDKAutoGen and Class set to the exact constructor name;
+// agentKindMatches keys each applies_to token on BOTH SDK==SDKAutoGen AND the
+// class name, so a collision never produces a cross-SDK match.
+//
+// The executor-class hosted discovery (CodeExecutorAgent +
+// LocalCommandLineCodeExecutor) and the register_function caller/executor
+// two-agent edge are documented v1 gaps.
+
+// autoGenAgentClasses is the closed set of AutoGen agent constructors across both
+// upstream lines, mapped to the canonical class name stamped on AgentDef.Class.
+// GroupChat is a config object rather than a runtime agent, but it carries the
+// max_round speaker-loop bound that AG2-004 audits, so it is discovered and
+// agentKindMatches("autogen_group_chat_manager") accepts both it and
+// GroupChatManager.
+var autoGenAgentClasses = map[string]string{
+	"ConversableAgent":  "ConversableAgent",
+	"UserProxyAgent":    "UserProxyAgent",
+	"AssistantAgent":    "AssistantAgent",
+	"GroupChat":         "GroupChat",
+	"GroupChatManager":  "GroupChatManager",
+	"CodeExecutorAgent": "CodeExecutorAgent",
+}
+
+// isAutoGenAG2Module reports whether a dotted module path belongs to the AG2 /
+// 0.2 line: `autogen` or `autogen.*`. The dot boundary is load-bearing — it must
+// NOT match the v0.4 packages `autogen_agentchat` / `autogen_core` /
+// `autogen_ext`, which are a separate import line handled by
+// isAutoGenV04Module. (`pyautogen` and `ag2` are the *distribution* names on
+// PyPI; the imported module is still `autogen`, so only `autogen` is matched.)
+func isAutoGenAG2Module(mod string) bool {
+	return mod == "autogen" || strings.HasPrefix(mod, "autogen.")
+}
+
+// isAutoGenV04Module reports whether a dotted module path belongs to Microsoft's
+// v0.4 line: autogen_agentchat / autogen_core / autogen_ext and their dotted
+// submodules. The underscore-prefixed roots are deliberately distinct from the
+// AG2 `autogen` root so the two lines never alias each other.
+func isAutoGenV04Module(mod string) bool {
+	for _, root := range []string{"autogen_agentchat", "autogen_core", "autogen_ext"} {
+		if mod == root || strings.HasPrefix(mod, root+".") {
+			return true
+		}
+	}
+	return false
+}
+
+// fileImportsAutoGen reports whether pf imports EITHER AutoGen upstream line via
+// a real import statement (AST-based, not a source substring — a comment that
+// merely mentions autogen must not trip the gate). The union of the two lines is
+// the discovery gate.
+func fileImportsAutoGen(pf ParsedFile) bool {
+	return fileImportsModule(pf, func(mod string) bool {
+		return isAutoGenAG2Module(mod) || isAutoGenV04Module(mod)
+	})
+}
+
+// DiscoverAutoGenAgents walks each ParsedFile and emits one AgentDef per
+// recognized AutoGen agent constructor call. Only files importing an AutoGen
+// line are considered (the import gate disambiguates AssistantAgent / GroupChat
+// from other SDKs and user code of the same name).
+func DiscoverAutoGenAgents(files []ParsedFile) []models.AgentDef {
+	var out []models.AgentDef
+	for _, pf := range files {
+		if !fileImportsAutoGen(pf) {
+			continue
+		}
+		out = append(out, discoverAutoGenAgentsInFile(pf)...)
+	}
+	return out
+}
+
+func discoverAutoGenAgentsInFile(pf ParsedFile) []models.AgentDef {
+	var out []models.AgentDef
+	astutil.Walk(pf.Tree.RootNode(), func(n *sitter.Node) bool {
+		if n.Type() != "call" {
+			return true
+		}
+		callee := astutil.NodeText(n.ChildByFieldName("function"), pf.Source)
+		class, ok := autoGenAgentClasses[callee]
+		if !ok {
+			return true
+		}
+		kwargs, opaque := extractCallKwargs(n, pf.Source)
+		a := models.AgentDef{
+			SDK:      models.SDKAutoGen,
+			Class:    class,
+			Language: models.LanguagePython,
+			Location: models.Location{
+				FilePath: pf.RelPath,
+				Line:     int(n.StartPoint().Row) + 1,
+				EndLine:  int(n.EndPoint().Row) + 1,
+			},
+			Kwargs: kwargs,
+			Opaque: opaque,
+		}
+		// AutoGen agents are labeled by a name= string literal; capture it.
+		if nm := kwargStringLiteral(kwargs, "name"); nm != "" {
+			a.Name = nm
+		}
+		// Capture the assignment-target identifier (user_proxy = UserProxyAgent(...))
+		// so a GroupChat's agents=[...] and register_function caller/executor
+		// references can resolve by variable name in a future pass.
+		if p := n.Parent(); p != nil && p.Type() == "assignment" {
+			if l := p.ChildByFieldName("left"); l != nil && l.Type() == "identifier" {
+				a.VarName = astutil.NodeText(l, pf.Source)
+			}
+		}
+		out = append(out, a)
+		return true
+	})
+	return out
+}

--- a/internal/analysis/autogen_agents_test.go
+++ b/internal/analysis/autogen_agents_test.go
@@ -1,0 +1,273 @@
+package analysis_test
+
+import (
+	"testing"
+
+	"github.com/trustabl/trustabl/internal/analysis"
+	"github.com/trustabl/trustabl/internal/models"
+)
+
+// A UserProxyAgent(...) in a file importing the AG2 line (`autogen`) is emitted
+// as one AgentDef with SDK=SDKAutoGen, Class="UserProxyAgent", and its nested
+// code_execution_config={"use_docker": False} captured as a nested KwargTree so
+// the agent-scope rules (AG2-001/002/006) can read code_execution_config.use_docker.
+func TestAutoGenAgent_ConversableAndUserProxyCaptured(t *testing.T) {
+	src := `from autogen import ConversableAgent, UserProxyAgent
+
+assistant = ConversableAgent(
+    name="assistant",
+    llm_config={"model": "gpt-4"},
+)
+
+user_proxy = UserProxyAgent(
+    name="user_proxy",
+    human_input_mode="NEVER",
+    code_execution_config={"use_docker": False},
+)
+`
+	pf := parsePyFile(t, "ag.py", src)
+	agents := analysis.DiscoverAutoGenAgents([]analysis.ParsedFile{pf})
+	if len(agents) != 2 {
+		t.Fatalf("got %d agents, want 2", len(agents))
+	}
+
+	byClass := map[string]models.AgentDef{}
+	for _, a := range agents {
+		if a.SDK != models.SDKAutoGen {
+			t.Errorf("SDK: got %q, want %q", a.SDK, models.SDKAutoGen)
+		}
+		if a.Language != models.LanguagePython {
+			t.Errorf("Language: got %q, want python", a.Language)
+		}
+		byClass[a.Class] = a
+	}
+
+	conv, ok := byClass["ConversableAgent"]
+	if !ok {
+		t.Fatalf("ConversableAgent not discovered; got classes %v", byClass)
+	}
+	if conv.Name != "assistant" || conv.VarName != "assistant" {
+		t.Errorf("ConversableAgent Name/VarName: got %q/%q, want assistant/assistant", conv.Name, conv.VarName)
+	}
+
+	up, ok := byClass["UserProxyAgent"]
+	if !ok {
+		t.Fatalf("UserProxyAgent not discovered; got classes %v", byClass)
+	}
+	if up.Name != "user_proxy" || up.VarName != "user_proxy" {
+		t.Errorf("UserProxyAgent Name/VarName: got %q/%q, want user_proxy/user_proxy", up.Name, up.VarName)
+	}
+	// The nested dict literal must be captured so the dotted-path predicate works.
+	cec := up.Kwargs.Children["code_execution_config"]
+	if cec == nil {
+		t.Fatalf("code_execution_config not captured: %+v", up.Kwargs)
+	}
+	ud := cec.Children["use_docker"]
+	if ud == nil || ud.Value == nil {
+		t.Fatalf("code_execution_config.use_docker not captured: %+v", cec)
+	}
+	if ud.Value.Kind != models.ExprLiteralBool || ud.Value.Text != "False" {
+		t.Errorf("use_docker leaf: got kind=%q text=%q, want bool/False", ud.Value.Kind, ud.Value.Text)
+	}
+	if hm := up.Kwargs.Children["human_input_mode"]; hm == nil || hm.Value == nil || hm.Value.Text != `"NEVER"` {
+		t.Errorf("human_input_mode not captured as NEVER: %+v", up.Kwargs)
+	}
+}
+
+// GroupChat and GroupChatManager (the AG2/0.2 orchestration classes) are both
+// discovered with their exact class names so agentKindMatches keys the
+// autogen_group_chat_manager token on either, and CodeExecutorAgent (the v0.4
+// class) is discovered from the autogen_agentchat import root.
+func TestAutoGenAgent_GroupChatAndV04Classes(t *testing.T) {
+	src := `from autogen import GroupChat, GroupChatManager
+from autogen_agentchat.agents import CodeExecutorAgent
+
+gc = GroupChat(agents=[a, b], messages=[])
+mgr = GroupChatManager(groupchat=gc)
+executor = CodeExecutorAgent(name="exec")
+`
+	pf := parsePyFile(t, "gc.py", src)
+	agents := analysis.DiscoverAutoGenAgents([]analysis.ParsedFile{pf})
+	got := map[string]bool{}
+	for _, a := range agents {
+		if a.SDK != models.SDKAutoGen {
+			t.Errorf("SDK: got %q, want autogen", a.SDK)
+		}
+		got[a.Class] = true
+	}
+	for _, want := range []string{"GroupChat", "GroupChatManager", "CodeExecutorAgent"} {
+		if !got[want] {
+			t.Errorf("class %q not discovered; got %v", want, got)
+		}
+	}
+}
+
+// register_function(fn, ...) and the @x.register_for_llm / @x.register_for_execution
+// stacked decorators both produce KindAutoGenTool ToolDefs, with description=
+// overrides and docstring fallback honored. A function carrying both stacked
+// decorators is emitted exactly once.
+func TestAutoGenTool_RegisterFunctionAndDecorators(t *testing.T) {
+	src := `from autogen import ConversableAgent, register_function
+
+assistant = ConversableAgent(name="a")
+user_proxy = ConversableAgent(name="u")
+
+def get_weather(city: str) -> str:
+    """Return the weather for a city."""
+    return "sunny"
+
+register_function(
+    get_weather,
+    caller=assistant,
+    executor=user_proxy,
+    name="weather",
+    description="Look up the weather.",
+)
+
+@user_proxy.register_for_execution()
+@assistant.register_for_llm(name="adder", description="Add two numbers.")
+def add(a: int, b: int) -> int:
+    return a + b
+
+@assistant.register_for_llm()
+def multiply(a: int, b: int) -> int:
+    """Multiply two numbers."""
+    return a * b
+`
+	pf := parsePyFile(t, "tools.py", src)
+	tools := analysis.DiscoverAutoGenTools([]analysis.ParsedFile{pf})
+
+	byName := map[string]models.ToolDef{}
+	for _, tl := range tools {
+		if tl.Kind != models.KindAutoGenTool {
+			t.Errorf("tool %q Kind: got %q, want %q", tl.Name, tl.Kind, models.KindAutoGenTool)
+		}
+		if tl.Language != models.LanguagePython {
+			t.Errorf("tool %q Language: got %q, want python", tl.Name, tl.Language)
+		}
+		if _, dup := byName[tl.Name]; dup {
+			t.Errorf("tool %q emitted more than once (stacked decorators must not double-emit)", tl.Name)
+		}
+		byName[tl.Name] = tl
+	}
+
+	// register_function with name= override.
+	weather, ok := byName["weather"]
+	if !ok {
+		t.Fatalf("register_function tool 'weather' not discovered; got %v", keysOf(byName))
+	}
+	if weather.Description != "Look up the weather." {
+		t.Errorf("weather description: got %q, want the description= override", weather.Description)
+	}
+
+	// Stacked decorators, description= on register_for_llm wins; emitted once.
+	adder, ok := byName["adder"]
+	if !ok {
+		t.Fatalf("decorator tool 'adder' not discovered; got %v", keysOf(byName))
+	}
+	if adder.Description != "Add two numbers." {
+		t.Errorf("adder description: got %q, want the register_for_llm description=", adder.Description)
+	}
+
+	// register_for_llm() with no description= falls back to the docstring.
+	mul, ok := byName["multiply"]
+	if !ok {
+		t.Fatalf("decorator tool 'multiply' not discovered; got %v", keysOf(byName))
+	}
+	if mul.Description != "Multiply two numbers." {
+		t.Errorf("multiply description: got %q, want the docstring fallback", mul.Description)
+	}
+}
+
+// The Location of a register_function tool points at the wrapped function body,
+// so the body-scanning predicates (has_shell_call etc.) inspect the function and
+// the shells_out structural fact is stamped.
+func TestAutoGenTool_LocationPointsAtFunctionBody(t *testing.T) {
+	src := `from autogen import register_function
+
+def run_cmd(cmd: str) -> str:
+    """Run a shell command."""
+    import subprocess
+    return subprocess.run(cmd, shell=True)
+
+register_function(run_cmd, name="runner")
+`
+	pf := parsePyFile(t, "shell.py", src)
+	tools := analysis.DiscoverAutoGenTools([]analysis.ParsedFile{pf})
+	if len(tools) != 1 {
+		t.Fatalf("got %d tools, want 1", len(tools))
+	}
+	tl := tools[0]
+	if tl.Facts["shells_out"] != "true" {
+		t.Errorf("shells_out fact not stamped (Location must point at the function body): %+v", tl.Facts)
+	}
+}
+
+// Collision guard: ConversableAgent / register_function in a file that imports
+// NEITHER AutoGen line must yield nothing. DiscoverAutoGenAgents and
+// DiscoverAutoGenTools are both import-gated.
+func TestAutoGen_GateExcludesUnimported(t *testing.T) {
+	src := `def ConversableAgent(**kw):
+    return kw
+
+def register_function(fn, **kw):
+    return fn
+
+agent = ConversableAgent(name="x", code_execution_config={"use_docker": False})
+
+def helper(q: str) -> str:
+    """Help."""
+    return q
+
+register_function(helper, name="help")
+`
+	pf := parsePyFile(t, "plain.py", src)
+	if agents := analysis.DiscoverAutoGenAgents([]analysis.ParsedFile{pf}); len(agents) != 0 {
+		t.Errorf("unimported ConversableAgent must not be an AutoGen agent; got %+v", agents)
+	}
+	if tools := analysis.DiscoverAutoGenTools([]analysis.ParsedFile{pf}); len(tools) != 0 {
+		t.Errorf("unimported register_function must not be an AutoGen tool; got %+v", tools)
+	}
+}
+
+// Import-gate boundary: both upstream lines are recognized as SDKAutoGen, but
+// the AG2 dot-boundary (`autogen` / `autogen.`) must NOT be satisfied by a file
+// that imports ONLY the v0.4 root `autogen_agentchat` — that file is still
+// recognized via the v0.4 arm, and the two arms are kept distinct so neither
+// root aliases the other. Each file independently yields the agent.
+func TestAutoGen_ImportGateBoundary(t *testing.T) {
+	// AG2 line: bare `autogen`.
+	ag2 := parsePyFile(t, "ag2.py", `from autogen import AssistantAgent
+a = AssistantAgent(name="a")
+`)
+	// v0.4 line: underscore root only.
+	v04 := parsePyFile(t, "v04.py", `from autogen_agentchat.agents import AssistantAgent
+a = AssistantAgent(name="b")
+`)
+
+	ag2Agents := analysis.DiscoverAutoGenAgents([]analysis.ParsedFile{ag2})
+	if len(ag2Agents) != 1 || ag2Agents[0].SDK != models.SDKAutoGen {
+		t.Fatalf("AG2 file: got %d agents (%+v), want 1 SDKAutoGen", len(ag2Agents), ag2Agents)
+	}
+	v04Agents := analysis.DiscoverAutoGenAgents([]analysis.ParsedFile{v04})
+	if len(v04Agents) != 1 || v04Agents[0].SDK != models.SDKAutoGen {
+		t.Fatalf("v0.4 file: got %d agents (%+v), want 1 SDKAutoGen", len(v04Agents), v04Agents)
+	}
+
+	// A file importing a deceptively-similar package that merely shares the
+	// `autogen` prefix text (no dot boundary) must NOT trip either gate.
+	bogus := parsePyFile(t, "bogus.py", `from autogenx import AssistantAgent
+a = AssistantAgent(name="c")
+`)
+	if got := analysis.DiscoverAutoGenAgents([]analysis.ParsedFile{bogus}); len(got) != 0 {
+		t.Errorf("autogenx (prefix-only, no dot boundary) must not match the AutoGen gate; got %+v", got)
+	}
+}
+
+func keysOf(m map[string]models.ToolDef) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/analysis/autogen_tools.go
+++ b/internal/analysis/autogen_tools.go
@@ -1,0 +1,238 @@
+package analysis
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/trustabl/trustabl/internal/analysis/astutil"
+	"github.com/trustabl/trustabl/internal/models"
+)
+
+// AutoGen / AG2 Python tool discovery.
+//
+// AutoGen registers a plain Python function as a model-callable tool in two
+// shapes, neither of which is a bare-name decorator (so neither flows through
+// discovery.go's kindFromDecorators):
+//
+//  1. register_function(fn, caller=, executor=, name=, description=) — a call
+//     expression. The first positional argument is the function being
+//     registered; name= / description= override its metadata. The
+//     caller/executor two-agent edge is a documented v1 gap and is not resolved.
+//
+//  2. Stacked attribute-call decorators:
+//
+//     @executor.register_for_execution()
+//     @assistant.register_for_llm(name="...", description="...")
+//     def fn(...): ...
+//
+//     The callee is an ATTRIBUTE (`<agentvar>.register_for_llm`), not a bare
+//     name, so kindFromDecorators (which only resolves unqualified tracked
+//     decorator names against imports) does not classify it. This file walks
+//     decorated_definition nodes and emits one ToolDef when any decorator's
+//     callee attribute suffix is register_for_llm / register_for_execution.
+//
+// Both shapes emit ToolDef{Kind: KindAutoGenTool, Language: python} with the
+// Location pointed at the resolved function body, so the body-scanning
+// predicates (has_shell_call / has_code_exec_call / has_dynamic_url_call) find
+// the function to inspect. All discovery is import-gated to files that import an
+// AutoGen line (fileImportsAutoGen).
+
+// autoGenRegisterDecorators is the set of attribute-call decorator suffixes that
+// register a function as an AutoGen tool. register_for_llm advertises the tool to
+// the LLM; register_for_execution wires its execution; either (or both, stacked)
+// marks the decorated function as a tool.
+var autoGenRegisterDecorators = map[string]bool{
+	"register_for_llm":       true,
+	"register_for_execution": true,
+}
+
+// DiscoverAutoGenTools walks each ParsedFile and emits one ToolDef per AutoGen
+// tool registration (register_function call or register_for_llm/_execution
+// decorator). Only files importing an AutoGen line are considered.
+func DiscoverAutoGenTools(files []ParsedFile) []models.ToolDef {
+	var out []models.ToolDef
+	for _, pf := range files {
+		if !fileImportsAutoGen(pf) {
+			continue
+		}
+		out = append(out, discoverAutoGenToolsInFile(pf)...)
+	}
+	return out
+}
+
+func discoverAutoGenToolsInFile(pf ParsedFile) []models.ToolDef {
+	root := pf.Tree.RootNode()
+	funcs := indexTopLevelFunctions(root, pf.Source)
+
+	var out []models.ToolDef
+	seen := map[string]bool{} // dedupe by tool name within a file
+
+	// Shape 2 first: register_for_llm / register_for_execution decorators. A
+	// function carrying either (or both, stacked) yields exactly one ToolDef.
+	for _, dec := range astutil.FindAll(root, "decorated_definition") {
+		fn := astutil.FunctionDef(dec)
+		if fn == nil {
+			continue
+		}
+		var matched bool
+		var description, nameOverride string
+		for _, d := range astutil.Decorators(dec) {
+			callee := decoratorCallee(d, pf.Source)
+			last := callee
+			if i := strings.LastIndex(callee, "."); i >= 0 {
+				last = callee[i+1:]
+			}
+			// Require an attribute callee (`<var>.register_for_llm`), not a bare
+			// `register_for_llm`, so an unqualified same-named local decorator is
+			// not swept up. The dot check is what distinguishes the attribute-call
+			// decorator from kindFromDecorators' bare-name path.
+			if !strings.Contains(callee, ".") || !autoGenRegisterDecorators[last] {
+				continue
+			}
+			matched = true
+			// name= and description= on register_for_llm override the function's
+			// own name and docstring (register_for_execution carries no metadata).
+			if last == "register_for_llm" {
+				if description == "" {
+					if v := decoratorStringKwarg(d, "description", pf.Source); v != "" {
+						description = v
+					}
+				}
+				if nameOverride == "" {
+					if v := decoratorStringKwarg(d, "name", pf.Source); v != "" {
+						nameOverride = v
+					}
+				}
+			}
+		}
+		if !matched {
+			continue
+		}
+		name := nameOverride
+		if name == "" {
+			name = astutil.FunctionName(fn, pf.Source)
+		}
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		if description == "" {
+			description = astutil.FunctionDocstring(fn, pf.Source)
+		}
+		out = append(out, buildAutoGenToolFromFunc(fn, pf, name, description))
+	}
+
+	// Shape 1: register_function(fn, name=, description=, caller=, executor=).
+	astutil.Walk(root, func(n *sitter.Node) bool {
+		if n.Type() != "call" {
+			return true
+		}
+		if astutil.NodeText(n.ChildByFieldName("function"), pf.Source) != "register_function" {
+			return true
+		}
+		wrapped := firstPositionalIdent(n, pf.Source)
+		if wrapped == "" {
+			return true // first arg is a lambda / call / nothing — unresolvable
+		}
+		fnDef, ok := funcs[wrapped]
+		if !ok {
+			return true // not a same-file top-level function
+		}
+		kwargs, _ := extractCallKwargs(n, pf.Source)
+		// name= override > wrapped function name.
+		name := kwargStringLiteral(kwargs, "name")
+		if name == "" {
+			name = wrapped
+		}
+		if seen[name] {
+			return true
+		}
+		seen[name] = true
+		// description= override > wrapped function docstring.
+		description := kwargStringLiteral(kwargs, "description")
+		if description == "" {
+			description = astutil.FunctionDocstring(fnDef, pf.Source)
+		}
+		tool := buildAutoGenToolFromFunc(fnDef, pf, name, description)
+		// Capture remaining constructor kwargs (e.g. api_style=) into Config,
+		// excluding the metadata/edge kwargs already consumed above.
+		if kwargs != nil {
+			cfg := map[string]string{}
+			for k, child := range kwargs.Children {
+				switch k {
+				case "name", "description", "caller", "executor":
+					continue
+				}
+				if child.Value != nil {
+					cfg[k] = child.Value.Text
+				}
+			}
+			if len(cfg) > 0 {
+				tool.Config = cfg
+			}
+		}
+		out = append(out, tool)
+		return true
+	})
+
+	return out
+}
+
+// buildAutoGenToolFromFunc constructs a KindAutoGenTool ToolDef whose Location is
+// the resolved function body, so the AST-walking tool predicates (has_shell_call
+// / has_code_exec_call / has_dynamic_url_call) inspect the function. Mirrors the
+// ADK FunctionTool / LangChain wrapped-function Location convention; the
+// shells_out structural fact is stamped for agent-scope reach checks.
+func buildAutoGenToolFromFunc(fn *sitter.Node, pf ParsedFile, name, description string) models.ToolDef {
+	facts := map[string]string{}
+	if pythonBodyShellsOut(fn, pf.Source) {
+		facts["shells_out"] = "true"
+	}
+	return models.ToolDef{
+		Name:     name,
+		Kind:     models.KindAutoGenTool,
+		Language: models.LanguagePython,
+		Location: models.Location{
+			FilePath: pf.RelPath,
+			Line:     int(fn.StartPoint().Row) + 1,
+			EndLine:  int(fn.EndPoint().Row) + 1,
+		},
+		Description:    description,
+		HasTypedParams: astutil.FunctionHasTypedParams(fn, pf.Source),
+		ParamNames:     toolParamNames(fn, pf.Source),
+		Facts:          facts,
+	}
+}
+
+// decoratorStringKwarg returns the unquoted value of a string-literal keyword
+// argument on a decorator call (e.g. the `description=` in
+// `@x.register_for_llm(description="...")`), or "" when absent or non-literal.
+func decoratorStringKwarg(d *sitter.Node, key string, src []byte) string {
+	if d == nil || d.Type() != "decorator" {
+		return ""
+	}
+	body := d.NamedChild(0)
+	if body == nil || body.Type() != "call" {
+		return ""
+	}
+	args := body.ChildByFieldName("arguments")
+	if args == nil {
+		return ""
+	}
+	for i := 0; i < int(args.ChildCount()); i++ {
+		arg := args.Child(i)
+		if arg.Type() != "keyword_argument" {
+			continue
+		}
+		if astutil.NodeText(arg.ChildByFieldName("name"), src) != key {
+			continue
+		}
+		val := arg.ChildByFieldName("value")
+		if val == nil || val.Type() != "string" {
+			return ""
+		}
+		return strings.Trim(astutil.NodeText(val, src), `"'`)
+	}
+	return ""
+}

--- a/internal/analysis/crewai_agents.go
+++ b/internal/analysis/crewai_agents.go
@@ -1,0 +1,108 @@
+package analysis
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/trustabl/trustabl/internal/analysis/astutil"
+	"github.com/trustabl/trustabl/internal/models"
+)
+
+// CrewAI Python agent discovery.
+//
+// CrewAI declares agents with a single `Agent(role=, goal=, backstory=, tools=,
+// allow_code_execution=, allow_delegation=, ...)` constructor. The class name
+// `Agent` collides with the OpenAI Agents SDK and Google ADK's `Agent` alias, so
+// all discovery is import-gated to files that import the crewai ecosystem
+// (`crewai` / `crewai_tools`). The emitted AgentDef carries SDK=SDKCrewAI and
+// Class="Agent"; agentKindMatches("crewai_agent") keys on BOTH, so an OpenAI
+// Agent and a CrewAI Agent never cross-match even though both have Class "Agent".
+//
+// CrewAI TOOLS are the `@tool` decorator from `crewai.tools` — routed through
+// discovery.go's kindFromDecorators (import-gated via collectToolImports /
+// fileImportsCrewAI), not here. The BaseTool-subclass tool shape is a documented
+// v1 gap (the analog of LangChain's `class X(BaseTool)` gap), as is Crew(...)
+// orchestration discovery.
+
+// crewAIAgentClasses is the closed set of CrewAI agent constructors. CrewAI has a
+// single agent class; the Crew(...) orchestration unit is a documented v1 gap.
+var crewAIAgentClasses = map[string]string{
+	"Agent": "Agent",
+}
+
+// isCrewAIModule reports whether a dotted module path belongs to the CrewAI
+// ecosystem: `crewai`, `crewai.*`, `crewai_tools`, `crewai_tools.*`. The
+// dot/underscore boundary keeps an unrelated package that merely shares the
+// prefix text (e.g. "crewaix") from matching, mirroring isLangChainModule.
+func isCrewAIModule(mod string) bool {
+	return mod == "crewai" || strings.HasPrefix(mod, "crewai.") ||
+		mod == "crewai_tools" || strings.HasPrefix(mod, "crewai_tools.")
+}
+
+// fileImportsCrewAI reports whether pf imports the CrewAI ecosystem via a real
+// import statement (AST-based, not a source substring — a comment that merely
+// mentions crewai must not trip the gate).
+func fileImportsCrewAI(pf ParsedFile) bool {
+	return fileImportsModule(pf, isCrewAIModule)
+}
+
+// DiscoverCrewAIAgents walks each ParsedFile and emits one AgentDef per
+// recognized CrewAI Agent(...) constructor call. Only files importing the crewai
+// ecosystem are considered (the import gate disambiguates `Agent` from the
+// OpenAI and ADK classes of the same name).
+func DiscoverCrewAIAgents(files []ParsedFile) []models.AgentDef {
+	var out []models.AgentDef
+	for _, pf := range files {
+		if !fileImportsCrewAI(pf) {
+			continue
+		}
+		out = append(out, discoverCrewAIAgentsInFile(pf)...)
+	}
+	return out
+}
+
+func discoverCrewAIAgentsInFile(pf ParsedFile) []models.AgentDef {
+	var out []models.AgentDef
+	astutil.Walk(pf.Tree.RootNode(), func(n *sitter.Node) bool {
+		if n.Type() != "call" {
+			return true
+		}
+		callee := astutil.NodeText(n.ChildByFieldName("function"), pf.Source)
+		class, ok := crewAIAgentClasses[callee]
+		if !ok {
+			return true
+		}
+		kwargs, opaque := extractCallKwargs(n, pf.Source)
+		a := models.AgentDef{
+			SDK:      models.SDKCrewAI,
+			Class:    class,
+			Language: models.LanguagePython,
+			Location: models.Location{
+				FilePath: pf.RelPath,
+				Line:     int(n.StartPoint().Row) + 1,
+				EndLine:  int(n.EndPoint().Row) + 1,
+			},
+			Kwargs: kwargs,
+			Opaque: opaque,
+		}
+		// CrewAI agents have no name= kwarg; the human-facing label is role=.
+		// Fall back to the assignment-target variable when role= is absent or
+		// not a string literal.
+		if nm := kwargStringLiteral(kwargs, "name"); nm != "" {
+			a.Name = nm
+		} else if role := kwargStringLiteral(kwargs, "role"); role != "" {
+			a.Name = role
+		}
+		// Capture the assignment-target identifier (researcher = Agent(...)) so
+		// tools=[...] and delegation references resolve by variable name.
+		if p := n.Parent(); p != nil && p.Type() == "assignment" {
+			if l := p.ChildByFieldName("left"); l != nil && l.Type() == "identifier" {
+				a.VarName = astutil.NodeText(l, pf.Source)
+			}
+		}
+		out = append(out, a)
+		return true
+	})
+	return out
+}

--- a/internal/analysis/crewai_agents_test.go
+++ b/internal/analysis/crewai_agents_test.go
@@ -1,0 +1,131 @@
+package analysis_test
+
+import (
+	"testing"
+
+	"github.com/trustabl/trustabl/internal/analysis"
+	"github.com/trustabl/trustabl/internal/models"
+)
+
+// A CrewAI Agent(...) in a file that imports `crewai` is emitted as one AgentDef
+// with SDK=SDKCrewAI, Class="Agent", and its constructor kwargs captured so the
+// agent-scope rules (CREW-101/102/104) can read allow_code_execution etc.
+func TestCrewAIAgent_ConstructorCaptured(t *testing.T) {
+	src := `from crewai import Agent
+
+researcher = Agent(
+    role="Researcher",
+    goal="Find facts",
+    backstory="An expert.",
+    allow_code_execution=True,
+)
+`
+	pf := parsePyFile(t, "crew.py", src)
+	agents := analysis.DiscoverCrewAIAgents([]analysis.ParsedFile{pf})
+	if len(agents) != 1 {
+		t.Fatalf("got %d agents, want 1", len(agents))
+	}
+	a := agents[0]
+	if a.SDK != models.SDKCrewAI {
+		t.Errorf("SDK: got %q, want %q", a.SDK, models.SDKCrewAI)
+	}
+	if a.Class != "Agent" {
+		t.Errorf("Class: got %q, want Agent", a.Class)
+	}
+	if a.Language != models.LanguagePython {
+		t.Errorf("Language: got %q, want python", a.Language)
+	}
+	if a.VarName != "researcher" {
+		t.Errorf("VarName: got %q, want researcher", a.VarName)
+	}
+	// role= is the human-facing label; discovery falls back to it for Name.
+	if a.Name != "Researcher" {
+		t.Errorf("Name: got %q, want Researcher", a.Name)
+	}
+	kw := a.Kwargs.Children["allow_code_execution"]
+	if kw == nil || kw.Value == nil {
+		t.Fatalf("allow_code_execution kwarg not captured: %+v", a.Kwargs)
+	}
+	if kw.Value.Text != "True" {
+		t.Errorf("allow_code_execution value: got %q, want True", kw.Value.Text)
+	}
+}
+
+// The `@tool` decorator imported from `crewai.tools` is discovered as a
+// KindCrewAITool ToolDef via the shared decorator path (import-gated).
+func TestCrewAITool_DecoratorDiscovered(t *testing.T) {
+	src := `from crewai.tools import tool
+
+@tool("search")
+def search(q: str) -> str:
+    """Search the web."""
+    return q
+`
+	pf := parsePyFile(t, "tools.py", src)
+	tools := analysis.DiscoverToolsFromParsed([]analysis.ParsedFile{pf})
+	if len(tools) != 1 {
+		t.Fatalf("got %d tools, want 1", len(tools))
+	}
+	tool := tools[0]
+	if tool.Kind != models.KindCrewAITool {
+		t.Errorf("Kind: got %q, want %q", tool.Kind, models.KindCrewAITool)
+	}
+	if tool.Language != models.LanguagePython {
+		t.Errorf("Language: got %q, want python", tool.Language)
+	}
+	if tool.Name != "search" {
+		t.Errorf("Name: got %q, want search", tool.Name)
+	}
+}
+
+// Collision guard: the class name `Agent` and the bare `@tool` decorator are
+// shared with other SDKs, so a file that imports NEITHER crewai nor another
+// agent SDK must not yield any CrewAI agent or tool. DiscoverCrewAIAgents is
+// import-gated, so it emits nothing; the bare @tool falls through to the
+// historical Claude-SDK default (not crewai).
+func TestCrewAIAgent_GateExcludesUnimported(t *testing.T) {
+	src := `def Agent(**kw):
+    return kw
+
+def tool(fn):
+    return fn
+
+planner = Agent(role="x", allow_code_execution=True)
+
+@tool
+def helper(q: str) -> str:
+    """Help."""
+    return q
+`
+	pf := parsePyFile(t, "plain.py", src)
+	if agents := analysis.DiscoverCrewAIAgents([]analysis.ParsedFile{pf}); len(agents) != 0 {
+		t.Errorf("unimported Agent must not be a CrewAI agent; got %+v", agents)
+	}
+	for _, tl := range analysis.DiscoverToolsFromParsed([]analysis.ParsedFile{pf}) {
+		if tl.Kind == models.KindCrewAITool {
+			t.Errorf("unimported @tool must not be a CrewAI tool; got %+v", tl)
+		}
+	}
+}
+
+// Collision guard, the other direction: an `Agent(...)` in a file importing the
+// OpenAI Agents SDK (`from agents import Agent`) stays an OpenAI agent and is
+// never re-attributed to CrewAI. DiscoverCrewAIAgents (import-gated to crewai)
+// emits nothing for it, and DiscoverAgents keeps it as SDKOpenAIAgents.
+func TestCrewAIAgent_DoesNotClaimOpenAIAgent(t *testing.T) {
+	src := `from agents import Agent
+
+agent = Agent(name="ops", instructions="Run ops.", model="gpt-4")
+`
+	pf := parsePyFile(t, "oai.py", src)
+	if crew := analysis.DiscoverCrewAIAgents([]analysis.ParsedFile{pf}); len(crew) != 0 {
+		t.Errorf("OpenAI Agent must not be discovered as CrewAI; got %+v", crew)
+	}
+	oai := analysis.DiscoverAgents([]analysis.ParsedFile{pf})
+	if len(oai) != 1 {
+		t.Fatalf("got %d OpenAI agents, want 1", len(oai))
+	}
+	if oai[0].SDK != models.SDKOpenAIAgents {
+		t.Errorf("SDK: got %q, want %q", oai[0].SDK, models.SDKOpenAIAgents)
+	}
+}

--- a/internal/analysis/crewai_hosted_tools.go
+++ b/internal/analysis/crewai_hosted_tools.go
@@ -1,0 +1,64 @@
+package analysis
+
+import "github.com/trustabl/trustabl/internal/models"
+
+// CrewAIHostedToolClasses is the set of CrewAI built-in / crewai_tools tool
+// classes that represent high-risk capabilities: model-driven code execution
+// (CodeInterpreterTool), unconstrained filesystem read/write (FileReadTool,
+// FileWriterTool, DirectoryReadTool, DirectorySearchTool), and tools that fetch
+// model-chosen URLs (ScrapeWebsiteTool, SeleniumScrapingTool, WebsiteSearchTool,
+// SerperDevTool, JSONSearchTool, PDFSearchTool, CSVSearchTool). Benign built-ins
+// are intentionally omitted so a match is always a meaningful security signal.
+//
+// They are recognized when they appear in a CrewAI agent's tools=[...] list and
+// emitted as HostedToolDef edges, so the agent-scope rules CREW-103 / CREW-106 /
+// CREW-107 can flag the capability. FileWriteTool is the older spelling of
+// FileWriterTool; both are listed so a rename in the (archived) crewai_tools repo
+// stays covered.
+var CrewAIHostedToolClasses = map[string]bool{
+	"CodeInterpreterTool":  true,
+	"FileReadTool":         true,
+	"FileWriterTool":       true,
+	"FileWriteTool":        true,
+	"DirectoryReadTool":    true,
+	"DirectorySearchTool":  true,
+	"ScrapeWebsiteTool":    true,
+	"SeleniumScrapingTool": true,
+	"WebsiteSearchTool":    true,
+	"SerperDevTool":        true,
+	"JSONSearchTool":       true,
+	"PDFSearchTool":        true,
+	"CSVSearchTool":        true,
+}
+
+// IsCrewAIHostedToolClass reports whether className is a recognized high-risk
+// CrewAI built-in tool class.
+func IsCrewAIHostedToolClass(className string) bool {
+	return CrewAIHostedToolClasses[className]
+}
+
+// classifyCrewAIHostedToolCall inspects an ExprCall item from a CrewAI agent's
+// tools=[...] list and returns a HostedToolDef + true when the callee names a
+// recognized high-risk built-in tool class. Mirrors
+// classifyLangChainHostedToolCall; the HostedToolDef.SDK is stamped SDKCrewAI so
+// a CrewAI CodeInterpreterTool and the OpenAI hosted tool of the same name are
+// evaluated by different rules (CREW-103 only fires against crewai_agent).
+func classifyCrewAIHostedToolCall(callItem models.Expr, filePath string) (models.HostedToolDef, bool) {
+	if callItem.Kind != models.ExprCall {
+		return models.HostedToolDef{}, false
+	}
+	name := calleeName(callItem.Text)
+	if !IsCrewAIHostedToolClass(name) {
+		return models.HostedToolDef{}, false
+	}
+	return models.HostedToolDef{
+		Class: name,
+		SDK:   models.SDKCrewAI,
+		Location: models.Location{
+			FilePath: filePath,
+			Line:     callItem.Line,
+			EndLine:  callItem.EndLine,
+		},
+		Kwargs: hostedKwargTree(callItem),
+	}, true
+}

--- a/internal/analysis/discovery.go
+++ b/internal/analysis/discovery.go
@@ -100,6 +100,8 @@ func toolsInFile(pf ParsedFile) []models.ToolDef {
 	toolImports := collectToolImports(pf)
 	lcImport := fileImportsLangChain(pf)
 	claudeImport := fileImportsClaudeSDK(pf)
+	crewaiImport := fileImportsCrewAI(pf)
+	pydanticImport := fileImportsPydanticAI(pf)
 
 	// Pass 1: decorated functions.
 	for _, dec := range astutil.FindAll(root, "decorated_definition") {
@@ -107,7 +109,7 @@ func toolsInFile(pf ParsedFile) []models.ToolDef {
 		if fn == nil {
 			continue
 		}
-		kind := kindFromDecorators(astutil.Decorators(dec), pf.Source, toolImports, lcImport, claudeImport)
+		kind := kindFromDecorators(astutil.Decorators(dec), pf.Source, toolImports, lcImport, claudeImport, crewaiImport, pydanticImport)
 		if kind == models.KindUnknown {
 			continue
 		}
@@ -146,7 +148,7 @@ func toolsInFile(pf ParsedFile) []models.ToolDef {
 // Order matters: @function_tool is OpenAI Agents SDK and is checked before
 // the more permissive "@tool" Claude SDK match (which would otherwise swallow
 // "@function_tool" via substring).
-func kindFromDecorators(decs []*sitter.Node, src []byte, toolImports map[string]models.ToolKind, lcImport, claudeImport bool) models.ToolKind {
+func kindFromDecorators(decs []*sitter.Node, src []byte, toolImports map[string]models.ToolKind, lcImport, claudeImport, crewaiImport, pydanticImport bool) models.ToolKind {
 	for _, d := range decs {
 		// Match on the decorator's resolved callee path (e.g. "function_tool",
 		// "agent.tool", "server.tool", "app.register_tool"), not a substring of
@@ -161,6 +163,19 @@ func kindFromDecorators(decs []*sitter.Node, src []byte, toolImports map[string]
 		last := callee
 		if i := strings.LastIndex(callee, "."); i >= 0 {
 			last = callee[i+1:]
+		}
+		// Pydantic AI context tools use ATTRIBUTE decorators on the agent var:
+		// `@agent.tool` (takes a leading RunContext) and `@agent.tool_plain` (no
+		// ctx). The callee is dotted (`<agentvar>.tool`), and `tool`/`tool_plain`
+		// as the attribute suffix is Pydantic's shape. This must route to
+		// KindPydanticAITool ONLY when the file imports pydantic_ai and does NOT
+		// import the Claude SDK — the `&& !claudeImport` guard is load-bearing:
+		// the Claude SDK also exposes an `@agent.tool`, so a Claude-only file (and
+		// a file importing BOTH) must fall through to the `callee == "agent.tool"`
+		// switch case below, which keeps it KindClaudeSDKTool (claude wins).
+		if strings.Contains(callee, ".") && (last == "tool" || last == "tool_plain") &&
+			pydanticImport && !claudeImport {
+			return models.KindPydanticAITool
 		}
 		// Precise resolution first: an UNQUALIFIED decorator name that was bound by
 		// an explicit import resolves to that import's SDK. This is the exact
@@ -182,11 +197,17 @@ func kindFromDecorators(decs []*sitter.Node, src []byte, toolImports map[string]
 		// pre-1.0. Expand this list as the SDK stabilizes.
 		case callee == "tool":
 			// Bare @tool that no import resolved (a star-import or a locally
-			// defined `tool`): fall back to file-level presence — a
-			// langchain-importing file that does not import the Claude SDK routes
-			// to LangChain; otherwise the historical Claude default holds.
-			if lcImport && !claudeImport {
+			// defined `tool`): fall back to file-level import presence. A file
+			// that imports exactly one of the @tool-exporting SDKs routes there;
+			// the historical Claude default holds when none — or more than one —
+			// are present. The extra !crewaiImport / !lcImport guards are no-ops
+			// for existing repos (those flags were always false before CrewAI),
+			// so this only adds the new CrewAI arm without changing prior routing.
+			if lcImport && !claudeImport && !crewaiImport {
 				return models.KindLangChainTool
+			}
+			if crewaiImport && !claudeImport && !lcImport {
+				return models.KindCrewAITool
 			}
 			return models.KindClaudeSDKTool
 		case callee == "claude_tool" || last == "claude_tool",
@@ -226,6 +247,8 @@ func collectToolImports(pf ParsedFile) map[string]models.ToolKind {
 		switch {
 		case isLangChainModule(module):
 			sdk = models.KindLangChainTool
+		case isCrewAIModule(module):
+			sdk = models.KindCrewAITool
 		case module == "claude_agent_sdk" || strings.HasPrefix(module, "claude_agent_sdk."):
 			sdk = models.KindClaudeSDKTool
 		default:

--- a/internal/analysis/heuristics.go
+++ b/internal/analysis/heuristics.go
@@ -12,25 +12,41 @@ import (
 // FindFunctionNode locates the function_definition node for a tool inside its
 // parsed file. Detectors and rule predicates carry only positions; storing
 // nodes in ToolDef would couple JSON serialization to tree-sitter internals.
+//
+// Matching is primarily by START LINE, which uniquely identifies a
+// function_definition (two defs cannot begin on the same line). The tool Name is
+// used only as a tie-break/confirmation when it matches the def's name; when a
+// tool was registered under a name= override that differs from the function name
+// (e.g. AutoGen register_function(fn, name="x") or a LangChain factory name=),
+// the line still resolves the body so the body-scan predicates (has_shell_call,
+// has_code_exec_call, has_dynamic_url_call, call_without_kwarg) keep working. A
+// line-only fallback cannot misfire: the line is unique, and a non-zero
+// disagreement on name does not point at a different function.
 func FindFunctionNode(t models.ToolDef, pf ParsedFile) *sitter.Node {
 	if pf.Tree == nil {
 		return nil
 	}
-	var match *sitter.Node
+	var lineMatch *sitter.Node
 	astutil.Walk(pf.Tree.RootNode(), func(n *sitter.Node) bool {
-		if match != nil {
-			return false
-		}
 		if n.Type() != "function_definition" {
 			return true
 		}
-		if astutil.NodeLine(n) == t.Line && astutil.FunctionName(n, pf.Source) == t.Name {
-			match = n
+		if astutil.NodeLine(n) != t.Line {
+			return true
+		}
+		// Same line: an exact name match is the confident hit; return it. A
+		// name mismatch (name= override) still resolves via the line, recorded
+		// as a fallback in case no exact-name def shares this line.
+		if astutil.FunctionName(n, pf.Source) == t.Name {
+			lineMatch = n
 			return false
+		}
+		if lineMatch == nil {
+			lineMatch = n
 		}
 		return true
 	})
-	return match
+	return lineMatch
 }
 
 // IsHTTPCall returns true if the literal callee text matches a known HTTP

--- a/internal/analysis/pydantic_ai_agents.go
+++ b/internal/analysis/pydantic_ai_agents.go
@@ -1,0 +1,109 @@
+package analysis
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/trustabl/trustabl/internal/analysis/astutil"
+	"github.com/trustabl/trustabl/internal/models"
+)
+
+// Pydantic AI Python agent discovery.
+//
+// Pydantic AI declares an agent with a single `Agent(model, output_type=,
+// system_prompt=, instructions=, tools=, retries=, end_strategy=, ...)`
+// constructor. The class name `Agent` collides with the OpenAI Agents SDK,
+// Google ADK, and CrewAI's `Agent`, so all discovery is import-gated to files
+// that import `pydantic_ai`. The emitted AgentDef carries SDK=SDKPydanticAI and
+// the normalized Class "PydanticAgent" (the upstream class is `Agent`, but the
+// stamped name disambiguates it from the other SDKs' `Agent`);
+// agentKindMatches("pydantic_ai_agent") keys on BOTH SDK and Class, so a
+// Pydantic Agent and an OpenAI/ADK/CrewAI Agent never cross-match even though
+// the source token is identical.
+//
+// Pydantic TOOLS are the `@<agentvar>.tool` / `@<agentvar>.tool_plain` attribute
+// decorators (routed through discovery.go's kindFromDecorators, import-gated via
+// fileImportsPydanticAI / !fileImportsClaudeSDK) and the `Tool(fn, ...)` factory
+// (pydantic_ai_tools.go). The bare-function `tools=[fn]` ToolDef-synthesis shape
+// is a documented v1 gap (the agent edge still works via the tools= kwarg).
+
+// pydanticAIAgentClasses is the closed set of Pydantic AI agent constructors.
+// Pydantic AI has a single agent class. The source token is `Agent`; the value
+// is the normalized Class name stamped on AgentDef.Class.
+var pydanticAIAgentClasses = map[string]string{
+	"Agent": "PydanticAgent",
+}
+
+// isPydanticAIModule reports whether a dotted module path belongs to the
+// Pydantic AI ecosystem: `pydantic_ai`, `pydantic_ai.*`. The dot boundary keeps
+// an unrelated package that merely shares the prefix text (e.g. "pydantic_aix")
+// from matching, mirroring isCrewAIModule.
+func isPydanticAIModule(mod string) bool {
+	return mod == "pydantic_ai" || strings.HasPrefix(mod, "pydantic_ai.")
+}
+
+// fileImportsPydanticAI reports whether pf imports the Pydantic AI ecosystem via
+// a real import statement (AST-based, not a source substring — a comment that
+// merely mentions pydantic_ai must not trip the gate).
+func fileImportsPydanticAI(pf ParsedFile) bool {
+	return fileImportsModule(pf, isPydanticAIModule)
+}
+
+// DiscoverPydanticAIAgents walks each ParsedFile and emits one AgentDef per
+// recognized Pydantic AI Agent(...) constructor call. Only files importing
+// pydantic_ai are considered (the import gate disambiguates `Agent` from the
+// OpenAI, ADK, and CrewAI classes of the same name).
+func DiscoverPydanticAIAgents(files []ParsedFile) []models.AgentDef {
+	var out []models.AgentDef
+	for _, pf := range files {
+		if !fileImportsPydanticAI(pf) {
+			continue
+		}
+		out = append(out, discoverPydanticAIAgentsInFile(pf)...)
+	}
+	return out
+}
+
+func discoverPydanticAIAgentsInFile(pf ParsedFile) []models.AgentDef {
+	var out []models.AgentDef
+	astutil.Walk(pf.Tree.RootNode(), func(n *sitter.Node) bool {
+		if n.Type() != "call" {
+			return true
+		}
+		callee := astutil.NodeText(n.ChildByFieldName("function"), pf.Source)
+		class, ok := pydanticAIAgentClasses[callee]
+		if !ok {
+			return true
+		}
+		kwargs, opaque := extractCallKwargs(n, pf.Source)
+		a := models.AgentDef{
+			SDK:      models.SDKPydanticAI,
+			Class:    class,
+			Language: models.LanguagePython,
+			Location: models.Location{
+				FilePath: pf.RelPath,
+				Line:     int(n.StartPoint().Row) + 1,
+				EndLine:  int(n.EndPoint().Row) + 1,
+			},
+			Kwargs: kwargs,
+			Opaque: opaque,
+		}
+		// Pydantic agents may carry a name= string literal; capture it as the
+		// human-facing label.
+		if nm := kwargStringLiteral(kwargs, "name"); nm != "" {
+			a.Name = nm
+		}
+		// Capture the assignment-target identifier (agent = Agent(...)) so the
+		// @agent.tool decorator owner and tools=[...] references resolve by
+		// variable name.
+		if p := n.Parent(); p != nil && p.Type() == "assignment" {
+			if l := p.ChildByFieldName("left"); l != nil && l.Type() == "identifier" {
+				a.VarName = astutil.NodeText(l, pf.Source)
+			}
+		}
+		out = append(out, a)
+		return true
+	})
+	return out
+}

--- a/internal/analysis/pydantic_ai_agents_test.go
+++ b/internal/analysis/pydantic_ai_agents_test.go
@@ -1,0 +1,123 @@
+package analysis_test
+
+import (
+	"testing"
+
+	"github.com/trustabl/trustabl/internal/analysis"
+	"github.com/trustabl/trustabl/internal/models"
+)
+
+// A Pydantic AI Agent(...) in a file that imports pydantic_ai is emitted as one
+// AgentDef with SDK=SDKPydanticAI, the normalized Class "PydanticAgent", and its
+// constructor kwargs captured so the agent-scope rules (PYD-101/105) can read
+// output_type / end_strategy.
+func TestPydanticAIAgent_ConstructorCaptured(t *testing.T) {
+	src := `from pydantic_ai import Agent
+
+agent = Agent(
+    "openai:gpt-4o",
+    name="assistant",
+    output_type=str,
+    end_strategy="exhaustive",
+)
+`
+	pf := parsePyFile(t, "agent.py", src)
+	agents := analysis.DiscoverPydanticAIAgents([]analysis.ParsedFile{pf})
+	if len(agents) != 1 {
+		t.Fatalf("got %d agents, want 1", len(agents))
+	}
+	a := agents[0]
+	if a.SDK != models.SDKPydanticAI {
+		t.Errorf("SDK: got %q, want %q", a.SDK, models.SDKPydanticAI)
+	}
+	if a.Class != "PydanticAgent" {
+		t.Errorf("Class: got %q, want PydanticAgent", a.Class)
+	}
+	if a.Language != models.LanguagePython {
+		t.Errorf("Language: got %q, want python", a.Language)
+	}
+	if a.VarName != "agent" {
+		t.Errorf("VarName: got %q, want agent", a.VarName)
+	}
+	if a.Name != "assistant" {
+		t.Errorf("Name: got %q, want assistant", a.Name)
+	}
+	if kw := a.Kwargs.Children["end_strategy"]; kw == nil || kw.Value == nil || kw.Value.Text != `"exhaustive"` {
+		t.Fatalf("end_strategy kwarg not captured: %+v", a.Kwargs)
+	}
+}
+
+// Collision guard: the class name `Agent` is shared with OpenAI/ADK/CrewAI, so
+// an `Agent(...)` in a file that does NOT import pydantic_ai must not be
+// discovered as a PydanticAgent. DiscoverPydanticAIAgents is import-gated, so it
+// emits nothing here.
+func TestPydanticAIAgent_GateExcludesUnimported(t *testing.T) {
+	src := `from agents import Agent
+
+agent = Agent(name="ops", instructions="Run ops.", model="gpt-4")
+`
+	pf := parsePyFile(t, "oai.py", src)
+	if pyd := analysis.DiscoverPydanticAIAgents([]analysis.ParsedFile{pf}); len(pyd) != 0 {
+		t.Errorf("non-pydantic Agent must not be a PydanticAgent; got %+v", pyd)
+	}
+	// And the OpenAI discovery still claims it as an OpenAI agent.
+	oai := analysis.DiscoverAgents([]analysis.ParsedFile{pf})
+	if len(oai) != 1 || oai[0].SDK != models.SDKOpenAIAgents {
+		t.Errorf("OpenAI Agent must stay SDKOpenAIAgents; got %+v", oai)
+	}
+}
+
+// NativeTool-unwrap (modern form): a Pydantic agent wired with
+// capabilities=[NativeTool(CodeExecutionTool())] must surface a HostedToolRef
+// whose Class is the UNWRAPPED inner class CodeExecutionTool (not NativeTool),
+// stamped SDKPydanticAI. This is the load-bearing unwrap in
+// classifyPydanticAIHostedToolCall.
+func TestResolveEdges_PydanticNativeToolUnwrap(t *testing.T) {
+	src := `from pydantic_ai import Agent, NativeTool, CodeExecutionTool
+
+agent = Agent(
+    "openai:gpt-4o",
+    capabilities=[NativeTool(CodeExecutionTool())],
+)
+`
+	pf := parsePyFile(t, "native.py", src)
+	inv := models.RepoInventory{Agents: analysis.DiscoverPydanticAIAgents([]analysis.ParsedFile{pf})}
+	analysis.ResolveEdges(&inv, []analysis.ParsedFile{pf})
+
+	if len(inv.Agents) != 1 {
+		t.Fatalf("got %d agents, want 1", len(inv.Agents))
+	}
+	a := inv.Agents[0]
+	if len(a.HostedToolRefs) != 1 {
+		t.Fatalf("HostedToolRefs: got %d, want 1 (%+v)", len(a.HostedToolRefs), a.HostedToolRefs)
+	}
+	if a.HostedToolRefs[0].Class != "CodeExecutionTool" {
+		t.Errorf("HostedToolRef class: got %q, want CodeExecutionTool (NativeTool wrapper must be unwrapped)", a.HostedToolRefs[0].Class)
+	}
+	if len(inv.HostedTools) != 1 || inv.HostedTools[0].SDK != models.SDKPydanticAI {
+		t.Errorf("inv.HostedTools: got %+v, want one SDKPydanticAI entry", inv.HostedTools)
+	}
+}
+
+// Legacy form: builtin_tools=[WebFetchTool()] (no NativeTool wrapper) is also
+// classified, proving both kwargs are scanned and the unwrap is optional.
+func TestResolveEdges_PydanticBuiltinToolsLegacy(t *testing.T) {
+	src := `from pydantic_ai import Agent, WebFetchTool
+
+agent = Agent(
+    "openai:gpt-4o",
+    builtin_tools=[WebFetchTool()],
+)
+`
+	pf := parsePyFile(t, "legacy.py", src)
+	inv := models.RepoInventory{Agents: analysis.DiscoverPydanticAIAgents([]analysis.ParsedFile{pf})}
+	analysis.ResolveEdges(&inv, []analysis.ParsedFile{pf})
+
+	if len(inv.Agents) != 1 {
+		t.Fatalf("got %d agents, want 1", len(inv.Agents))
+	}
+	a := inv.Agents[0]
+	if len(a.HostedToolRefs) != 1 || a.HostedToolRefs[0].Class != "WebFetchTool" {
+		t.Errorf("HostedToolRefs: got %+v, want one WebFetchTool", a.HostedToolRefs)
+	}
+}

--- a/internal/analysis/pydantic_ai_hosted_tools.go
+++ b/internal/analysis/pydantic_ai_hosted_tools.go
@@ -1,0 +1,96 @@
+package analysis
+
+import (
+	"strings"
+
+	"github.com/trustabl/trustabl/internal/models"
+)
+
+// Pydantic AI built-in (native) tool discovery.
+//
+// Pydantic AI ships provider-native tools — code execution, web fetch, URL
+// context, web search — that the model can invoke directly. The dangerous
+// subset (model-driven code execution and model-chosen URL fetching) is
+// recognized so the agent-scope rules PYD-102 / PYD-103 can flag the
+// capability. Benign provider tools are intentionally omitted so a match is
+// always a meaningful security signal.
+//
+// Native tools are wired onto an agent in two shapes:
+//
+//	capabilities=[NativeTool(CodeExecutionTool())]   (modern wrapper form)
+//	builtin_tools=[CodeExecutionTool()]              (legacy direct form)
+//
+// They live under the `capabilities=` and `builtin_tools=` kwargs, NOT the
+// generic `tools=` list, so ResolveEdges scans those two kwargs for Pydantic
+// agents. The modern form wraps the tool in a NativeTool(...) call;
+// classifyPydanticAIHostedToolCall unwraps that wrapper and classifies the inner
+// class.
+
+// PydanticAIHostedToolClasses is the dangerous subset of Pydantic AI native
+// tool classes: CodeExecutionTool runs model-generated code; WebFetchTool /
+// UrlContextTool / WebSearchTool fetch model-chosen URLs (the SSRF and
+// data-exfiltration surface). Benign native tools are deliberately excluded.
+var PydanticAIHostedToolClasses = map[string]bool{
+	"CodeExecutionTool": true,
+	"WebFetchTool":      true,
+	"UrlContextTool":    true,
+	"WebSearchTool":     true,
+}
+
+// IsPydanticAIHostedToolClass reports whether className is a recognized
+// high-risk Pydantic AI native tool class.
+func IsPydanticAIHostedToolClass(className string) bool {
+	return PydanticAIHostedToolClasses[className]
+}
+
+// nativeToolInnerClass unwraps a `NativeTool(<inner>())` wrapper and returns the
+// inner tool class name. Pydantic's modern native-tool form wraps the tool class
+// in a NativeTool(...) call (`NativeTool(CodeExecutionTool())`), so the list
+// item's own callee is NativeTool, not the tool class — the classifier must
+// descend one level. Returns ("", false) when text is not a NativeTool(...)
+// wrapper.
+func nativeToolInnerClass(text string) (string, bool) {
+	const prefix = "NativeTool("
+	if !strings.HasPrefix(text, prefix) || !strings.HasSuffix(text, ")") {
+		return "", false
+	}
+	inner := strings.TrimSpace(text[len(prefix) : len(text)-1])
+	if inner == "" {
+		return "", false
+	}
+	// inner is the wrapped call (e.g. "CodeExecutionTool()" or
+	// "tools.CodeExecutionTool(timeout=30)"); calleeName strips the arg list and
+	// any module/attribute qualifier down to the bare class name.
+	return calleeName(inner), true
+}
+
+// classifyPydanticAIHostedToolCall inspects an ExprCall item from a Pydantic
+// agent's capabilities=[...] or builtin_tools=[...] list and returns a
+// HostedToolDef + true when the callee (or, for the NativeTool(...) wrapper, the
+// inner call) names a recognized high-risk native tool class. Mirrors
+// classifyCrewAIHostedToolCall; the HostedToolDef.SDK is stamped SDKPydanticAI
+// so a Pydantic CodeExecutionTool and the OpenAI hosted tool of the same name
+// are evaluated by different rules (PYD-102 only fires against pydantic_ai_agent).
+func classifyPydanticAIHostedToolCall(callItem models.Expr, filePath string) (models.HostedToolDef, bool) {
+	if callItem.Kind != models.ExprCall {
+		return models.HostedToolDef{}, false
+	}
+	name := calleeName(callItem.Text)
+	// Unwrap the modern NativeTool(...) wrapper to the inner tool class.
+	if inner, ok := nativeToolInnerClass(callItem.Text); ok {
+		name = inner
+	}
+	if !IsPydanticAIHostedToolClass(name) {
+		return models.HostedToolDef{}, false
+	}
+	return models.HostedToolDef{
+		Class: name,
+		SDK:   models.SDKPydanticAI,
+		Location: models.Location{
+			FilePath: filePath,
+			Line:     callItem.Line,
+			EndLine:  callItem.EndLine,
+		},
+		Kwargs: hostedKwargTree(callItem),
+	}, true
+}

--- a/internal/analysis/pydantic_ai_tools.go
+++ b/internal/analysis/pydantic_ai_tools.go
@@ -1,0 +1,155 @@
+package analysis
+
+import (
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/trustabl/trustabl/internal/analysis/astutil"
+	"github.com/trustabl/trustabl/internal/models"
+)
+
+// Pydantic AI Python tool discovery (non-decorator factory shape).
+//
+// The `@<agentvar>.tool` / `@<agentvar>.tool_plain` attribute decorators are
+// handled in discovery.go's kindFromDecorators (import-gated, with the Claude
+// SDK winning the `@agent.tool` collision). This file handles the NON-decorator
+// `Tool(...)` factory, a plain call expression:
+//
+//	Tool(fn, takes_ctx=False, requires_approval=False, name="...", description="...")
+//
+// The first positional argument is the function being registered; explicit
+// name= / description= kwargs override its metadata. Discovery is gated on
+// fileImportsPydanticAI AND NOT fileImportsLangChain: LangChain ships an
+// identically-named `Tool(...)` factory (langChainToolFactories), and a file
+// importing both SDKs must not double-emit the same call — LangChain's gate
+// wins there, exactly as the Claude SDK wins the @agent.tool decorator
+// collision. The bare-function `tools=[fn]` ToolDef-synthesis shape is a
+// documented v1 gap (the agent edge still works via the tools= kwarg).
+
+// DiscoverPydanticAITools walks each ParsedFile and emits one ToolDef per
+// recognized Pydantic AI Tool(...) factory call. Only files importing
+// pydantic_ai (and not the LangChain ecosystem, which owns the colliding
+// Tool(...) name) are considered.
+func DiscoverPydanticAITools(files []ParsedFile) []models.ToolDef {
+	var out []models.ToolDef
+	for _, pf := range files {
+		if !fileImportsPydanticAI(pf) || fileImportsLangChain(pf) {
+			continue
+		}
+		out = append(out, discoverPydanticAIToolsInFile(pf)...)
+	}
+	return out
+}
+
+func discoverPydanticAIToolsInFile(pf ParsedFile) []models.ToolDef {
+	root := pf.Tree.RootNode()
+	funcs := indexTopLevelFunctions(root, pf.Source)
+
+	var out []models.ToolDef
+	astutil.Walk(root, func(n *sitter.Node) bool {
+		if n.Type() != "call" {
+			return true
+		}
+		if astutil.NodeText(n.ChildByFieldName("function"), pf.Source) != "Tool" {
+			return true
+		}
+		if tool, ok := buildPydanticAITool(n, pf, funcs); ok {
+			out = append(out, tool)
+		}
+		return true
+	})
+	return out
+}
+
+// buildPydanticAITool extracts a ToolDef from a Pydantic AI `Tool(fn, ...)`
+// factory call. It resolves the first positional ident to a same-file function
+// (mirroring buildLangChainTool's from_function resolution) to recover the
+// docstring, parameter typing, and shell-out fact; explicit name= / description=
+// kwargs override the wrapped function's values. The Location points at the
+// resolved function body so the AST-walking predicates (has_shell_call /
+// has_code_exec_call / has_dynamic_url_call) find the body to scan. Returns
+// ok=false when no tool name can be determined.
+func buildPydanticAITool(n *sitter.Node, pf ParsedFile, funcs map[string]*sitter.Node) (models.ToolDef, bool) {
+	kwargs, _ := extractCallKwargs(n, pf.Source)
+
+	// Resolve the wrapped function symbol: the first positional argument.
+	wrappedName := firstPositionalIdent(n, pf.Source)
+	var fnDef *sitter.Node
+	if wrappedName != "" {
+		fnDef = funcs[wrappedName]
+	}
+
+	// Name: explicit name= kwarg > wrapped function name.
+	name := kwargStringLiteral(kwargs, "name")
+	if name == "" {
+		name = wrappedName
+	}
+	if name == "" {
+		return models.ToolDef{}, false
+	}
+
+	// Description: explicit description= kwarg > wrapped function docstring.
+	description := kwargStringLiteral(kwargs, "description")
+	if description == "" && fnDef != nil {
+		description = astutil.FunctionDocstring(fnDef, pf.Source)
+	}
+
+	var (
+		hasTyped bool
+		params   []string
+	)
+	facts := map[string]string{}
+	if fnDef != nil {
+		hasTyped = astutil.FunctionHasTypedParams(fnDef, pf.Source)
+		params = toolParamNames(fnDef, pf.Source)
+		if pythonBodyShellsOut(fnDef, pf.Source) {
+			facts["shells_out"] = "true"
+		}
+	}
+
+	// Point the location at the wrapped function body when resolved; otherwise at
+	// the factory call site. The body-scanning predicates only see the function
+	// when the location is on it (i.e. the wrapped function was resolved).
+	line, endLine := int(n.StartPoint().Row)+1, int(n.EndPoint().Row)+1
+	if fnDef != nil {
+		line, endLine = int(fnDef.StartPoint().Row)+1, int(fnDef.EndPoint().Row)+1
+	}
+	tool := models.ToolDef{
+		Name:     name,
+		Kind:     models.KindPydanticAITool,
+		Language: models.LanguagePython,
+		Location: models.Location{
+			FilePath: pf.RelPath,
+			Line:     line,
+			EndLine:  endLine,
+		},
+		Description:    description,
+		HasTypedParams: hasTyped,
+		ParamNames:     params,
+		Facts:          facts,
+	}
+	// Capture remaining constructor kwargs (e.g. takes_ctx=, requires_approval=)
+	// into Config so any tool_decorator_kwarg_value rule can read them.
+	if kwargs != nil {
+		cfg := map[string]string{}
+		for k, child := range kwargs.Children {
+			switch k {
+			case "name", "description":
+				continue
+			}
+			if child.Value != nil {
+				cfg[k] = child.Value.Text
+			}
+		}
+		if len(cfg) > 0 {
+			tool.Config = cfg
+		}
+	}
+	// Capture the assignment-target identifier (my_tool = Tool(fn)) so agent
+	// tools=[my_tool] references resolve by variable name.
+	if p := n.Parent(); p != nil && p.Type() == "assignment" {
+		if l := p.ChildByFieldName("left"); l != nil && l.Type() == "identifier" {
+			tool.VarName = astutil.NodeText(l, pf.Source)
+		}
+	}
+	return tool, true
+}

--- a/internal/analysis/pydantic_ai_tools_test.go
+++ b/internal/analysis/pydantic_ai_tools_test.go
@@ -1,0 +1,158 @@
+package analysis_test
+
+import (
+	"testing"
+
+	"github.com/trustabl/trustabl/internal/analysis"
+	"github.com/trustabl/trustabl/internal/models"
+)
+
+// kindByName runs tool discovery over one parsed file and returns a name→Kind map.
+func kindByName(t *testing.T, path, src string) map[string]models.ToolKind {
+	t.Helper()
+	pf := parsePyFile(t, path, src)
+	tools := analysis.DiscoverToolsFromParsed([]analysis.ParsedFile{pf})
+	out := map[string]models.ToolKind{}
+	for _, td := range tools {
+		out[td.Name] = td.Kind
+	}
+	return out
+}
+
+// REGRESSION GUARD (the load-bearing half of the kindFromDecorators rework):
+// the Claude Agent SDK also exposes an `@agent.tool` decorator. Routing
+// `*.tool` / `*.tool_plain` attribute decorators to Pydantic must NOT change
+// Claude behavior — a file that imports the Claude SDK and uses `@agent.tool`
+// must still classify as KindClaudeSDKTool via the existing switch case. If this
+// breaks, the `&& !claudeImport` guard in kindFromDecorators is wrong.
+func TestKindFromDecorators_ClaudeAgentToolUnchanged(t *testing.T) {
+	src := `from claude_agent_sdk import ClaudeSDKClient
+
+agent = ClaudeSDKClient()
+
+@agent.tool
+def lookup(q: str) -> str:
+    """Look something up."""
+    return q
+`
+	kind := kindByName(t, "claude_tools.py", src)
+	if kind["lookup"] != models.KindClaudeSDKTool {
+		t.Errorf("@agent.tool in a Claude-SDK file: got kind %q, want %q (the Pydantic rework must not steal Claude's @agent.tool)",
+			kind["lookup"], models.KindClaudeSDKTool)
+	}
+}
+
+// A `@agent.tool` / `@agent.tool_plain` attribute decorator in a file that
+// imports pydantic_ai (and NOT the Claude SDK) routes to KindPydanticAITool.
+func TestKindFromDecorators_PydanticAgentTool(t *testing.T) {
+	src := `from pydantic_ai import Agent, RunContext
+
+agent = Agent("openai:gpt-4o")
+
+@agent.tool
+def ctx_tool(ctx: RunContext[None], q: str) -> str:
+    """A context tool."""
+    return q
+
+@agent.tool_plain
+def plain_tool(q: str) -> str:
+    """A plain tool."""
+    return q
+`
+	kind := kindByName(t, "pyd_tools.py", src)
+	if kind["ctx_tool"] != models.KindPydanticAITool {
+		t.Errorf("@agent.tool in a pydantic_ai file: got %q, want %q", kind["ctx_tool"], models.KindPydanticAITool)
+	}
+	if kind["plain_tool"] != models.KindPydanticAITool {
+		t.Errorf("@agent.tool_plain in a pydantic_ai file: got %q, want %q", kind["plain_tool"], models.KindPydanticAITool)
+	}
+}
+
+// Collision precedence: a file importing BOTH pydantic_ai and the Claude SDK
+// must keep `@agent.tool` as KindClaudeSDKTool (claude wins, mirroring the
+// import-binding precedence for the bare `@tool` collision).
+func TestKindFromDecorators_BothImportsClaudeWins(t *testing.T) {
+	src := `from pydantic_ai import Agent
+from claude_agent_sdk import ClaudeSDKClient
+
+agent = Agent("openai:gpt-4o")
+
+@agent.tool
+def shared(q: str) -> str:
+    """Shared shape."""
+    return q
+`
+	kind := kindByName(t, "both.py", src)
+	if kind["shared"] != models.KindClaudeSDKTool {
+		t.Errorf("@agent.tool in a file importing BOTH pydantic_ai and Claude: got %q, want %q (claude must win)",
+			kind["shared"], models.KindClaudeSDKTool)
+	}
+}
+
+// The non-decorator `Tool(fn, ...)` factory in a pydantic_ai file is discovered
+// as a KindPydanticAITool ToolDef, resolving the first positional ident to a
+// same-file function for docstring + typed-param recovery; an explicit name=
+// overrides the wrapped function's name.
+func TestPydanticAITool_FactoryDiscovered(t *testing.T) {
+	src := `from pydantic_ai import Agent, Tool
+
+def fetch(url: str) -> str:
+    """Fetch a URL."""
+    import requests
+    return requests.get(url).text
+
+my_tool = Tool(fetch, takes_ctx=False, name="fetcher")
+`
+	pf := parsePyFile(t, "factory.py", src)
+	tools := analysis.DiscoverPydanticAITools([]analysis.ParsedFile{pf})
+	if len(tools) != 1 {
+		t.Fatalf("got %d Pydantic tools, want 1: %+v", len(tools), tools)
+	}
+	tl := tools[0]
+	if tl.Kind != models.KindPydanticAITool {
+		t.Errorf("Kind: got %q, want %q", tl.Kind, models.KindPydanticAITool)
+	}
+	if tl.Name != "fetcher" {
+		t.Errorf("Name: got %q, want fetcher (explicit name= override)", tl.Name)
+	}
+	if tl.Description != "Fetch a URL." {
+		t.Errorf("Description: got %q, want the wrapped function docstring", tl.Description)
+	}
+	if tl.VarName != "my_tool" {
+		t.Errorf("VarName: got %q, want my_tool", tl.VarName)
+	}
+}
+
+// The Tool(...) factory is import-gated: a Tool(...) call in a file that imports
+// neither pydantic_ai nor LangChain yields no Pydantic tool, and a file that
+// imports LangChain (which owns the colliding Tool name) is also skipped.
+func TestPydanticAITool_FactoryGate(t *testing.T) {
+	// No pydantic_ai import → nothing.
+	plain := `def Tool(fn, **kw):
+    return fn
+
+def fetch(url: str) -> str:
+    """Fetch."""
+    return url
+
+t = Tool(fetch)
+`
+	pf := parsePyFile(t, "plain.py", plain)
+	if tools := analysis.DiscoverPydanticAITools([]analysis.ParsedFile{pf}); len(tools) != 0 {
+		t.Errorf("unimported Tool() must not be a Pydantic tool; got %+v", tools)
+	}
+	// Imports LangChain (owns Tool) → Pydantic discovery defers.
+	lc := `from langchain_core.tools import Tool
+from pydantic_ai import Agent
+
+def fetch(url: str) -> str:
+    """Fetch."""
+    return url
+
+t = Tool(fetch)
+`
+	pf2 := parsePyFile(t, "lc.py", lc)
+	if tools := analysis.DiscoverPydanticAITools([]analysis.ParsedFile{pf2}); len(tools) != 0 {
+		t.Errorf("Tool() in a LangChain-importing file must defer to LangChain; got %+v", tools)
+	}
+}

--- a/internal/analysis/ts_vercel_agents.go
+++ b/internal/analysis/ts_vercel_agents.go
@@ -1,0 +1,215 @@
+package analysis
+
+import (
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/trustabl/trustabl/internal/analysis/astutil"
+	"github.com/trustabl/trustabl/internal/models"
+)
+
+// Vercel AI SDK (TypeScript) agent discovery.
+//
+// Two agent shapes, both SDK=SDKVercelAI, Language=typescript:
+//
+//  1. Call-based: generateText / streamText / generateObject / streamObject
+//     ({ model, system, tools, stopWhen, maxSteps, toolChoice }). An AgentDef
+//     is emitted ONLY when the options object carries a `tools` property — a
+//     bare generateText({model, prompt}) is a one-shot completion, not an
+//     agent, and emitting one would flood findings. Class is the normalized
+//     callee name ("GenerateText" / "StreamText" / "GenerateObject" /
+//     "StreamObject").
+//
+//  2. Class-based: new ToolLoopAgent({...}) and new Experimental_Agent({...})
+//     (often imported `as Agent`; alias-resolved via the `ai` import map).
+//     Both normalize to Class "ToolLoopAgent". The system-prompt slot here is
+//     `instructions` (vs `system` in the call form) — both keys are captured.
+//
+// THE NEW MECHANIC: in BOTH forms, `tools` is an OBJECT/RECORD
+// (`{ weather: weatherTool, search: tool({...}) }`), NOT an array. Every other
+// TS agent pass reads `tools: [...]` arrays; this walk iterates the object's
+// property VALUES. For each value:
+//   - a bare identifier        -> ToolRef{Name: ident}   (ResolveEdges wires it
+//                                  by VarName/Name; Vercel ToolDefs have empty
+//                                  Name + VarName set, and toolsByFileSym keys
+//                                  by both, so it resolves).
+//   - an inline tool({...}) /  -> mark the agent Opaque (no symbol edge), as
+//     dynamicTool({...}) call      ts_openai_agents marks inline tool({...}).
+//   - <provider>.tools.<name>()-> HostedToolRef{Class: canonical, DefIndex:-1}
+//                                  for ResolveEdges to materialize.
+//   - a spread (...mcpTools) or -> mark the agent Opaque.
+//     any other value
+
+// tsVercelAgentCallFactories maps a recognized generation-call callee to its
+// normalized Class. An agent is emitted from one of these only when `tools` is
+// present in the options object.
+var tsVercelAgentCallFactories = map[string]string{
+	"generateText":   "GenerateText",
+	"streamText":     "StreamText",
+	"generateObject": "GenerateObject",
+	"streamObject":   "StreamObject",
+}
+
+// tsVercelAgentCtors maps a `new X({...})` constructor (resolved via the `ai`
+// alias map) to its normalized Class. Both the stable ToolLoopAgent and the
+// experimental alias normalize to "ToolLoopAgent".
+var tsVercelAgentCtors = map[string]string{
+	"ToolLoopAgent":      "ToolLoopAgent",
+	"Experimental_Agent": "ToolLoopAgent",
+}
+
+// DiscoverTSVercelAgents walks each parsed TS file and emits an AgentDef per
+// recognized Vercel agent shape. Import-gated to the `ai` module.
+func DiscoverTSVercelAgents(files []ParsedFile, onFile func(string)) []models.AgentDef {
+	var out []models.AgentDef
+	for _, pf := range files {
+		if onFile != nil {
+			onFile(pf.RelPath)
+		}
+		out = append(out, discoverTSVercelAgentsInFile(pf)...)
+	}
+	return out
+}
+
+func discoverTSVercelAgentsInFile(pf ParsedFile) []models.AgentDef {
+	if pf.Tree == nil {
+		return nil
+	}
+	aliases := astutil.TSImportAliasesMatch(pf.Tree.RootNode(), pf.Source, isTSVercelModule)
+	if len(aliases) == 0 {
+		return nil
+	}
+	var out []models.AgentDef
+	astutil.Walk(pf.Tree.RootNode(), func(n *sitter.Node) bool {
+		switch n.Type() {
+		case "call_expression":
+			class, ok := tsVercelAgentCallFactories[astutil.TSCalleeText(n, pf.Source, aliases)]
+			if !ok {
+				return true
+			}
+			// Call-form agents require a tools record — a bare completion is
+			// not an agent.
+			opts := firstObjectArg(n)
+			if opts == nil || getObjectProperty(opts, "tools", pf.Source) == nil {
+				return true
+			}
+			out = append(out, buildTSVercelAgent(n, opts, pf, class))
+		case "new_expression":
+			ctor := n.ChildByFieldName("constructor")
+			if ctor == nil || ctor.Type() != "identifier" {
+				return true
+			}
+			class, ok := tsVercelAgentCtors[aliases[astutil.NodeText(ctor, pf.Source)]]
+			if !ok {
+				return true
+			}
+			args := n.ChildByFieldName("arguments")
+			var opts *sitter.Node
+			if args != nil && args.NamedChildCount() > 0 {
+				opts = args.NamedChild(0)
+			}
+			out = append(out, buildTSVercelAgent(n, opts, pf, class))
+		}
+		return true
+	})
+	return out
+}
+
+// buildTSVercelAgent builds an AgentDef from a call or new-expression. opts is
+// the already-extracted options object (may be nil for a class ctor with no
+// args). class is the normalized Class.
+func buildTSVercelAgent(n, opts *sitter.Node, pf ParsedFile, class string) models.AgentDef {
+	a := models.AgentDef{
+		SDK:      models.SDKVercelAI,
+		Class:    class,
+		Language: models.LanguageTypeScript,
+		Location: models.Location{
+			FilePath: pf.RelPath,
+			Line:     int(n.StartPoint().Row) + 1,
+			EndLine:  int(n.EndPoint().Row) + 1,
+		},
+		VarName: directAssignmentName(n, pf.Source),
+	}
+	if opts == nil || opts.Type() != "object" {
+		a.Opaque = true
+		return a
+	}
+	// A spread at the top level means the captured kwarg view is incomplete.
+	for i := 0; i < int(opts.NamedChildCount()); i++ {
+		if opts.NamedChild(i).Type() == "spread_element" {
+			a.Opaque = true
+			break
+		}
+	}
+	a.Kwargs = astutil.TSObjectKwargs(opts, pf.Source)
+	populateTSVercelToolRefs(&a, opts, pf)
+	return a
+}
+
+// populateTSVercelToolRefs walks options.tools as an OBJECT RECORD (not an
+// array) and resolves each property value to a ToolRef, a HostedToolRef, or an
+// Opaque flag. A non-object tools value (identifier, spread, array, computed)
+// is unenumerable by symbol, so the agent is marked Opaque.
+func populateTSVercelToolRefs(a *models.AgentDef, opts *sitter.Node, pf ParsedFile) {
+	tools := getObjectProperty(opts, "tools", pf.Source)
+	if tools == nil {
+		return
+	}
+	if tools.Type() != "object" {
+		// tools: someRecord / tools: [...] / tools: computed — can't enumerate.
+		a.Opaque = true
+		return
+	}
+	for i := 0; i < int(tools.NamedChildCount()); i++ {
+		prop := tools.NamedChild(i)
+		if prop.Type() == "spread_element" {
+			// tools: { ...mcpTools } — unenumerable.
+			a.Opaque = true
+			continue
+		}
+		if prop.Type() != "pair" {
+			continue // shorthand / computed key handled below as opaque only if a value-bearing pair
+		}
+		val := prop.ChildByFieldName("value")
+		if val == nil {
+			continue
+		}
+		switch val.Type() {
+		case "identifier":
+			a.ToolRefs = append(a.ToolRefs, models.ToolRef{Name: astutil.NodeText(val, pf.Source)})
+		case "call_expression":
+			if canon, ok := classifyTSVercelHostedCall(val, pf.Source); ok {
+				a.HostedToolRefs = append(a.HostedToolRefs, models.HostedToolRef{
+					Class:    canon,
+					DefIndex: -1,
+				})
+			} else {
+				// An inline tool({...}) / dynamicTool({...}) (or any other call):
+				// no symbol edge to a ToolDef, so the agent's tool set is not
+				// fully enumerable. Mark Opaque so "agent has no tools" rules do
+				// not false-fire.
+				a.Opaque = true
+			}
+		default:
+			// A non-identifier, non-call value (member access, object, etc.)
+			// cannot be wired to an edge — be conservative.
+			a.Opaque = true
+		}
+	}
+}
+
+// classifyTSVercelHostedCall reports whether a call_expression is a Vercel
+// provider hosted-tool call (`<provider>.tools.<name>(...)`) and returns its
+// canonical class string. The callee is a member_expression whose text is read
+// directly: the provider object (anthropic / openai / google) is a runtime
+// value from a provider package, not an import alias TSCalleeText can resolve.
+func classifyTSVercelHostedCall(call *sitter.Node, src []byte) (string, bool) {
+	fn := call.ChildByFieldName("function")
+	if fn == nil || fn.Type() != "member_expression" {
+		return "", false
+	}
+	canon := canonicalVercelHostedClass(astutil.NodeText(fn, src))
+	if !IsVercelHostedTool(canon) {
+		return "", false
+	}
+	return canon, true
+}

--- a/internal/analysis/ts_vercel_agents_test.go
+++ b/internal/analysis/ts_vercel_agents_test.go
@@ -1,0 +1,186 @@
+package analysis_test
+
+import (
+	"testing"
+
+	"github.com/trustabl/trustabl/internal/analysis"
+	"github.com/trustabl/trustabl/internal/models"
+)
+
+func vaiHasHostedClass(a models.AgentDef, class string) bool {
+	for _, ref := range a.HostedToolRefs {
+		if ref.Class == class {
+			return true
+		}
+	}
+	return false
+}
+
+func vaiHasToolRef(a models.AgentDef, name string) bool {
+	for _, ref := range a.ToolRefs {
+		if ref.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// The core new mechanic: tools is an OBJECT RECORD, not an array. The walk must
+// resolve a bare-identifier value to a ToolRef and a provider hosted-tool call
+// to a HostedToolRef whose canonical Class has the date suffix stripped.
+func TestTSVercel_AgentObjectRecordTools(t *testing.T) {
+	src := `import { generateText } from "ai";
+import { anthropic } from "@ai-sdk/anthropic";
+const result = await generateText({
+  model: anthropic("claude-sonnet-4"),
+  tools: {
+    weather: weatherTool,
+    bash: anthropic.tools.bash_20250124(),
+  },
+});
+`
+	pf := parseTSForTest(t, "agent.ts", src)
+	agents := analysis.DiscoverTSVercelAgents([]analysis.ParsedFile{pf}, nil)
+	if len(agents) != 1 {
+		t.Fatalf("expected 1 agent, got %d (%+v)", len(agents), agents)
+	}
+	a := agents[0]
+	if a.SDK != models.SDKVercelAI {
+		t.Errorf("SDK: got %q, want vercel_ai", a.SDK)
+	}
+	if a.Class != "GenerateText" {
+		t.Errorf("Class: got %q, want GenerateText", a.Class)
+	}
+	if a.Language != models.LanguageTypeScript {
+		t.Errorf("Language: got %q, want typescript", a.Language)
+	}
+	if !vaiHasToolRef(a, "weatherTool") {
+		t.Errorf("expected a ToolRef{Name: weatherTool} from the record value; got %+v", a.ToolRefs)
+	}
+	if !vaiHasHostedClass(a, "anthropic.tools.bash") {
+		t.Errorf("expected HostedToolRef class anthropic.tools.bash (date suffix stripped); got %+v", a.HostedToolRefs)
+	}
+}
+
+// A bare generateText({model, prompt}) with NO tools is a one-shot completion,
+// not an agent — discovery must emit nothing.
+func TestTSVercel_NoToolsNoAgent(t *testing.T) {
+	src := `import { generateText } from "ai";
+import { openai } from "@ai-sdk/openai";
+const r = await generateText({ model: openai("gpt-5"), prompt: "hi" });
+`
+	pf := parseTSForTest(t, "oneshot.ts", src)
+	agents := analysis.DiscoverTSVercelAgents([]analysis.ParsedFile{pf}, nil)
+	if len(agents) != 0 {
+		t.Errorf("a completion with no tools must not be an agent; got %d (%+v)", len(agents), agents)
+	}
+}
+
+// Class-based agent: new Experimental_Agent({...}) imported `as Agent`
+// normalizes to Class ToolLoopAgent, and `instructions` is its system slot.
+func TestTSVercel_ClassAgentAliased(t *testing.T) {
+	src := `import { Experimental_Agent as Agent } from "ai";
+import { openai } from "@ai-sdk/openai";
+const a = new Agent({
+  model: openai("gpt-5"),
+  instructions: "You help with billing.",
+  tools: { ci: openai.tools.codeInterpreter() },
+});
+`
+	pf := parseTSForTest(t, "classagent.ts", src)
+	agents := analysis.DiscoverTSVercelAgents([]analysis.ParsedFile{pf}, nil)
+	if len(agents) != 1 {
+		t.Fatalf("expected 1 agent, got %d (%+v)", len(agents), agents)
+	}
+	a := agents[0]
+	if a.Class != "ToolLoopAgent" {
+		t.Errorf("Class: got %q, want ToolLoopAgent", a.Class)
+	}
+	if !vaiHasHostedClass(a, "openai.tools.codeInterpreter") {
+		t.Errorf("expected HostedToolRef openai.tools.codeInterpreter; got %+v", a.HostedToolRefs)
+	}
+	if a.Kwargs == nil || a.Kwargs.Children["instructions"] == nil {
+		t.Errorf("expected `instructions` captured in Kwargs; got %+v", a.Kwargs)
+	}
+}
+
+// An inline tool({...}) value in the tools record cannot be wired to a symbol
+// edge — the agent is marked Opaque (matching ts_openai_agents' inline-tool
+// handling) so "agent has no tools" rules don't false-fire.
+func TestTSVercel_InlineToolMarksOpaque(t *testing.T) {
+	src := `import { generateText, tool } from "ai";
+import { openai } from "@ai-sdk/openai";
+import { z } from "zod";
+const r = await generateText({
+  model: openai("gpt-5"),
+  tools: { weather: tool({ description: "w", inputSchema: z.object({ c: z.string() }), execute: async () => "" }) },
+});
+`
+	pf := parseTSForTest(t, "inline.ts", src)
+	agents := analysis.DiscoverTSVercelAgents([]analysis.ParsedFile{pf}, nil)
+	if len(agents) != 1 {
+		t.Fatalf("expected 1 agent, got %d", len(agents))
+	}
+	if !agents[0].Opaque {
+		t.Errorf("an inline tool({...}) record value should mark the agent Opaque; got %+v", agents[0])
+	}
+}
+
+// A spread in the tools record (...mcpTools) is unenumerable — mark Opaque.
+func TestTSVercel_SpreadToolsMarksOpaque(t *testing.T) {
+	src := `import { streamText } from "ai";
+import { openai } from "@ai-sdk/openai";
+const r = streamText({ model: openai("gpt-5"), tools: { ...mcpTools, weather: weatherTool } });
+`
+	pf := parseTSForTest(t, "spread.ts", src)
+	agents := analysis.DiscoverTSVercelAgents([]analysis.ParsedFile{pf}, nil)
+	if len(agents) != 1 {
+		t.Fatalf("expected 1 agent, got %d", len(agents))
+	}
+	if !agents[0].Opaque {
+		t.Errorf("a spread tools value should mark the agent Opaque; got %+v", agents[0])
+	}
+}
+
+// The named ToolRef must resolve end-to-end through ResolveEdges to a Vercel
+// ToolDef whose VarName matches (Vercel ToolDefs have empty Name; toolsByFileSym
+// keys by both Name and VarName).
+func TestTSVercel_ResolveEdgesWiresNamedTool(t *testing.T) {
+	src := `import { generateText, tool } from "ai";
+import { anthropic } from "@ai-sdk/anthropic";
+import { z } from "zod";
+const weatherTool = tool({ description: "w", inputSchema: z.object({ c: z.string() }), execute: async () => "" });
+const r = await generateText({ model: anthropic("claude-sonnet-4"), tools: { weather: weatherTool, bash: anthropic.tools.bash_20250124() } });
+`
+	pf := parseTSForTest(t, "wire.ts", src)
+	tools := analysis.DiscoverTSVercelTools([]analysis.ParsedFile{pf}, nil)
+	agents := analysis.DiscoverTSVercelAgents([]analysis.ParsedFile{pf}, nil)
+	inv := models.RepoInventory{Tools: tools, Agents: agents}
+	analysis.ResolveEdges(&inv, []analysis.ParsedFile{pf})
+	if len(inv.Agents) != 1 {
+		t.Fatalf("expected 1 agent post-resolve, got %d", len(inv.Agents))
+	}
+	a := inv.Agents[0]
+	var resolved bool
+	for _, ref := range a.ToolRefs {
+		if ref.Name == "weatherTool" && ref.Resolved != nil {
+			resolved = true
+			if ref.Resolved.Kind != models.KindVercelAITool {
+				t.Errorf("resolved tool Kind: got %q, want vercel_ai_tool", ref.Resolved.Kind)
+			}
+		}
+	}
+	if !resolved {
+		t.Errorf("named tool ref 'weatherTool' did not resolve to a ToolDef; refs=%+v", a.ToolRefs)
+	}
+	// The provider hosted tool should have been materialized into the inventory.
+	var sawHosted bool
+	for _, h := range inv.HostedTools {
+		if h.Class == "anthropic.tools.bash" && h.SDK == models.SDKVercelAI {
+			sawHosted = true
+		}
+	}
+	if !sawHosted {
+		t.Errorf("expected anthropic.tools.bash materialized with SDK vercel_ai; hosted=%+v", inv.HostedTools)
+	}
+}

--- a/internal/analysis/ts_vercel_hosted_tools.go
+++ b/internal/analysis/ts_vercel_hosted_tools.go
@@ -1,0 +1,95 @@
+package analysis
+
+import "strings"
+
+// Vercel AI SDK provider-defined ("hosted") tools.
+//
+// Unlike the OpenAI Agents SDK (camelCase factory functions) and Google ADK
+// (PascalCase class instantiations), Vercel exposes provider tools as a
+// member call on a provider object: `anthropic.tools.bash_20250124()`,
+// `openai.tools.localShell()`, `google.tools.codeExecution()`. The callee
+// text discovery reads is therefore the full member path
+// `<provider>.tools.<name>` (TSCalleeText cannot resolve this — the object is
+// a runtime value, not an import alias — so the Vercel agent walk reads the
+// member_expression text directly).
+//
+// canonicalVercelHostedClass normalizes that callee text into a stable class
+// string by stripping any trailing `_<date>` version suffix that Anthropic's
+// computer-use tools carry (bash_20250124 -> bash, computer_20241022 ->
+// computer). The canonical string is what HostedToolRef.Class stores and what
+// the vercel_ai agent rules list in `agent_uses_hosted_tool_class:`.
+
+// vercelHostedToolPrefixes is the closed set of recognized provider-tool
+// canonical names (after date-suffix stripping). Source: the Vercel AI SDK
+// provider packages — @ai-sdk/anthropic (anthropic.tools.*), @ai-sdk/openai
+// (openai.tools.*), and @ai-sdk/google (google.tools.*).
+var vercelHostedToolPrefixes = map[string]bool{
+	// @ai-sdk/anthropic — computer-use + code-execution provider tools.
+	"anthropic.tools.bash":          true,
+	"anthropic.tools.textEditor":    true,
+	"anthropic.tools.computer":      true,
+	"anthropic.tools.codeExecution": true,
+	"anthropic.tools.webSearch":     true,
+	// @ai-sdk/openai — responses-API provider tools.
+	"openai.tools.localShell":         true,
+	"openai.tools.computerUsePreview": true,
+	"openai.tools.codeInterpreter":    true,
+	"openai.tools.webSearch":          true,
+	"openai.tools.webSearchPreview":   true,
+	"openai.tools.fileSearch":         true,
+	// @ai-sdk/google — Gemini provider tools.
+	"google.tools.codeExecution": true,
+	"google.tools.googleSearch":  true,
+	"google.tools.urlContext":    true,
+}
+
+// canonicalVercelHostedClass strips a trailing `_<digits>` version suffix from
+// the last path segment of a `<provider>.tools.<name>` callee and returns the
+// canonical class string. `anthropic.tools.bash_20250124` -> `anthropic.tools.bash`.
+// A callee with no recognized shape is returned unchanged.
+func canonicalVercelHostedClass(callee string) string {
+	dot := strings.LastIndex(callee, ".")
+	if dot < 0 {
+		return callee
+	}
+	head, name := callee[:dot+1], callee[dot+1:]
+	if us := strings.LastIndex(name, "_"); us > 0 {
+		// Only strip when everything after the underscore is digits (a date /
+		// version stamp); a name like "code_execution" must survive intact —
+		// but the Vercel surface uses camelCase, so an underscore here is
+		// always a version suffix. Guard on digits anyway for safety.
+		suffix := name[us+1:]
+		allDigits := suffix != ""
+		for _, r := range suffix {
+			if r < '0' || r > '9' {
+				allDigits = false
+				break
+			}
+		}
+		if allDigits {
+			name = name[:us]
+		}
+	}
+	return head + name
+}
+
+// IsVercelHostedTool reports whether class (a canonical
+// `<provider>.tools.<name>` string, already date-suffix-stripped) is a
+// recognized Vercel provider tool.
+func IsVercelHostedTool(class string) bool {
+	return vercelHostedToolPrefixes[class]
+}
+
+// vercelDangerousHostedClasses is the subset of provider tools that give the
+// model shell, computer-control, or code-execution reach — the surface the
+// VAI-006 agent rule flags. Web-search / URL-context retrieval tools are
+// deliberately excluded (they are an SSRF-class concern, not RCE).
+var vercelDangerousHostedClasses = []string{
+	"anthropic.tools.bash",
+	"anthropic.tools.computer",
+	"anthropic.tools.codeExecution",
+	"openai.tools.localShell",
+	"openai.tools.computerUsePreview",
+	"openai.tools.codeInterpreter",
+	"google.tools.codeExecution",
+}

--- a/internal/analysis/ts_vercel_tools.go
+++ b/internal/analysis/ts_vercel_tools.go
@@ -1,0 +1,207 @@
+package analysis
+
+import (
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/trustabl/trustabl/internal/analysis/astutil"
+	"github.com/trustabl/trustabl/internal/models"
+)
+
+// Vercel AI SDK (TypeScript) tool discovery.
+//
+// Recognized shapes (import-gated to the bare `ai` module):
+//
+//	tool({ description, inputSchema, execute })   // v5/v6 — inputSchema
+//	tool({ description, parameters, execute })     // v4 — parameters
+//	dynamicTool({ description, inputSchema, execute })  // input is always unknown
+//
+// Unlike LangChain's `tool(fn, {...})` (handler is arg 0, config arg 1) and
+// the OpenAI Agents SDK's `tool({...})`, the Vercel factory takes a SINGLE
+// options object (arg 0). The disambiguator from the identically-named
+// Claude / OpenAI / LangChain `tool()` factories is the `ai`-module import
+// gate (isTSVercelModule): a Vercel-importing file routes tool() here and the
+// other passes skip it (they gate on their own imports).
+//
+// A Vercel tool's NAME is derived from the agent's tools-record KEY
+// (`tools: { weather: weatherTool }`), not from the tool definition — so the
+// emitted ToolDef.Name is empty and the binding identifier is captured as
+// VarName. The model sees only the `description` (there is no docstring
+// fallback as in Python), so an absent/empty description is the sole authoring
+// signal.
+
+// isTSVercelModule reports whether a TS import specifier is the Vercel AI SDK
+// core module. Matched exactly (`ai`) — the provider packages (@ai-sdk/*) are
+// not import-gated here; provider hosted tools are recognized structurally in
+// the agent walk by their `<provider>.tools.<name>` callee shape.
+func isTSVercelModule(mod string) bool {
+	return mod == "ai"
+}
+
+// tsVercelToolFactories maps a recognized factory callee to whether its input
+// is dynamic (always `unknown`). `dynamicTool` forces HasTypedParams=false
+// regardless of any schema present.
+var tsVercelToolFactories = map[string]bool{
+	"tool":        false,
+	"dynamicTool": true,
+}
+
+// DiscoverTSVercelTools walks each parsed TS file and emits a ToolDef per
+// recognized Vercel tool factory call. Import-gated to the `ai` module.
+func DiscoverTSVercelTools(files []ParsedFile, onFile func(string)) []models.ToolDef {
+	var out []models.ToolDef
+	for _, pf := range files {
+		if onFile != nil {
+			onFile(pf.RelPath)
+		}
+		out = append(out, discoverTSVercelToolsInFile(pf)...)
+	}
+	return out
+}
+
+func discoverTSVercelToolsInFile(pf ParsedFile) []models.ToolDef {
+	if pf.Tree == nil {
+		return nil
+	}
+	aliases := astutil.TSImportAliasesMatch(pf.Tree.RootNode(), pf.Source, isTSVercelModule)
+	if len(aliases) == 0 {
+		return nil
+	}
+	var out []models.ToolDef
+	astutil.Walk(pf.Tree.RootNode(), func(n *sitter.Node) bool {
+		if n.Type() != "call_expression" {
+			return true
+		}
+		callee := astutil.TSCalleeText(n, pf.Source, aliases)
+		dynamic, ok := tsVercelToolFactories[callee]
+		if !ok {
+			return true
+		}
+		if td, built := buildTSVercelTool(n, dynamic, pf); built {
+			out = append(out, td)
+		}
+		return true
+	})
+	return out
+}
+
+// buildTSVercelTool builds a ToolDef from a `tool({...})` / `dynamicTool({...})`
+// call. dynamic forces HasTypedParams=false (the dynamicTool input is always
+// `unknown`).
+func buildTSVercelTool(call *sitter.Node, dynamic bool, pf ParsedFile) (models.ToolDef, bool) {
+	args := call.ChildByFieldName("arguments")
+	if args == nil || args.NamedChildCount() == 0 {
+		return models.ToolDef{}, false
+	}
+	opts := args.NamedChild(0)
+	if opts.Type() != "object" {
+		return models.ToolDef{}, false // non-object arg — skip silently
+	}
+	kt := astutil.TSObjectKwargs(opts, pf.Source)
+	td := models.ToolDef{
+		Kind:     models.KindVercelAITool,
+		Language: models.LanguageTypeScript,
+		Location: models.Location{
+			FilePath: pf.RelPath,
+			Line:     int(call.StartPoint().Row) + 1,
+			EndLine:  int(call.EndPoint().Row) + 1,
+		},
+		VarName: directAssignmentName(call, pf.Source),
+	}
+	// description → the only model-visible signal (no docstring fallback in TS).
+	if c := kt.Children["description"]; c != nil && c.Value != nil &&
+		c.Value.Kind == models.ExprLiteralString {
+		td.Description = unquote(c.Value.Text)
+	}
+	// Params. Two questions matter to the tool rules: does the tool accept
+	// model input at all (has_params), and is that input typed (has_typed_params)?
+	//
+	//   - dynamicTool: input is always `unknown`. It DOES take input but with no
+	//     type discipline — record a synthetic "input" param so has_params holds
+	//     while HasTypedParams stays false (the VAI-005 "untyped input" signal).
+	//   - tool with inputSchema (v5/v6) or parameters (v4):
+	//       * a typed Zod object ({ city: z.string() } or z.object({ city: ... }))
+	//         -> real param names, HasTypedParams=true.
+	//       * an OPEN schema (z.any() / z.unknown() / z.object({}) / {}) -> the
+	//         tool takes input but imposes no field types: synthetic "input",
+	//         HasTypedParams=false.
+	//       * no schema key at all -> no input surface, leave ParamNames empty.
+	if dynamic {
+		td.ParamNames = []string{"input"}
+	} else {
+		schema := getObjectProperty(opts, "inputSchema", pf.Source)
+		if schema == nil {
+			schema = getObjectProperty(opts, "parameters", pf.Source)
+		}
+		if schema != nil {
+			if tsSchemaIsOpen(schema, pf.Source) {
+				td.ParamNames = []string{"input"}
+			} else if names, typed := tsZodParamNames(schema, pf.Source); typed {
+				td.HasTypedParams = true
+				td.ParamNames = names
+			}
+		}
+	}
+	// execute → body facts (shells_out / code_exec / dynamic_url).
+	if exec := getObjectProperty(opts, "execute", pf.Source); exec != nil {
+		if facts := tsHandlerFacts(exec, pf.Source); len(facts) > 0 {
+			td.Facts = facts
+		}
+	}
+	consumed := map[string]bool{
+		"description": true, "inputSchema": true, "parameters": true, "execute": true,
+	}
+	cfg := map[string]string{}
+	for k, child := range kt.Children {
+		if consumed[k] {
+			continue
+		}
+		if child.Value != nil {
+			cfg[k] = child.Value.Text
+		} else {
+			flattenKwargs(k, child, cfg)
+		}
+	}
+	if len(cfg) > 0 {
+		td.Config = cfg
+	}
+	return td, true
+}
+
+// tsSchemaIsOpen reports whether a schema value node is an "open" schema that
+// imposes no field typing: z.any(), z.unknown(), or an empty z.object({}) /
+// empty object literal {}. These mean the model gets no argument-shape
+// guidance, so the tool is treated as having untyped params (HasTypedParams
+// stays false), matching the Python "no type hints" signal.
+func tsSchemaIsOpen(schema *sitter.Node, src []byte) bool {
+	switch schema.Type() {
+	case "object":
+		// `{}` — empty inline object literal.
+		return objectHasNoPairs(schema)
+	case "call_expression":
+		callee := astutil.NodeText(schema.ChildByFieldName("function"), src)
+		switch callee {
+		case "z.any", "z.unknown":
+			return true
+		case "z.object":
+			// z.object({}) with an empty object argument is open.
+			if obj := firstObjectArg(schema); obj != nil {
+				return objectHasNoPairs(obj)
+			}
+			// z.object() with no object arg — treat as open.
+			return true
+		}
+	}
+	return false
+}
+
+// objectHasNoPairs reports whether an object literal node has no `pair`
+// children (i.e. it is `{}` or contains only spreads / shorthand, which carry
+// no explicit field types).
+func objectHasNoPairs(obj *sitter.Node) bool {
+	for i := 0; i < int(obj.NamedChildCount()); i++ {
+		if obj.NamedChild(i).Type() == "pair" {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/analysis/ts_vercel_tools_test.go
+++ b/internal/analysis/ts_vercel_tools_test.go
@@ -1,0 +1,166 @@
+package analysis_test
+
+import (
+	"testing"
+
+	"github.com/trustabl/trustabl/internal/analysis"
+	"github.com/trustabl/trustabl/internal/models"
+)
+
+// vaiFindTool finds a discovered Vercel tool by its VarName (Vercel tools carry
+// no Name — the model-facing name is the agent's tools-record key).
+func vaiFindTool(tools []models.ToolDef, varName string) (models.ToolDef, bool) {
+	for _, td := range tools {
+		if td.VarName == varName {
+			return td, true
+		}
+	}
+	return models.ToolDef{}, false
+}
+
+func TestTSVercel_ToolFactoryTyped(t *testing.T) {
+	src := `import { tool } from "ai";
+import { z } from "zod";
+const weatherTool = tool({
+  description: "Get the weather.",
+  inputSchema: z.object({ city: z.string() }),
+  execute: async ({ city }) => "sunny in " + city,
+});
+`
+	pf := parseTSForTest(t, "tools.ts", src)
+	tools := analysis.DiscoverTSVercelTools([]analysis.ParsedFile{pf}, nil)
+	tl, ok := vaiFindTool(tools, "weatherTool")
+	if !ok {
+		t.Fatalf("tool 'weatherTool' not discovered; got %+v", tools)
+	}
+	if tl.Kind != models.KindVercelAITool {
+		t.Errorf("Kind: got %q, want %q", tl.Kind, models.KindVercelAITool)
+	}
+	if tl.Language != models.LanguageTypeScript {
+		t.Errorf("Language: got %q, want typescript", tl.Language)
+	}
+	if tl.Description != "Get the weather." {
+		t.Errorf("Description: got %q", tl.Description)
+	}
+	if !tl.HasTypedParams {
+		t.Errorf("HasTypedParams: got false, want true (inputSchema zod object)")
+	}
+	if tl.Name != "" {
+		t.Errorf("Name: got %q, want empty (Vercel derives name from the tools-record key)", tl.Name)
+	}
+}
+
+// v4 used `parameters`; v5/v6 use `inputSchema`. Both must yield typed params.
+func TestTSVercel_ToolParametersAlias(t *testing.T) {
+	src := `import { tool } from "ai";
+import { z } from "zod";
+const t = tool({ description: "x", parameters: z.object({ q: z.string() }), execute: async ({ q }) => q });
+`
+	pf := parseTSForTest(t, "v4.ts", src)
+	tools := analysis.DiscoverTSVercelTools([]analysis.ParsedFile{pf}, nil)
+	tl, ok := vaiFindTool(tools, "t")
+	if !ok {
+		t.Fatalf("v4 parameters tool not discovered; got %+v", tools)
+	}
+	if !tl.HasTypedParams {
+		t.Errorf("HasTypedParams: got false, want true (v4 parameters zod object)")
+	}
+}
+
+func TestTSVercel_DynamicToolIsUntyped(t *testing.T) {
+	src := `import { dynamicTool } from "ai";
+import { z } from "zod";
+const echo = dynamicTool({ description: "Echo.", inputSchema: z.unknown(), execute: async (input) => input });
+`
+	pf := parseTSForTest(t, "dyn.ts", src)
+	tools := analysis.DiscoverTSVercelTools([]analysis.ParsedFile{pf}, nil)
+	tl, ok := vaiFindTool(tools, "echo")
+	if !ok {
+		t.Fatalf("dynamicTool not discovered; got %+v", tools)
+	}
+	if tl.HasTypedParams {
+		t.Errorf("dynamicTool input is always unknown; HasTypedParams should be false")
+	}
+	if len(tl.ParamNames) == 0 {
+		t.Errorf("dynamicTool should still register a synthetic param so has_params holds")
+	}
+}
+
+func TestTSVercel_EmptyObjectSchemaIsUntyped(t *testing.T) {
+	src := `import { tool } from "ai";
+import { z } from "zod";
+const open = tool({ description: "x", inputSchema: z.object({}), execute: async () => 1 });
+`
+	pf := parseTSForTest(t, "open.ts", src)
+	tools := analysis.DiscoverTSVercelTools([]analysis.ParsedFile{pf}, nil)
+	tl, ok := vaiFindTool(tools, "open")
+	if !ok {
+		t.Fatalf("open-schema tool not discovered; got %+v", tools)
+	}
+	if tl.HasTypedParams {
+		t.Errorf("z.object({}) imposes no field types; HasTypedParams should be false")
+	}
+	if len(tl.ParamNames) == 0 {
+		t.Errorf("an open schema present means the tool takes input; has_params should hold")
+	}
+}
+
+func TestTSVercel_NoDescription(t *testing.T) {
+	src := `import { tool } from "ai";
+import { z } from "zod";
+const t = tool({ inputSchema: z.object({ q: z.string() }), execute: async ({ q }) => q });
+`
+	pf := parseTSForTest(t, "nodesc.ts", src)
+	tools := analysis.DiscoverTSVercelTools([]analysis.ParsedFile{pf}, nil)
+	tl, ok := vaiFindTool(tools, "t")
+	if !ok {
+		t.Fatalf("tool not discovered; got %+v", tools)
+	}
+	if tl.Description != "" {
+		t.Errorf("Description: got %q, want empty", tl.Description)
+	}
+}
+
+func TestTSVercel_ToolShellAndSSRFFacts(t *testing.T) {
+	src := `import { tool } from "ai";
+import { z } from "zod";
+import { execSync } from "child_process";
+const run = tool({ description: "run", inputSchema: z.object({ cmd: z.string() }), execute: async ({ cmd }) => execSync(cmd).toString() });
+const fetchUrl = tool({ description: "get", inputSchema: z.object({ url: z.string() }), execute: async ({ url }) => (await fetch(url)).text() });
+`
+	pf := parseTSForTest(t, "facts.ts", src)
+	tools := analysis.DiscoverTSVercelTools([]analysis.ParsedFile{pf}, nil)
+	run, ok := vaiFindTool(tools, "run")
+	if !ok {
+		t.Fatalf("tool 'run' not discovered")
+	}
+	if run.Facts["shells_out"] != "true" {
+		t.Errorf("shells_out: got %q, want true; facts=%v", run.Facts["shells_out"], run.Facts)
+	}
+	fu, ok := vaiFindTool(tools, "fetchUrl")
+	if !ok {
+		t.Fatalf("tool 'fetchUrl' not discovered")
+	}
+	if fu.Facts["dynamic_url"] != "true" {
+		t.Errorf("dynamic_url: got %q, want true; facts=%v", fu.Facts["dynamic_url"], fu.Facts)
+	}
+}
+
+// Collision guard: a tool({...}) in a file importing @langchain/core/tools must
+// be discovered by the LangChain pass, NOT the Vercel pass — the `ai`-module
+// import gate is the disambiguator.
+func TestTSVercel_NoCrossFireWithLangChain(t *testing.T) {
+	src := `import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+const lc = tool(async (i) => "", { name: "lc_tool", description: "x", schema: z.object({ q: z.string() }) });
+`
+	pf := parseTSForTest(t, "lc.ts", src)
+	vai := analysis.DiscoverTSVercelTools([]analysis.ParsedFile{pf}, nil)
+	if len(vai) != 0 {
+		t.Errorf("Vercel pass must not discover a LangChain tool; got %d (%+v)", len(vai), vai)
+	}
+	lc := analysis.DiscoverTSLangChainTools([]analysis.ParsedFile{pf}, nil)
+	if len(lc) != 1 {
+		t.Errorf("LangChain pass: got %d tools, want 1", len(lc))
+	}
+}

--- a/internal/ingestion/normalizer.go
+++ b/internal/ingestion/normalizer.go
@@ -92,6 +92,31 @@ func detectSDKDeps(root string) []models.SDKDep {
 			Manifests: []string{"pyproject.toml", "requirements.txt", "Pipfile", "poetry.lock", "package.json"}},
 		{Name: "langchain", Pattern: "langgraph",
 			Manifests: []string{"pyproject.toml", "requirements.txt", "Pipfile", "poetry.lock", "package.json"}},
+		// CrewAI (Python). The "crewai" needle also catches the "crewai-tools"
+		// companion package — both map to the one SDKCrewAI row.
+		{Name: "crewai", Pattern: "crewai",
+			Manifests: []string{"pyproject.toml", "requirements.txt", "Pipfile", "poetry.lock"}},
+		// Pydantic AI (Python). MUST be "pydantic-ai" (catches "pydantic-ai-slim"
+		// too), NOT the bare "pydantic" — pydantic is a ubiquitous validation dep
+		// and would over-match nearly every FastAPI project.
+		{Name: "pydantic-ai", Pattern: "pydantic-ai",
+			Manifests: []string{"pyproject.toml", "requirements.txt", "Pipfile", "poetry.lock"}},
+		// AutoGen / AG2 (Python). Two upstream lines: the AG2 fork (pyautogen / ag2)
+		// and Microsoft's autogen-agentchat / autogen-core / autogen-ext.
+		{Name: "autogen", Pattern: "pyautogen",
+			Manifests: []string{"pyproject.toml", "requirements.txt", "Pipfile", "poetry.lock"}},
+		{Name: "autogen", Pattern: "autogen-agentchat",
+			Manifests: []string{"pyproject.toml", "requirements.txt", "Pipfile", "poetry.lock"}},
+		// Vercel AI SDK (TypeScript). The core package is literally named "ai", so
+		// the needle is the QUOTED JSON key `"ai"` — it matches the dependency
+		// entry, not the substring "ai" inside "@langchain/openai" / "tailwindcss".
+		// The @ai-sdk/ provider packages are the unambiguous secondary anchor.
+		// Both are drift signals only; pack loading is gated on observed code via
+		// deriveSDKsDetected (import gate on 'ai'), never on this dep scan.
+		{Name: "vercel-ai", Pattern: "\"ai\"",
+			Manifests: []string{"package.json"}},
+		{Name: "vercel-ai", Pattern: "@ai-sdk/",
+			Manifests: []string{"package.json"}},
 	}
 	seen := make(map[string]bool)
 	var out []models.SDKDep

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -55,12 +55,16 @@ func SeverityWeight(s Severity) float64 {
 type DetectorCategory string
 
 const (
-	CategoryClaudeSDK DetectorCategory = "claude_sdk"
-	CategoryOpenAISDK DetectorCategory = "openai_sdk"
-	CategoryOpenShell DetectorCategory = "openshell"
-	CategoryGoogleADK DetectorCategory = "google_adk"
-	CategoryMCP       DetectorCategory = "mcp"
-	CategoryLangChain DetectorCategory = "langchain"
+	CategoryClaudeSDK  DetectorCategory = "claude_sdk"
+	CategoryOpenAISDK  DetectorCategory = "openai_sdk"
+	CategoryOpenShell  DetectorCategory = "openshell"
+	CategoryGoogleADK  DetectorCategory = "google_adk"
+	CategoryMCP        DetectorCategory = "mcp"
+	CategoryLangChain  DetectorCategory = "langchain"
+	CategoryCrewAI     DetectorCategory = "crewai"
+	CategoryPydanticAI DetectorCategory = "pydantic_ai"
+	CategoryVercelAI   DetectorCategory = "vercel_ai"
+	CategoryAutoGen    DetectorCategory = "autogen"
 )
 
 // ToolKind drives detector applicability.
@@ -78,7 +82,11 @@ const (
 	// factory / DynamicStructuredTool / DynamicTool (TypeScript). Discovery is
 	// import-gated so it does not collide with the Claude-SDK @tool / tool()
 	// shapes that share the same callee name.
-	KindLangChainTool ToolKind = "langchain_tool"
+	KindLangChainTool  ToolKind = "langchain_tool"
+	KindCrewAITool     ToolKind = "crewai_tool"
+	KindPydanticAITool ToolKind = "pydantic_ai_tool"
+	KindVercelAITool   ToolKind = "vercel_ai_tool"
+	KindAutoGenTool    ToolKind = "autogen_tool"
 )
 
 // Language identifies the source language of a discovered tool. Rules
@@ -211,6 +219,10 @@ const (
 	SDKMCP            SDK = "mcp"
 	SDKGoogleADK      SDK = "google_adk"
 	SDKLangChain      SDK = "langchain" // LangChain + LangGraph (one ecosystem, one SDK row)
+	SDKCrewAI         SDK = "crewai"
+	SDKPydanticAI     SDK = "pydantic_ai"
+	SDKVercelAI       SDK = "vercel_ai"
+	SDKAutoGen        SDK = "autogen"
 )
 
 // "openshell" is intentionally NOT in the SDK enum: it is not a library

--- a/internal/rules/loader.go
+++ b/internal/rules/loader.go
@@ -74,10 +74,12 @@ func Load(fsys fs.FS) ([]PolicyFile, error) {
 			switch pf.Policy.Category {
 			case models.CategoryClaudeSDK, models.CategoryOpenAISDK,
 				models.CategoryOpenShell, models.CategoryGoogleADK,
-				models.CategoryMCP, models.CategoryLangChain:
+				models.CategoryMCP, models.CategoryLangChain,
+				models.CategoryCrewAI, models.CategoryPydanticAI,
+				models.CategoryVercelAI, models.CategoryAutoGen:
 				// valid
 			default:
-				errs = append(errs, fmt.Errorf("%s: unknown category %q (allowed: claude_sdk, openai_sdk, openshell, google_adk, mcp, langchain)", name, pf.Policy.Category))
+				errs = append(errs, fmt.Errorf("%s: unknown category %q (allowed: claude_sdk, openai_sdk, openshell, google_adk, mcp, langchain, crewai, pydantic_ai, vercel_ai, autogen)", name, pf.Policy.Category))
 			}
 		}
 		if len(errs) > policyErrCount {
@@ -221,7 +223,9 @@ func validRepoHasSDKInCode(tok string) bool {
 	switch tok {
 	case string(models.SDKClaudeAgentSDK), string(models.SDKOpenAIAgents),
 		string(models.SDKGoogleADK), string(models.SDKMCP),
-		string(models.SDKLangChain), "openshell":
+		string(models.SDKLangChain), "openshell",
+		string(models.SDKCrewAI), string(models.SDKPydanticAI),
+		string(models.SDKVercelAI), string(models.SDKAutoGen):
 		return true
 	}
 	return false
@@ -233,7 +237,8 @@ func validAppliesToForScope(scope models.Scope, kind string) bool {
 		switch kind {
 		case "claude_sdk_tool", "openai_tool", "mcp_tool",
 			"shell_invocation", "unknown", "adk_function_tool",
-			"langchain_tool":
+			"langchain_tool",
+			"crewai_tool", "pydantic_ai_tool", "vercel_ai_tool", "autogen_tool":
 			return true
 		}
 	case models.ScopeAgent:
@@ -242,13 +247,18 @@ func validAppliesToForScope(scope models.Scope, kind string) bool {
 			"claude_query_main",
 			"adk_llm_agent", "adk_sequential_agent", "adk_parallel_agent",
 			"adk_loop_agent", "adk_langgraph_agent",
-			"langchain_agent", "langchain_agent_executor", "langchain_state_graph":
+			"langchain_agent", "langchain_agent_executor", "langchain_state_graph",
+			"crewai_agent", "pydantic_ai_agent", "vercel_ai_agent",
+			"autogen_conversable_agent", "autogen_user_proxy_agent",
+			"autogen_assistant_agent", "autogen_group_chat_manager",
+			"autogen_code_executor_agent":
 			return true
 		}
 	case models.ScopeRepo:
 		switch kind {
 		case "claude_sdk", "openai_agents", "openshell", "mcp", "google_adk",
-			"langchain":
+			"langchain",
+			"crewai", "pydantic_ai", "vercel_ai", "autogen":
 			return true
 		}
 	case models.ScopeSubagent:

--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -261,6 +261,328 @@ import { z } from "zod";
 export const t = tool(async (i) => i.q, { name: "x", description: "X.", schema: z.object({ q: z.string() }) });
 `},
 
+	// ─── Vercel AI SDK tool rules (VAI-*) ───────────────────────────────────
+	// Import-gated to the bare `ai` module; tool name comes from the agent's
+	// tools-record KEY so ToolDef.Name is empty (VarName carries the binding).
+	{name: "VAI-001 fires on TS subprocess", ruleID: "VAI-001", kind: models.KindVercelAITool, lang: models.LanguageTypeScript, wantFires: true, src: `
+import { tool } from "ai";
+import { z } from "zod";
+import { execSync } from "child_process";
+export const t = tool({ description: "run", inputSchema: z.object({ cmd: z.string() }), execute: async ({ cmd }) => {
+  return execSync(cmd).toString();
+} });
+`},
+	{name: "VAI-001 silent without TS shell", ruleID: "VAI-001", kind: models.KindVercelAITool, lang: models.LanguageTypeScript, wantFires: false, src: `
+import { tool } from "ai";
+import { z } from "zod";
+export const t = tool({ description: "add", inputSchema: z.object({ a: z.number() }), execute: async ({ a }) => a + 1 });
+`},
+
+	{name: "VAI-002 fires on TS eval", ruleID: "VAI-002", kind: models.KindVercelAITool, lang: models.LanguageTypeScript, wantFires: true, src: `
+import { tool } from "ai";
+import { z } from "zod";
+export const t = tool({ description: "calc", inputSchema: z.object({ expr: z.string() }), execute: async ({ expr }) => eval(expr) });
+`},
+	{name: "VAI-002 silent without TS eval", ruleID: "VAI-002", kind: models.KindVercelAITool, lang: models.LanguageTypeScript, wantFires: false, src: `
+import { tool } from "ai";
+import { z } from "zod";
+export const t = tool({ description: "calc", inputSchema: z.object({ a: z.number() }), execute: async ({ a }) => a * 2 });
+`},
+
+	{name: "VAI-003 fires on TS dynamic URL", ruleID: "VAI-003", kind: models.KindVercelAITool, lang: models.LanguageTypeScript, wantFires: true, src: `
+import { tool } from "ai";
+import { z } from "zod";
+export const t = tool({ description: "get", inputSchema: z.object({ url: z.string() }), execute: async ({ url }) => {
+  const r = await fetch(url);
+  return r.text();
+} });
+`},
+	{name: "VAI-003 silent on TS literal URL", ruleID: "VAI-003", kind: models.KindVercelAITool, lang: models.LanguageTypeScript, wantFires: false, src: `
+import { tool } from "ai";
+import { z } from "zod";
+export const t = tool({ description: "get", inputSchema: z.object({ q: z.string() }), execute: async () => {
+  const r = await fetch("https://api.example.com/status");
+  return r.text();
+} });
+`},
+
+	{name: "VAI-004 fires on tool with no description", ruleID: "VAI-004", kind: models.KindVercelAITool, lang: models.LanguageTypeScript, wantFires: true, src: `
+import { tool } from "ai";
+import { z } from "zod";
+export const t = tool({ inputSchema: z.object({ q: z.string() }), execute: async ({ q }) => q });
+`},
+	{name: "VAI-004 silent with description", ruleID: "VAI-004", kind: models.KindVercelAITool, lang: models.LanguageTypeScript, wantFires: false, src: `
+import { tool } from "ai";
+import { z } from "zod";
+export const t = tool({ description: "Echoes the query.", inputSchema: z.object({ q: z.string() }), execute: async ({ q }) => q });
+`},
+
+	// VAI-005: dynamicTool is always untyped (fire); an empty z.object({}) is an
+	// open schema (fire); a concrete Zod object is typed (silent).
+	{name: "VAI-005 fires on dynamicTool", ruleID: "VAI-005", kind: models.KindVercelAITool, lang: models.LanguageTypeScript, wantFires: true, src: `
+import { dynamicTool } from "ai";
+import { z } from "zod";
+export const t = dynamicTool({ description: "x", inputSchema: z.unknown(), execute: async (input) => input });
+`},
+	{name: "VAI-005 fires on empty z.object schema", ruleID: "VAI-005", kind: models.KindVercelAITool, lang: models.LanguageTypeScript, wantFires: true, src: `
+import { tool } from "ai";
+import { z } from "zod";
+export const t = tool({ description: "x", inputSchema: z.object({}), execute: async () => 1 });
+`},
+	{name: "VAI-005 silent with typed zod schema", ruleID: "VAI-005", kind: models.KindVercelAITool, lang: models.LanguageTypeScript, wantFires: false, src: `
+import { tool } from "ai";
+import { z } from "zod";
+export const t = tool({ description: "x", inputSchema: z.object({ city: z.string() }), execute: async ({ city }) => city });
+`},
+
+	// ─── CrewAI tool rules (CREW-*) ─────────────────────────────────────────
+	{name: "CREW-001 fires on tool with no docstring", ruleID: "CREW-001", kind: models.KindCrewAITool, src: `
+def search(q: str) -> str:
+    return q
+`, wantFires: true},
+	{name: "CREW-001 silent with docstring", ruleID: "CREW-001", kind: models.KindCrewAITool, src: `
+def search(q: str) -> str:
+    """Search the web."""
+    return q
+`, wantFires: false},
+
+	{name: "CREW-002 fires on untyped params", ruleID: "CREW-002", kind: models.KindCrewAITool, src: `
+def search(q):
+    """Search."""
+    return q
+`, wantFires: true},
+	{name: "CREW-002 silent with typed params", ruleID: "CREW-002", kind: models.KindCrewAITool, src: `
+def search(q: str) -> str:
+    """Search."""
+    return q
+`, wantFires: false},
+	{name: "CREW-002 silent with no params", ruleID: "CREW-002", kind: models.KindCrewAITool, src: `
+def now() -> str:
+    """No params, no problem."""
+    return "ok"
+`, wantFires: false},
+
+	{name: "CREW-003 fires on eval", ruleID: "CREW-003", kind: models.KindCrewAITool, src: `
+def calc(expr: str) -> str:
+    """Calculate."""
+    return eval(expr)
+`, wantFires: true},
+	{name: "CREW-003 silent without eval", ruleID: "CREW-003", kind: models.KindCrewAITool, src: `
+def calc(expr: str) -> str:
+    """Calculate."""
+    return expr
+`, wantFires: false},
+
+	{name: "CREW-004 fires on subprocess", ruleID: "CREW-004", kind: models.KindCrewAITool, src: `
+def run(cmd: str) -> str:
+    """Run a command."""
+    import subprocess
+    return subprocess.run(cmd, shell=True)
+`, wantFires: true},
+	{name: "CREW-004 silent without shell", ruleID: "CREW-004", kind: models.KindCrewAITool, src: `
+def run(cmd: str) -> str:
+    """Run."""
+    return cmd
+`, wantFires: false},
+
+	{name: "CREW-005 fires on dynamic URL", ruleID: "CREW-005", kind: models.KindCrewAITool, src: `
+def fetch(url: str) -> str:
+    """Fetch a URL."""
+    import requests
+    return requests.get(url).text
+`, wantFires: true},
+	{name: "CREW-005 silent on literal URL", ruleID: "CREW-005", kind: models.KindCrewAITool, src: `
+def fetch(q: str) -> str:
+    """Fetch."""
+    import requests
+    return requests.get("https://api.example.com/data").text
+`, wantFires: false},
+
+	{name: "CREW-006 fires on mutating tool without key", ruleID: "CREW-006", kind: models.KindCrewAITool, src: `
+def create_order(customer_id: str, amount: float) -> dict:
+    """Create an order."""
+    return {"ok": True}
+`, wantFires: true},
+	{name: "CREW-006 silent with idempotency key", ruleID: "CREW-006", kind: models.KindCrewAITool, src: `
+def create_order(customer_id: str, amount: float, idempotency_key: str) -> dict:
+    """Create an order."""
+    return {"ok": True}
+`, wantFires: false},
+
+	{name: "CREW-108 fires on result_as_answer=True", ruleID: "CREW-108", kind: models.KindCrewAITool, src: `
+def f(x: str) -> str:
+    """Doc."""
+    return x
+`, toolConfig: map[string]string{"result_as_answer": "True"}, wantFires: true},
+	{name: "CREW-108 silent without result_as_answer", ruleID: "CREW-108", kind: models.KindCrewAITool, src: `
+def f(x: str) -> str:
+    """Doc."""
+    return x
+`, toolConfig: map[string]string{}, wantFires: false},
+
+	// ─── AutoGen tool rules (AG2-*) ─────────────────────────────────────────
+	{name: "AG2-007 fires on tool with no docstring", ruleID: "AG2-007", kind: models.KindAutoGenTool, src: `
+def search(q: str) -> str:
+    return q
+`, wantFires: true},
+	{name: "AG2-007 silent with docstring", ruleID: "AG2-007", kind: models.KindAutoGenTool, src: `
+def search(q: str) -> str:
+    """Search the web."""
+    return q
+`, wantFires: false},
+
+	{name: "AG2-008 fires on untyped params", ruleID: "AG2-008", kind: models.KindAutoGenTool, src: `
+def search(q):
+    """Search."""
+    return q
+`, wantFires: true},
+	{name: "AG2-008 silent with typed params", ruleID: "AG2-008", kind: models.KindAutoGenTool, src: `
+def search(q: str) -> str:
+    """Search."""
+    return q
+`, wantFires: false},
+	{name: "AG2-008 silent with no params", ruleID: "AG2-008", kind: models.KindAutoGenTool, src: `
+def now() -> str:
+    """No params, no problem."""
+    return "ok"
+`, wantFires: false},
+
+	{name: "AG2-009 fires on subprocess", ruleID: "AG2-009", kind: models.KindAutoGenTool, src: `
+def run(cmd: str) -> str:
+    """Run a command."""
+    import subprocess
+    return subprocess.run(cmd, shell=True)
+`, wantFires: true},
+	{name: "AG2-009 silent without shell", ruleID: "AG2-009", kind: models.KindAutoGenTool, src: `
+def run(cmd: str) -> str:
+    """Run."""
+    return cmd
+`, wantFires: false},
+
+	{name: "AG2-010 fires on eval", ruleID: "AG2-010", kind: models.KindAutoGenTool, src: `
+def calc(expr: str) -> str:
+    """Calculate."""
+    return eval(expr)
+`, wantFires: true},
+	{name: "AG2-010 silent without eval", ruleID: "AG2-010", kind: models.KindAutoGenTool, src: `
+def calc(expr: str) -> str:
+    """Calculate."""
+    return expr
+`, wantFires: false},
+
+	{name: "AG2-011 fires on dynamic URL", ruleID: "AG2-011", kind: models.KindAutoGenTool, src: `
+def fetch(url: str) -> str:
+    """Fetch a URL."""
+    import requests
+    return requests.get(url).text
+`, wantFires: true},
+	{name: "AG2-011 silent on literal URL", ruleID: "AG2-011", kind: models.KindAutoGenTool, src: `
+def fetch(q: str) -> str:
+    """Fetch."""
+    import requests
+    return requests.get("https://api.example.com/data").text
+`, wantFires: false},
+
+	{name: "AG2-012 fires on network call without timeout", ruleID: "AG2-012", kind: models.KindAutoGenTool, src: `
+def fetch(q: str) -> str:
+    """Fetch."""
+    import requests
+    return requests.get("https://api.example.com/data").text
+`, wantFires: true},
+	{name: "AG2-012 silent with timeout", ruleID: "AG2-012", kind: models.KindAutoGenTool, src: `
+def fetch(q: str) -> str:
+    """Fetch."""
+    import requests
+    return requests.get("https://api.example.com/data", timeout=10).text
+`, wantFires: false},
+
+	// ─── Pydantic AI tool rules (PYD-*) ─────────────────────────────────────
+	{name: "PYD-001 fires on tool with no docstring", ruleID: "PYD-001", kind: models.KindPydanticAITool, src: `
+def search(q: str) -> str:
+    return q
+`, wantFires: true},
+	{name: "PYD-001 silent with docstring", ruleID: "PYD-001", kind: models.KindPydanticAITool, src: `
+def search(q: str) -> str:
+    """Search the web."""
+    return q
+`, wantFires: false},
+
+	{name: "PYD-002 fires on untyped params", ruleID: "PYD-002", kind: models.KindPydanticAITool, src: `
+def search(q):
+    """Search."""
+    return q
+`, wantFires: true},
+	{name: "PYD-002 silent with typed params", ruleID: "PYD-002", kind: models.KindPydanticAITool, src: `
+def search(q: str) -> str:
+    """Search."""
+    return q
+`, wantFires: false},
+	{name: "PYD-002 silent with no params", ruleID: "PYD-002", kind: models.KindPydanticAITool, src: `
+def now() -> str:
+    """No params, no problem."""
+    return "ok"
+`, wantFires: false},
+
+	{name: "PYD-003 fires on subprocess", ruleID: "PYD-003", kind: models.KindPydanticAITool, src: `
+def run(cmd: str) -> str:
+    """Run a command."""
+    import subprocess
+    return subprocess.run(cmd, shell=True)
+`, wantFires: true},
+	{name: "PYD-003 silent without shell", ruleID: "PYD-003", kind: models.KindPydanticAITool, src: `
+def run(cmd: str) -> str:
+    """Run."""
+    return cmd
+`, wantFires: false},
+
+	{name: "PYD-004 fires on eval", ruleID: "PYD-004", kind: models.KindPydanticAITool, src: `
+def calc(expr: str) -> str:
+    """Calculate."""
+    return eval(expr)
+`, wantFires: true},
+	{name: "PYD-004 silent without eval", ruleID: "PYD-004", kind: models.KindPydanticAITool, src: `
+def calc(expr: str) -> str:
+    """Calculate."""
+    return expr
+`, wantFires: false},
+
+	{name: "PYD-005 fires on dynamic URL", ruleID: "PYD-005", kind: models.KindPydanticAITool, src: `
+def fetch(url: str) -> str:
+    """Fetch a URL."""
+    import requests
+    return requests.get(url).text
+`, wantFires: true},
+	{name: "PYD-005 silent on literal URL", ruleID: "PYD-005", kind: models.KindPydanticAITool, src: `
+def fetch(q: str) -> str:
+    """Fetch."""
+    import requests
+    return requests.get("https://api.example.com/data").text
+`, wantFires: false},
+
+	{name: "PYD-006 fires on network call without timeout", ruleID: "PYD-006", kind: models.KindPydanticAITool, src: `
+def fetch(q: str) -> str:
+    """Fetch."""
+    import requests
+    return requests.get("https://api.example.com/data").text
+`, wantFires: true},
+	{name: "PYD-006 silent with timeout", ruleID: "PYD-006", kind: models.KindPydanticAITool, src: `
+def fetch(q: str) -> str:
+    """Fetch."""
+    import requests
+    return requests.get("https://api.example.com/data", timeout=10).text
+`, wantFires: false},
+
+	{name: "PYD-007 fires on mutating tool without key", ruleID: "PYD-007", kind: models.KindPydanticAITool, src: `
+def create_order(customer_id: str, amount: float) -> dict:
+    """Create an order."""
+    return {"ok": True}
+`, wantFires: true},
+	{name: "PYD-007 silent with idempotency key", ruleID: "PYD-007", kind: models.KindPydanticAITool, src: `
+def create_order(customer_id: str, amount: float, idempotency_key: str) -> dict:
+    """Create an order."""
+    return {"ok": True}
+`, wantFires: false},
+
 	// ─── CSDK-001 missing docstring ─────────────────────────────────────────
 	{name: "CSDK-001 fires on missing docstring", ruleID: "CSDK-001", kind: models.KindClaudeSDKTool, src: `
 def fetch_data(x: str) -> dict:
@@ -1454,6 +1776,54 @@ var policyRepoRuleCases = []policyRepoCase{
 		},
 		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKLangChain}},
 		false},
+	// ─── CrewAI repo rule (CREW-201) ─────────────────────────────────────────
+	{"CREW-201 fires when CrewAI code has no agent-guidance doc", "CREW-201",
+		models.RepoProfile{Languages: []models.Language{models.LanguagePython}},
+		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKCrewAI}},
+		true},
+	{"CREW-201 silent when AGENTS.md present", "CREW-201",
+		models.RepoProfile{
+			Languages: []models.Language{models.LanguagePython},
+			Manifest:  models.ScanManifest{Components: []models.AgentComponent{{Kind: models.ComponentAgentsMd}}},
+		},
+		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKCrewAI}},
+		false},
+	// ─── AutoGen repo rule (AG2-201) ─────────────────────────────────────────
+	{"AG2-201 fires when AutoGen code has no agent-guidance doc", "AG2-201",
+		models.RepoProfile{Languages: []models.Language{models.LanguagePython}},
+		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKAutoGen}},
+		true},
+	{"AG2-201 silent when AGENTS.md present", "AG2-201",
+		models.RepoProfile{
+			Languages: []models.Language{models.LanguagePython},
+			Manifest:  models.ScanManifest{Components: []models.AgentComponent{{Kind: models.ComponentAgentsMd}}},
+		},
+		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKAutoGen}},
+		false},
+	// ─── Pydantic AI repo rule (PYD-201) ─────────────────────────────────────
+	{"PYD-201 fires when Pydantic AI code has no agent-guidance doc", "PYD-201",
+		models.RepoProfile{Languages: []models.Language{models.LanguagePython}},
+		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKPydanticAI}},
+		true},
+	{"PYD-201 silent when AGENTS.md present", "PYD-201",
+		models.RepoProfile{
+			Languages: []models.Language{models.LanguagePython},
+			Manifest:  models.ScanManifest{Components: []models.AgentComponent{{Kind: models.ComponentAgentsMd}}},
+		},
+		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKPydanticAI}},
+		false},
+	// ─── Vercel AI repo rule (VAI-012) ───────────────────────────────────────
+	{"VAI-012 fires when Vercel AI code has no agent-guidance doc", "VAI-012",
+		models.RepoProfile{Languages: []models.Language{models.LanguageTypeScript}},
+		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKVercelAI}},
+		true},
+	{"VAI-012 silent when CLAUDE.md present", "VAI-012",
+		models.RepoProfile{
+			Languages: []models.Language{models.LanguageTypeScript},
+			Manifest:  models.ScanManifest{Components: []models.AgentComponent{{Kind: models.ComponentClaudeMd}}},
+		},
+		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKVercelAI}},
+		false},
 	// ─── OAI-201 default tracing (repo-scoped) ───────────────────────────────
 	{"OAI-201 fires when using default tracing", "OAI-201",
 		models.RepoProfile{Languages: []models.Language{models.LanguagePython}},
@@ -1665,6 +2035,187 @@ var policyAgentRuleCases = []policyAgentCase{
 				"maxIterations": {Value: &models.Expr{Kind: models.ExprLiteralInt, Text: "5"}},
 			}}},
 		models.RepoInventory{}, false},
+
+	// ─── CrewAI agent rules (CREW-*) ────────────────────────────────────────
+	{"CREW-101 fires when allow_code_execution=True", "CREW-101",
+		models.AgentDef{
+			SDK: models.SDKCrewAI, Class: "Agent", Language: models.LanguagePython,
+			Kwargs: &models.KwargTree{Children: map[string]*models.KwargTree{
+				"allow_code_execution": {Value: &models.Expr{Kind: models.ExprLiteralBool, Text: "True"}},
+			}}},
+		models.RepoInventory{}, true},
+	{"CREW-101 silent when allow_code_execution=False", "CREW-101",
+		models.AgentDef{
+			SDK: models.SDKCrewAI, Class: "Agent", Language: models.LanguagePython,
+			Kwargs: &models.KwargTree{Children: map[string]*models.KwargTree{
+				"allow_code_execution": {Value: &models.Expr{Kind: models.ExprLiteralBool, Text: "False"}},
+			}}},
+		models.RepoInventory{}, false},
+
+	{"CREW-102 fires when code_execution_mode=unsafe", "CREW-102",
+		models.AgentDef{
+			SDK: models.SDKCrewAI, Class: "Agent", Language: models.LanguagePython,
+			Kwargs: &models.KwargTree{Children: map[string]*models.KwargTree{
+				"code_execution_mode": {Value: &models.Expr{Kind: models.ExprLiteralString, Text: `"unsafe"`}},
+			}}},
+		models.RepoInventory{}, true},
+	{"CREW-102 silent when code_execution_mode=safe (default)", "CREW-102",
+		models.AgentDef{
+			SDK: models.SDKCrewAI, Class: "Agent", Language: models.LanguagePython,
+			Kwargs: &models.KwargTree{Children: map[string]*models.KwargTree{
+				"code_execution_mode": {Value: &models.Expr{Kind: models.ExprLiteralString, Text: `"safe"`}},
+			}}},
+		models.RepoInventory{}, false},
+
+	{"CREW-103 fires when agent wires CodeInterpreterTool", "CREW-103",
+		models.AgentDef{
+			SDK: models.SDKCrewAI, Class: "Agent", Language: models.LanguagePython,
+			HostedToolRefs: []models.HostedToolRef{{Class: "CodeInterpreterTool"}},
+		},
+		models.RepoInventory{}, true},
+	{"CREW-103 silent without the code interpreter", "CREW-103",
+		models.AgentDef{SDK: models.SDKCrewAI, Class: "Agent", Language: models.LanguagePython},
+		models.RepoInventory{}, false},
+
+	{"CREW-104 fires when allow_delegation=True", "CREW-104",
+		models.AgentDef{
+			SDK: models.SDKCrewAI, Class: "Agent", Language: models.LanguagePython,
+			Kwargs: &models.KwargTree{Children: map[string]*models.KwargTree{
+				"allow_delegation": {Value: &models.Expr{Kind: models.ExprLiteralBool, Text: "True"}},
+			}}},
+		models.RepoInventory{}, true},
+	{"CREW-104 silent when allow_delegation=False", "CREW-104",
+		models.AgentDef{
+			SDK: models.SDKCrewAI, Class: "Agent", Language: models.LanguagePython,
+			Kwargs: &models.KwargTree{Children: map[string]*models.KwargTree{
+				"allow_delegation": {Value: &models.Expr{Kind: models.ExprLiteralBool, Text: "False"}},
+			}}},
+		models.RepoInventory{}, false},
+
+	{"CREW-106 fires when FileReadTool has no file_path", "CREW-106",
+		models.AgentDef{
+			SDK: models.SDKCrewAI, Class: "Agent", Language: models.LanguagePython,
+			HostedToolRefs: []models.HostedToolRef{
+				{Class: "FileReadTool", Resolved: &models.HostedToolDef{Class: "FileReadTool"}},
+			}},
+		models.RepoInventory{}, true},
+	{"CREW-106 silent when FileReadTool pins file_path", "CREW-106",
+		models.AgentDef{
+			SDK: models.SDKCrewAI, Class: "Agent", Language: models.LanguagePython,
+			HostedToolRefs: []models.HostedToolRef{
+				{Class: "FileReadTool", Resolved: &models.HostedToolDef{Class: "FileReadTool",
+					Kwargs: &models.KwargTree{Children: map[string]*models.KwargTree{
+						"file_path": {Value: &models.Expr{Kind: models.ExprLiteralString, Text: `"data.txt"`}},
+					}}}},
+			}},
+		models.RepoInventory{}, false},
+
+	{"CREW-107 fires when agent wires ScrapeWebsiteTool", "CREW-107",
+		models.AgentDef{
+			SDK: models.SDKCrewAI, Class: "Agent", Language: models.LanguagePython,
+			HostedToolRefs: []models.HostedToolRef{{Class: "ScrapeWebsiteTool"}},
+		},
+		models.RepoInventory{}, true},
+	{"CREW-107 silent without a URL-fetching builtin", "CREW-107",
+		models.AgentDef{SDK: models.SDKCrewAI, Class: "Agent", Language: models.LanguagePython},
+		models.RepoInventory{}, false},
+
+	// ─── AutoGen agent rules (AG2-*) ────────────────────────────────────────
+	// AG2-001: code_execution_config={"use_docker": False} — nested kwarg path.
+	{"AG2-001 fires when use_docker=False", "AG2-001",
+		models.AgentDef{
+			SDK: models.SDKAutoGen, Class: "UserProxyAgent", Language: models.LanguagePython,
+			Kwargs: &models.KwargTree{Children: map[string]*models.KwargTree{
+				"code_execution_config": {Children: map[string]*models.KwargTree{
+					"use_docker": {Value: &models.Expr{Kind: models.ExprLiteralBool, Text: "False"}},
+				}},
+			}}},
+		models.RepoInventory{}, true},
+	{"AG2-001 silent when use_docker=True", "AG2-001",
+		models.AgentDef{
+			SDK: models.SDKAutoGen, Class: "UserProxyAgent", Language: models.LanguagePython,
+			Kwargs: &models.KwargTree{Children: map[string]*models.KwargTree{
+				"code_execution_config": {Children: map[string]*models.KwargTree{
+					"use_docker": {Value: &models.Expr{Kind: models.ExprLiteralBool, Text: "True"}},
+				}},
+			}}},
+		models.RepoInventory{}, false},
+
+	// AG2-002: human_input_mode=NEVER AND code_execution_config present.
+	{"AG2-002 fires when human_input_mode=NEVER with code exec", "AG2-002",
+		models.AgentDef{
+			SDK: models.SDKAutoGen, Class: "UserProxyAgent", Language: models.LanguagePython,
+			Kwargs: &models.KwargTree{Children: map[string]*models.KwargTree{
+				"human_input_mode": {Value: &models.Expr{Kind: models.ExprLiteralString, Text: `"NEVER"`}},
+				"code_execution_config": {Children: map[string]*models.KwargTree{
+					"use_docker": {Value: &models.Expr{Kind: models.ExprLiteralBool, Text: "True"}},
+				}},
+			}}},
+		models.RepoInventory{}, true},
+	{"AG2-002 silent when human_input_mode=ALWAYS", "AG2-002",
+		models.AgentDef{
+			SDK: models.SDKAutoGen, Class: "UserProxyAgent", Language: models.LanguagePython,
+			Kwargs: &models.KwargTree{Children: map[string]*models.KwargTree{
+				"human_input_mode": {Value: &models.Expr{Kind: models.ExprLiteralString, Text: `"ALWAYS"`}},
+				"code_execution_config": {Children: map[string]*models.KwargTree{
+					"use_docker": {Value: &models.Expr{Kind: models.ExprLiteralBool, Text: "True"}},
+				}},
+			}}},
+		models.RepoInventory{}, false},
+
+	// AG2-004: GroupChatManager / GroupChat with no max_round.
+	{"AG2-004 fires when GroupChatManager has no max_round", "AG2-004",
+		models.AgentDef{
+			SDK: models.SDKAutoGen, Class: "GroupChatManager", Language: models.LanguagePython,
+			Kwargs: &models.KwargTree{Children: map[string]*models.KwargTree{}}},
+		models.RepoInventory{}, true},
+	{"AG2-004 silent when max_round is set", "AG2-004",
+		models.AgentDef{
+			SDK: models.SDKAutoGen, Class: "GroupChat", Language: models.LanguagePython,
+			Kwargs: &models.KwargTree{Children: map[string]*models.KwargTree{
+				"max_round": {Value: &models.Expr{Kind: models.ExprLiteralInt, Text: "12"}},
+			}}},
+		models.RepoInventory{}, false},
+
+	// AG2-005: AssistantAgent with code_execution_config present.
+	{"AG2-005 fires when AssistantAgent enables code exec", "AG2-005",
+		models.AgentDef{
+			SDK: models.SDKAutoGen, Class: "AssistantAgent", Language: models.LanguagePython,
+			Kwargs: &models.KwargTree{Children: map[string]*models.KwargTree{
+				"code_execution_config": {Children: map[string]*models.KwargTree{
+					"use_docker": {Value: &models.Expr{Kind: models.ExprLiteralBool, Text: "True"}},
+				}},
+			}}},
+		models.RepoInventory{}, true},
+	{"AG2-005 silent when AssistantAgent has no code exec", "AG2-005",
+		models.AgentDef{
+			SDK: models.SDKAutoGen, Class: "AssistantAgent", Language: models.LanguagePython,
+			Kwargs: &models.KwargTree{Children: map[string]*models.KwargTree{
+				"llm_config": {Value: &models.Expr{Kind: models.ExprNameRef, Text: "llm_config"}},
+			}}},
+		models.RepoInventory{}, false},
+
+	// AG2-006: code_execution_config present AND no max_consecutive_auto_reply.
+	{"AG2-006 fires when code exec has no auto-reply cap", "AG2-006",
+		models.AgentDef{
+			SDK: models.SDKAutoGen, Class: "UserProxyAgent", Language: models.LanguagePython,
+			Kwargs: &models.KwargTree{Children: map[string]*models.KwargTree{
+				"code_execution_config": {Children: map[string]*models.KwargTree{
+					"use_docker": {Value: &models.Expr{Kind: models.ExprLiteralBool, Text: "True"}},
+				}},
+			}}},
+		models.RepoInventory{}, true},
+	{"AG2-006 silent when max_consecutive_auto_reply is set", "AG2-006",
+		models.AgentDef{
+			SDK: models.SDKAutoGen, Class: "UserProxyAgent", Language: models.LanguagePython,
+			Kwargs: &models.KwargTree{Children: map[string]*models.KwargTree{
+				"code_execution_config": {Children: map[string]*models.KwargTree{
+					"use_docker": {Value: &models.Expr{Kind: models.ExprLiteralBool, Text: "True"}},
+				}},
+				"max_consecutive_auto_reply": {Value: &models.Expr{Kind: models.ExprLiteralInt, Text: "3"}},
+			}}},
+		models.RepoInventory{}, false},
+
 	// ─── OAI-101 no input_guardrails + shell tools ────────────────────────────
 	{"OAI-101 fires when no guardrails and has shell tool", "OAI-101",
 		models.AgentDef{
@@ -2499,6 +3050,111 @@ var policyAgentRuleCases = []policyAgentCase{
 	{"ADK-109 silent when TS LlmAgent has description", "ADK-109",
 		parseTSADKAgentInline("import { LlmAgent } from \"@google/adk\";\n" +
 			"const a = new LlmAgent({ name: \"x\", model: \"gemini-2.0-flash\", description: \"routes billing questions\" });\n"),
+		models.RepoInventory{},
+		false},
+
+	// ─── Pydantic AI agent rules (PYD-*) ─────────────────────────────────────
+	// PYD-101: output_type omitted (free-form str) fires; output_type=str fires
+	// explicitly; output_type set to a Pydantic model (Result) is validated → silent.
+	{"PYD-101 fires when output_type omitted", "PYD-101",
+		models.AgentDef{SDK: models.SDKPydanticAI, Class: "PydanticAgent", Language: models.LanguagePython},
+		models.RepoInventory{}, true},
+	{"PYD-101 fires when output_type=str", "PYD-101",
+		models.AgentDef{
+			SDK: models.SDKPydanticAI, Class: "PydanticAgent", Language: models.LanguagePython,
+			Kwargs: &models.KwargTree{Children: map[string]*models.KwargTree{
+				"output_type": {Value: &models.Expr{Kind: models.ExprNameRef, Text: "str"}},
+			}}},
+		models.RepoInventory{}, true},
+	{"PYD-101 silent when output_type is a validated model", "PYD-101",
+		models.AgentDef{
+			SDK: models.SDKPydanticAI, Class: "PydanticAgent", Language: models.LanguagePython,
+			Kwargs: &models.KwargTree{Children: map[string]*models.KwargTree{
+				"output_type": {Value: &models.Expr{Kind: models.ExprNameRef, Text: "Result"}},
+			}}},
+		models.RepoInventory{}, false},
+
+	{"PYD-102 fires when agent wires CodeExecutionTool", "PYD-102",
+		models.AgentDef{
+			SDK: models.SDKPydanticAI, Class: "PydanticAgent", Language: models.LanguagePython,
+			HostedToolRefs: []models.HostedToolRef{{Class: "CodeExecutionTool"}},
+		},
+		models.RepoInventory{}, true},
+	{"PYD-102 silent without the code-execution tool", "PYD-102",
+		models.AgentDef{SDK: models.SDKPydanticAI, Class: "PydanticAgent", Language: models.LanguagePython},
+		models.RepoInventory{}, false},
+
+	{"PYD-103 fires when agent wires WebFetchTool", "PYD-103",
+		models.AgentDef{
+			SDK: models.SDKPydanticAI, Class: "PydanticAgent", Language: models.LanguagePython,
+			HostedToolRefs: []models.HostedToolRef{{Class: "WebFetchTool"}},
+		},
+		models.RepoInventory{}, true},
+	{"PYD-103 silent without a URL-fetching native tool", "PYD-103",
+		models.AgentDef{SDK: models.SDKPydanticAI, Class: "PydanticAgent", Language: models.LanguagePython},
+		models.RepoInventory{}, false},
+
+	{"PYD-105 fires when end_strategy=exhaustive", "PYD-105",
+		models.AgentDef{
+			SDK: models.SDKPydanticAI, Class: "PydanticAgent", Language: models.LanguagePython,
+			Kwargs: &models.KwargTree{Children: map[string]*models.KwargTree{
+				"end_strategy": {Value: &models.Expr{Kind: models.ExprLiteralString, Text: `"exhaustive"`}},
+			}}},
+		models.RepoInventory{}, true},
+	{"PYD-105 silent when end_strategy=early (default)", "PYD-105",
+		models.AgentDef{
+			SDK: models.SDKPydanticAI, Class: "PydanticAgent", Language: models.LanguagePython,
+			Kwargs: &models.KwargTree{Children: map[string]*models.KwargTree{
+				"end_strategy": {Value: &models.Expr{Kind: models.ExprLiteralString, Text: `"early"`}},
+			}}},
+		models.RepoInventory{}, false},
+
+	// ─── Vercel AI SDK agent rules (VAI-*) ────────────────────────────────────
+	// The object-record tools walk: a provider hosted-tool call
+	// (anthropic.tools.bash_20250124()) becomes a HostedToolRef whose canonical
+	// Class (date suffix stripped) is "anthropic.tools.bash".
+	{"VAI-006 fires when agent wires anthropic bash tool", "VAI-006",
+		parseTSVercelAgentInline("import { generateText } from \"ai\";\n" +
+			"import { anthropic } from \"@ai-sdk/anthropic\";\n" +
+			"const r = await generateText({ model: anthropic(\"claude-sonnet-4\"), tools: { bash: anthropic.tools.bash_20250124() } });\n"),
+		models.RepoInventory{},
+		true},
+	{"VAI-006 fires when ToolLoopAgent wires openai codeInterpreter", "VAI-006",
+		parseTSVercelAgentInline("import { Experimental_Agent as Agent } from \"ai\";\n" +
+			"import { openai } from \"@ai-sdk/openai\";\n" +
+			"const a = new Agent({ model: openai(\"gpt-5\"), tools: { ci: openai.tools.codeInterpreter() } });\n"),
+		models.RepoInventory{},
+		true},
+	{"VAI-006 silent when agent wires only a named user tool", "VAI-006",
+		parseTSVercelAgentInline("import { generateText } from \"ai\";\n" +
+			"import { openai } from \"@ai-sdk/openai\";\n" +
+			"const r = await generateText({ model: openai(\"gpt-5\"), tools: { weather: weatherTool } });\n"),
+		models.RepoInventory{},
+		false},
+
+	{"VAI-007 fires when tool loop has no bound", "VAI-007",
+		parseTSVercelAgentInline("import { generateText } from \"ai\";\n" +
+			"import { openai } from \"@ai-sdk/openai\";\n" +
+			"const r = await generateText({ model: openai(\"gpt-5\"), tools: { weather: weatherTool } });\n"),
+		models.RepoInventory{},
+		true},
+	{"VAI-007 silent when maxSteps set", "VAI-007",
+		parseTSVercelAgentInline("import { generateText } from \"ai\";\n" +
+			"import { openai } from \"@ai-sdk/openai\";\n" +
+			"const r = await generateText({ model: openai(\"gpt-5\"), maxSteps: 5, tools: { weather: weatherTool } });\n"),
+		models.RepoInventory{},
+		false},
+
+	{"VAI-008 fires when toolChoice required with dangerous tool", "VAI-008",
+		parseTSVercelAgentInline("import { generateText } from \"ai\";\n" +
+			"import { anthropic } from \"@ai-sdk/anthropic\";\n" +
+			"const r = await generateText({ model: anthropic(\"claude-sonnet-4\"), toolChoice: \"required\", tools: { bash: anthropic.tools.bash_20250124() } });\n"),
+		models.RepoInventory{},
+		true},
+	{"VAI-008 silent when toolChoice auto", "VAI-008",
+		parseTSVercelAgentInline("import { generateText } from \"ai\";\n" +
+			"import { anthropic } from \"@ai-sdk/anthropic\";\n" +
+			"const r = await generateText({ model: anthropic(\"claude-sonnet-4\"), toolChoice: \"auto\", tools: { bash: anthropic.tools.bash_20250124() } });\n"),
 		models.RepoInventory{},
 		false},
 }

--- a/internal/rules/predicates_test.go
+++ b/internal/rules/predicates_test.go
@@ -76,6 +76,8 @@ func parseTSTool(t *testing.T, src string, kind models.ToolKind) (models.ToolDef
 		tools = analysis.DiscoverTSMCPProper([]analysis.ParsedFile{pf}, func(string) {})
 	case models.KindLangChainTool:
 		tools = analysis.DiscoverTSLangChainTools([]analysis.ParsedFile{pf}, func(string) {})
+	case models.KindVercelAITool:
+		tools = analysis.DiscoverTSVercelTools([]analysis.ParsedFile{pf}, func(string) {})
 	default:
 		t.Fatalf("parseTSTool: unsupported kind %q", kind)
 	}
@@ -130,6 +132,24 @@ func parseTSADKAgentInline(src string) models.AgentDef {
 	agents := analysis.DiscoverTSADKAgents([]analysis.ParsedFile{pf}, func(string) {})
 	if len(agents) == 0 {
 		panic("parseTSADKAgentInline: no agent discovered")
+	}
+	return agents[0]
+}
+
+// parseTSVercelAgentInline parses a TS snippet and returns the first discovered
+// Vercel AI SDK agent. HostedToolRefs carry their canonical Class at discovery
+// (agent_uses_hosted_tool_class matches on Class, not Resolved), so no
+// ResolveEdges pass is needed for the hosted-tool-class rules. Panics (no
+// *testing.T available in package-level case tables).
+func parseTSVercelAgentInline(src string) models.AgentDef {
+	tree, err := astutil.NewTSParser().ParseCtx(context.Background(), nil, []byte(src))
+	if err != nil {
+		panic("parseTSVercelAgentInline parse: " + err.Error())
+	}
+	pf := analysis.ParsedFile{RelPath: "src/a.ts", Tree: tree, Source: []byte(src)}
+	agents := analysis.DiscoverTSVercelAgents([]analysis.ParsedFile{pf}, func(string) {})
+	if len(agents) == 0 {
+		panic("parseTSVercelAgentInline: no agent discovered")
 	}
 	return agents[0]
 }

--- a/internal/rules/rule_detector.go
+++ b/internal/rules/rule_detector.go
@@ -151,6 +151,31 @@ func agentKindMatches(kind string, a models.AgentDef) bool {
 		return a.SDK == models.SDKLangChain && a.Class == "AgentExecutor"
 	case "langchain_state_graph":
 		return a.SDK == models.SDKLangChain && a.Class == "StateGraph"
+	// CrewAI: the single Agent(...) constructor, SDK-stamped at discovery to
+	// disambiguate from the identically-named OpenAI and ADK Agent classes.
+	case "crewai_agent":
+		return a.SDK == models.SDKCrewAI && a.Class == "Agent"
+	// Pydantic AI: the lone Agent(...) constructor, normalized Class "PydanticAgent".
+	case "pydantic_ai_agent":
+		return a.SDK == models.SDKPydanticAI && a.Class == "PydanticAgent"
+	// Vercel AI SDK: one token spans every call/class agent shape
+	// (generateText / streamText / generateObject / streamObject / ToolLoopAgent);
+	// the SDK stamp is the disambiguator, so no per-Class gate is needed.
+	case "vercel_ai_agent":
+		return a.SDK == models.SDKVercelAI
+	// AutoGen / AG2: distinct tokens per class so a rule can target the executor
+	// presets (UserProxy/ConversableAgent/CodeExecutorAgent) without firing on the
+	// LLM-only AssistantAgent, and vice-versa.
+	case "autogen_conversable_agent":
+		return a.SDK == models.SDKAutoGen && a.Class == "ConversableAgent"
+	case "autogen_user_proxy_agent":
+		return a.SDK == models.SDKAutoGen && a.Class == "UserProxyAgent"
+	case "autogen_assistant_agent":
+		return a.SDK == models.SDKAutoGen && a.Class == "AssistantAgent"
+	case "autogen_group_chat_manager":
+		return a.SDK == models.SDKAutoGen && (a.Class == "GroupChatManager" || a.Class == "GroupChat")
+	case "autogen_code_executor_agent":
+		return a.SDK == models.SDKAutoGen && a.Class == "CodeExecutorAgent"
 	}
 	return false
 }
@@ -228,6 +253,14 @@ func LoadFor(fsys fs.FS, sdks []models.SDK) (*detectors.Registry, error) {
 			wanted["google_adk"] = true
 		case models.SDKLangChain:
 			wanted["langchain"] = true
+		case models.SDKCrewAI:
+			wanted["crewai"] = true
+		case models.SDKPydanticAI:
+			wanted["pydantic_ai"] = true
+		case models.SDKVercelAI:
+			wanted["vercel_ai"] = true
+		case models.SDKAutoGen:
+			wanted["autogen"] = true
 		}
 	}
 	all, err := Load(fsys)

--- a/internal/scanner/policy_selection.go
+++ b/internal/scanner/policy_selection.go
@@ -15,6 +15,11 @@ var shippedPolicySDKs = map[models.SDK]bool{
 	models.SDKOpenAIAgents:   true,
 	models.SDKMCP:            true,
 	models.SDKGoogleADK:      true,
+	models.SDKLangChain:      true, // ships the langchain/ pack (was missing → false META-001)
+	models.SDKCrewAI:         true,
+	models.SDKAutoGen:        true,
+	models.SDKPydanticAI:     true, // ships the pydantic_ai/ pack
+	models.SDKVercelAI:       true, // ships the vercel_ai/ pack
 }
 
 // depNameToSDK maps the canonical dep-file package name to the SDK enum.
@@ -22,6 +27,9 @@ var depNameToSDK = map[string]models.SDK{
 	"claude-agent-sdk": models.SDKClaudeAgentSDK,
 	"openai-agents":    models.SDKOpenAIAgents,
 	"google-adk":       models.SDKGoogleADK,
+	"crewai":           models.SDKCrewAI,
+	"autogen":          models.SDKAutoGen,
+	"pydantic-ai":      models.SDKPydanticAI,
 }
 
 // SelectAndEmitMETA inspects the profile + inventory and emits engine-level
@@ -109,6 +117,11 @@ var sdkToCategory = map[models.SDK]models.DetectorCategory{
 	models.SDKClaudeAgentSDK: models.CategoryClaudeSDK,
 	models.SDKOpenAIAgents:   models.CategoryOpenAISDK,
 	models.SDKGoogleADK:      models.CategoryGoogleADK,
+	models.SDKLangChain:      models.CategoryLangChain, // was missing → META-004 never fired for LangChain
+	models.SDKCrewAI:         models.CategoryCrewAI,
+	models.SDKAutoGen:        models.CategoryAutoGen,
+	models.SDKPydanticAI:     models.CategoryPydanticAI,
+	models.SDKVercelAI:       models.CategoryVercelAI,
 }
 
 // EmitCoverageMETA emits META-004 when an audited SDK was observed in code

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -136,8 +136,13 @@ func Run(cfg Config) (models.ScanResult, error) {
 	agents := analysis.DiscoverAgents(parsed)
 	agents = append(agents, analysis.DiscoverADKAgents(parsed)...)
 	agents = append(agents, analysis.DiscoverLangChainAgents(parsed)...)
+	agents = append(agents, analysis.DiscoverCrewAIAgents(parsed)...)
+	agents = append(agents, analysis.DiscoverAutoGenAgents(parsed)...)
+	agents = append(agents, analysis.DiscoverPydanticAIAgents(parsed)...)
 	tools = append(tools, analysis.DiscoverADKTools(parsed)...)
 	tools = append(tools, analysis.DiscoverLangChainTools(parsed)...)
+	tools = append(tools, analysis.DiscoverAutoGenTools(parsed)...)
+	tools = append(tools, analysis.DiscoverPydanticAITools(parsed)...)
 	guardrails := analysis.DiscoverGuardrails(parsed)
 	sessions := analysis.DiscoverSessions(parsed)
 
@@ -181,6 +186,11 @@ func Run(cfg Config) (models.ScanResult, error) {
 	// LangChain / LangGraph TS
 	tools = append(tools, analysis.DiscoverTSLangChainTools(tsFiles, nil)...)
 	agents = append(agents, analysis.DiscoverTSLangChainAgents(tsFiles, nil)...)
+	// Vercel AI SDK TS — tool()/dynamicTool() and generateText/streamText/
+	// generateObject/streamObject + ToolLoopAgent agents. Emits KindVercelAITool,
+	// so deriveSDKsDetected stamps SDKVercelAI and the vercel_ai pack loads.
+	tools = append(tools, analysis.DiscoverTSVercelTools(tsFiles, nil)...)
+	agents = append(agents, analysis.DiscoverTSVercelAgents(tsFiles, nil)...)
 	// MCP server authoring (@modelcontextprotocol/sdk) TS — registerTool/tool.
 	// Emits KindMCPTool, so deriveSDKsDetected stamps SDKMCP and the mcp pack
 	// loads automatically (same path as the Python MCP tools).
@@ -341,6 +351,14 @@ func deriveSDKsDetected(tools []models.ToolDef, agents []models.AgentDef, subage
 			seen[models.SDKGoogleADK] = true
 		case models.KindLangChainTool:
 			seen[models.SDKLangChain] = true
+		case models.KindCrewAITool:
+			seen[models.SDKCrewAI] = true
+		case models.KindPydanticAITool:
+			seen[models.SDKPydanticAI] = true
+		case models.KindVercelAITool:
+			seen[models.SDKVercelAI] = true
+		case models.KindAutoGenTool:
+			seen[models.SDKAutoGen] = true
 		}
 	}
 	for _, a := range agents {

--- a/scripts/check-rules-sync.sh
+++ b/scripts/check-rules-sync.sh
@@ -32,10 +32,13 @@ fi
 # every <category>/*.yaml plus the top-level manifest.yaml.
 list_yaml() { # $1 = root
   ( cd "$1"
-    for d in claude_sdk openai_sdk google_adk; do
-      [ -d "$d" ] && find "$d" -name '*.yaml'
-    done
-    [ -f manifest.yaml ] && echo manifest.yaml
+    # Every <category>/*.yaml at depth >= 2 (one entry per pack file, any
+    # category, nested or flat), discovered dynamically so a new SDK pack is
+    # covered automatically. The previous hardcoded list (claude_sdk openai_sdk
+    # google_adk) silently skipped langchain, mcp, and every later pack, so a
+    # fixture/production drift in those categories went unchecked.
+    find . -mindepth 2 -name '*.yaml'
+    [ -f manifest.yaml ] && echo ./manifest.yaml
   ) | sed 's#^\./##' | sort
 }
 

--- a/testdata/rules-fixture/autogen/agent_safety.yaml
+++ b/testdata/rules-fixture/autogen/agent_safety.yaml
@@ -1,0 +1,145 @@
+policy:
+  id: autogen_agent_safety
+  name: AutoGen agent safety
+  category: autogen
+  description: >
+    Agent-scope safety rules for AutoGen / AG2 agents. These flag constructor
+    kwargs that hand a model-driven agent host code execution with no container,
+    no human review, or no loop bound — the configurations AutoGen's own docs
+    warn against ("we strongly recommend Docker"; "local execution is not
+    recommended").
+
+rules:
+  - id: AG2-001
+    title: AutoGen executor runs code on the host without Docker
+    severity: high
+    confidence: 0.9
+    language: python
+    applies_to:
+      - autogen_conversable_agent
+      - autogen_user_proxy_agent
+    scope: agent
+    match:
+      agent_kwarg_value:
+        kwarg: code_execution_config.use_docker
+        value: "False"
+    explanation: >
+      This agent sets code_execution_config={"use_docker": False}, so every code
+      block the model emits is written to disk and executed directly on the host
+      with the agent process's privileges — no container, no isolation. Because the
+      conversation, tool outputs, and any retrieved content are all model-reachable,
+      a single prompt injection turns into host remote code execution. AutoGen's own
+      documentation strongly recommends Docker for exactly this reason: container
+      execution is the boundary that keeps model-chosen code off the host.
+    fix: >
+      Set use_docker=True (the default when Docker is available) so generated code
+      runs inside a container, or disable code execution on this agent entirely
+      (code_execution_config=False) and move any genuine code-running need to a
+      hardened external sandbox gated behind explicit human approval.
+
+  - id: AG2-002
+    title: AutoGen executor runs code with no human review (human_input_mode=NEVER)
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - autogen_conversable_agent
+      - autogen_user_proxy_agent
+    scope: agent
+    match:
+      all:
+        - agent_kwarg_value:
+            kwarg: human_input_mode
+            value: NEVER
+        - agent_kwarg_present:
+            - code_execution_config
+    explanation: >
+      This agent enables code execution (code_execution_config is set) while
+      human_input_mode="NEVER" removes the human-in-the-loop step. The combination
+      makes the agent fully autonomous: every code block the model emits runs with
+      zero review, so a prompt injection or a confused model executes attacker-chosen
+      code with no chance for a human to intervene. AutoGen's human_input_mode exists
+      precisely to gate this; setting it to NEVER on a code-executing agent removes
+      the last checkpoint before execution.
+    fix: >
+      Set human_input_mode="ALWAYS" (or "TERMINATE") on any agent that executes
+      code, so a human approves each run, or disable code execution on this agent
+      (code_execution_config=False). If unattended execution is a hard requirement,
+      run the code in a hardened external sandbox with no host access rather than via
+      the AutoGen executor.
+
+  - id: AG2-004
+    title: AutoGen GroupChatManager has no max_round bound
+    severity: medium
+    confidence: 0.8
+    language: python
+    applies_to:
+      - autogen_group_chat_manager
+    scope: agent
+    match:
+      agent_kwarg_missing:
+        - max_round
+    explanation: >
+      This group chat does not set max_round, so the speaker-selection loop has no
+      upper bound on the number of turns. A degenerate conversation — two agents that
+      keep handing work back and forth, or a model that never emits the termination
+      signal — runs until something else stops it, burning token budget the whole
+      time. When the participating agents wield side-effecting tools (file writes,
+      shell, network), an unbounded loop is not just a cost incident but a
+      correctness one: the same mutation can be applied many times over.
+    fix: >
+      Pass max_round= to GroupChat / GroupChatManager with a concrete cap sized to
+      the workflow (often 10–25). Pair it with a clear termination condition so the
+      chat ends on success rather than only on the round cap.
+
+  - id: AG2-005
+    title: AutoGen AssistantAgent enables code execution on the LLM agent
+    severity: medium
+    confidence: 0.7
+    language: python
+    applies_to:
+      - autogen_assistant_agent
+    scope: agent
+    match:
+      agent_kwarg_present:
+        - code_execution_config
+    explanation: >
+      This AssistantAgent sets code_execution_config, enabling code execution on the
+      LLM-facing agent. AutoGen's recommended pattern splits responsibilities: the
+      AssistantAgent generates code with code_execution_config=False, and a separate
+      UserProxyAgent (the executor) runs it. Collapsing both roles into one agent
+      removes that review boundary — the same agent that the model fully controls
+      also executes whatever it produces, so a prompt injection has a direct path
+      from generation to execution.
+    fix: >
+      Set code_execution_config=False on the AssistantAgent and route execution
+      through a dedicated UserProxyAgent executor, keeping the generate/execute split
+      AutoGen recommends. Apply the executor's own safety controls (Docker,
+      human_input_mode) on that proxy rather than on the assistant.
+
+  - id: AG2-006
+    title: AutoGen executor with code execution has no auto-reply cap
+    severity: medium
+    confidence: 0.7
+    language: python
+    applies_to:
+      - autogen_conversable_agent
+      - autogen_user_proxy_agent
+    scope: agent
+    match:
+      all:
+        - agent_kwarg_present:
+            - code_execution_config
+        - agent_kwarg_missing:
+            - max_consecutive_auto_reply
+    explanation: >
+      This executor enables code execution (code_execution_config is set) but does
+      not set max_consecutive_auto_reply, so there is no cap on how many times it will
+      auto-respond — and therefore auto-execute model-emitted code — in a single
+      exchange. An agent that keeps replying without limit can run generated code an
+      unbounded number of times, amplifying both the cost and the blast radius of a
+      single injected instruction.
+    fix: >
+      Set max_consecutive_auto_reply= to a small integer on any code-executing agent
+      so the auto-reply loop is bounded, and combine it with human_input_mode and
+      Docker so each run is both capped and reviewed.

--- a/testdata/rules-fixture/autogen/code_execution.yaml
+++ b/testdata/rules-fixture/autogen/code_execution.yaml
@@ -1,0 +1,33 @@
+policy:
+  id: autogen_code_execution
+  name: AutoGen code-execution safety
+  category: autogen
+  description: >
+    Flags AutoGen tools whose body evaluates code at runtime. Model-selected code
+    execution is a direct arbitrary-execution path; AutoGen's own docs recommend
+    Docker and warn that local execution is not recommended.
+
+rules:
+  - id: AG2-010
+    title: AutoGen tool body evaluates dynamic code
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - autogen_tool
+    scope: tool
+    match:
+      has_code_exec_call: true
+    explanation: >
+      This AutoGen tool's body calls eval(), exec(), or compile() — Python's
+      dynamic-code-execution builtins. Because the tool is registered with an agent
+      and exposed to the model, a prompt injection can steer it to run attacker-chosen
+      Python in the agent process. This is the same arbitrary-execution risk AutoGen's
+      code executor carries — and AutoGen's documentation strongly recommends running
+      such code inside Docker, not directly via in-process eval/exec.
+    fix: >
+      Remove eval/exec/compile from agent-callable tool bodies. If the tool must
+      compute over structured input, parse it with a real parser (ast.literal_eval
+      for data, a typed schema for arguments). If running code is genuinely the
+      product, route it through AutoGen's Docker code executor or a locked-down
+      external sandbox with no filesystem or network and a hard timeout.

--- a/testdata/rules-fixture/autogen/network.yaml
+++ b/testdata/rules-fixture/autogen/network.yaml
@@ -1,0 +1,47 @@
+policy:
+  id: autogen_network
+  name: AutoGen tool network hygiene
+  category: autogen
+  description: >
+    Network-call hygiene inside AutoGen-registered tool functions. A tool that
+    makes a network request without a timeout can hang the conversation loop
+    indefinitely.
+
+rules:
+  - id: AG2-012
+    title: AutoGen tool network call has no timeout
+    severity: medium
+    confidence: 0.8
+    language: python
+    applies_to:
+      - autogen_tool
+    scope: tool
+    match:
+      call_without_kwarg:
+        callees:
+          - requests.get
+          - requests.post
+          - requests.put
+          - requests.delete
+          - requests.patch
+          - requests.head
+          - requests.request
+          - httpx.get
+          - httpx.post
+          - httpx.put
+          - httpx.delete
+          - httpx.patch
+          - httpx.head
+          - httpx.request
+        missing: timeout
+    explanation: >
+      This AutoGen tool makes a network request without a timeout, so it will hang
+      indefinitely on a slow or unresponsive remote. AutoGen has no tool-level
+      timeout — the entire agent conversation blocks until the request returns, and
+      under load this exhausts whatever runtime the agent is hosted on without ever
+      surfacing the failure to the model.
+    fix: >
+      Pass timeout= (typically 5–30 seconds) to the request. Choose a value tight
+      enough to fail fast and loose enough to allow legitimate slow responses for
+      this endpoint, and surface failures as a structured error the model can react
+      to.

--- a/testdata/rules-fixture/autogen/repo_hygiene.yaml
+++ b/testdata/rules-fixture/autogen/repo_hygiene.yaml
@@ -1,0 +1,40 @@
+policy:
+  id: autogen_repo_hygiene
+  name: AutoGen repo hygiene
+  category: autogen
+  description: >
+    Repo-scoped hygiene rules for projects that use AutoGen / AG2. Fire once per
+    scan against the repo manifest and inventory.
+
+rules:
+  - id: AG2-201
+    title: AutoGen project ships no agent-guidance doc (AGENTS.md/CLAUDE.md)
+    severity: low
+    confidence: 0.9
+    applies_to:
+      - autogen
+    scope: repo
+    match:
+      all:
+        - repo_has_sdk_in_code:
+            - autogen
+        - not:
+            repo_component_present:
+              - agents_md
+              - claude_md
+    explanation: >
+      The project uses AutoGen in code but ships no agent-guidance doc (AGENTS.md or
+      CLAUDE.md) at the repo root. AGENTS.md is the cross-vendor convention an editing
+      coding agent reads before it acts; with neither file present, any agent that
+      opens this repo has no project-specific guidance on how agents and tools must be
+      configured — in particular, whether code execution is permitted, whether the
+      executor must run in Docker, and whether human_input_mode may be set to NEVER.
+      The likely consequence is generated code that violates the project's safety
+      contract because nothing in-tree teaches the agent the local rules.
+    fix: >
+      Add an AGENTS.md at the repo root (a CLAUDE.md also satisfies this rule). State
+      whether code execution is permitted and under what guard (Docker,
+      human_input_mode), how tools must be registered and constrained, any required
+      human-in-the-loop gates, and the exact test, lint, and build commands. Keep it
+      short and concrete so an editing agent can act on it without re-deriving the
+      conventions.

--- a/testdata/rules-fixture/autogen/shell_safety.yaml
+++ b/testdata/rules-fixture/autogen/shell_safety.yaml
@@ -1,0 +1,32 @@
+policy:
+  id: autogen_shell_safety
+  name: AutoGen shell-execution safety
+  category: autogen
+  description: >
+    Flags AutoGen tools whose body shells out to the operating system. A
+    model-callable tool that runs shell commands is the most direct
+    prompt-injection path to arbitrary code execution.
+
+rules:
+  - id: AG2-009
+    title: AutoGen tool body spawns a subprocess
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - autogen_tool
+    scope: tool
+    match:
+      has_shell_call: true
+    explanation: >
+      This AutoGen tool's body invokes a shell primitive (subprocess.*, os.system,
+      os.popen, or os.spawn*). Because the tool is registered with an agent and
+      exposed to the model, a prompt-injected or confused model can drive it to run
+      arbitrary commands with the agent process's privileges — shell execution
+      selected by model output is the most direct path from prompt injection to
+      remote code execution.
+    fix: >
+      Do not let model-controlled input reach a shell. Replace shell-outs with a
+      typed library call; if a subprocess is unavoidable, pass an argument list
+      (never shell=True), allow-list the exact commands, and run it in a sandbox with
+      no ambient credentials. Keep shell logic out of any agent-callable tool.

--- a/testdata/rules-fixture/autogen/ssrf.yaml
+++ b/testdata/rules-fixture/autogen/ssrf.yaml
@@ -1,0 +1,32 @@
+policy:
+  id: autogen_ssrf
+  name: AutoGen SSRF safety
+  category: autogen
+  description: >
+    Flags AutoGen tools that issue an outbound HTTP request to a
+    caller-controlled (non-literal) URL — the server-side request forgery
+    surface a model-callable tool exposes.
+
+rules:
+  - id: AG2-011
+    title: AutoGen tool fetches a caller-controlled URL (SSRF)
+    severity: high
+    confidence: 0.8
+    language: python
+    applies_to:
+      - autogen_tool
+    scope: tool
+    match:
+      has_dynamic_url_call: true
+    explanation: >
+      This AutoGen tool issues an HTTP request whose URL is built from a parameter
+      or interpolated value rather than a fixed literal. Because the tool is
+      model-callable, the model (or a prompt injection) controls the destination —
+      it can reach internal services, the cloud metadata endpoint (169.254.169.254),
+      or localhost admin ports the agent host can see but an external caller cannot.
+      This is a classic server-side request forgery primitive handed to the model.
+    fix: >
+      Constrain the destination: validate the URL against an allow-list of hosts,
+      reject private and link-local IP ranges (and redirects into them), and forbid
+      raw model-supplied URLs. If the tool only ever talks to one service, hard-code
+      the base URL and accept only a path or query from the model.

--- a/testdata/rules-fixture/autogen/tool_definition.yaml
+++ b/testdata/rules-fixture/autogen/tool_definition.yaml
@@ -1,0 +1,56 @@
+policy:
+  id: autogen_tool_definition
+  name: AutoGen tool definition hygiene
+  category: autogen
+  description: >
+    Hygiene rules for AutoGen tools registered via register_function or the
+    register_for_llm / register_for_execution decorators. AutoGen turns the
+    registered function's docstring and parameter type hints into the tool's
+    description and argument schema for the model.
+
+rules:
+  - id: AG2-007
+    title: AutoGen tool has no description
+    severity: low
+    confidence: 0.9
+    language: python
+    applies_to:
+      - autogen_tool
+    scope: tool
+    match:
+      has_docstring: false
+    explanation: >
+      AutoGen advertises a registered function to the model through its description,
+      which it derives from the function's docstring (unless an explicit description=
+      is passed at registration). A tool with neither reaches the model as a bare
+      name, so the model cannot tell what the tool does or when to call it — it will
+      skip the tool or invoke it with the wrong arguments. This is the single
+      highest-leverage authoring fix.
+    fix: >
+      Add a one-paragraph docstring to the registered function describing what the
+      tool does, the inputs it expects, and what it returns — or pass description= at
+      registration. AutoGen passes this text to the model verbatim, so write it for
+      the model rather than a human maintainer.
+
+  - id: AG2-008
+    title: AutoGen tool parameters are not type-annotated
+    severity: medium
+    confidence: 0.85
+    language: python
+    applies_to:
+      - autogen_tool
+    scope: tool
+    match:
+      all:
+        - has_params: true
+        - has_typed_params: false
+    explanation: >
+      AutoGen builds a tool's argument schema from the registered function's type
+      hints. A tool whose parameters carry no annotations produces an underspecified
+      schema: the model gets no type guidance and passes arguments of the wrong
+      shape, which the SDK then rejects at validation time — a silent reliability tax
+      on every call.
+    fix: >
+      Annotate every parameter with a concrete type (str, int, list[str], a
+      typing.Annotated description, etc.). AutoGen propagates these annotations into
+      the schema the model sees, so the model emits correctly-shaped arguments.

--- a/testdata/rules-fixture/crewai/agent_safety.yaml
+++ b/testdata/rules-fixture/crewai/agent_safety.yaml
@@ -1,0 +1,89 @@
+policy:
+  id: crewai_agent_safety
+  name: CrewAI agent safety
+  category: crewai
+  description: >
+    Agent-scope safety rules for CrewAI agents (the Agent(...) constructor).
+    These flag constructor kwargs that hand the model code-execution or
+    delegation capabilities — the entry points of CrewAI's published RCE and
+    confused-deputy chains.
+
+rules:
+  - id: CREW-101
+    title: CrewAI agent enables built-in code execution
+    severity: high
+    confidence: 0.9
+    language: python
+    applies_to:
+      - crewai_agent
+    scope: agent
+    match:
+      agent_kwarg_value:
+        kwarg: allow_code_execution
+        value: "True"
+    explanation: >
+      This Agent sets allow_code_execution=True, which makes CrewAI auto-inject a
+      CodeInterpreterTool into the agent's tool set. From that point the model can
+      run arbitrary Python it generates — and because the agent's instructions and
+      tool outputs are model-reachable, a prompt injection has a direct path to
+      code execution. This flag is the entry point of CrewAI's published RCE chain:
+      CVE-2026-2275 escapes the SandboxPython interpreter via a ctypes call, and
+      CVE-2026-2287 silently falls back from the Docker sandbox to host execution
+      when Docker is unavailable. The flag is also deprecated upstream.
+    fix: >
+      Remove allow_code_execution=True. If the agent genuinely needs to run code,
+      do it outside CrewAI in a hardened external sandbox (E2B, Modal, or an
+      equivalent isolated runner with no filesystem, no network, no credentials,
+      and a hard timeout) and gate it behind an explicit human approval rather than
+      letting the model invoke an in-process interpreter.
+
+  - id: CREW-102
+    title: CrewAI agent runs code execution in unsafe mode
+    severity: high
+    confidence: 0.9
+    language: python
+    applies_to:
+      - crewai_agent
+    scope: agent
+    match:
+      agent_kwarg_value:
+        kwarg: code_execution_mode
+        value: unsafe
+    explanation: >
+      This Agent sets code_execution_mode="unsafe", which tells CrewAI to run
+      model-generated code directly on the host instead of inside the Docker
+      sandbox. There is no boundary left to escape: a single prompt injection or a
+      confused model yields arbitrary code execution with the agent process's
+      privileges. This is strictly worse than the default "safe" mode, which at
+      least confines execution to a container.
+    fix: >
+      Remove code_execution_mode="unsafe" (the default "safe" mode keeps execution
+      in Docker). Better still, do not run model-chosen code in-process at all —
+      move it to a hardened external sandbox and require a human approval before
+      any code runs.
+
+  - id: CREW-104
+    title: CrewAI agent allows delegation to peer agents
+    severity: medium
+    confidence: 0.75
+    language: python
+    applies_to:
+      - crewai_agent
+    scope: agent
+    match:
+      agent_kwarg_value:
+        kwarg: allow_delegation
+        value: "True"
+    explanation: >
+      This Agent sets allow_delegation=True, so it can hand work to any peer agent
+      in the crew and invoke their tools. Delegation widens the agent's effective
+      trust boundary to the union of every peer's capabilities with no
+      per-delegation gate — a classic confused-deputy setup. If any peer holds the
+      code interpreter or an unconstrained file reader, a prompt injection against
+      this agent can reach that capability indirectly, even though this agent was
+      never granted it directly.
+    fix: >
+      Set allow_delegation=False unless delegation is essential to the workflow.
+      If the crew must delegate, keep high-risk tools (code execution, file read,
+      shell) off every agent reachable through delegation, and constrain each
+      peer's tool set to the minimum its role requires.

--- a/testdata/rules-fixture/crewai/code_execution.yaml
+++ b/testdata/rules-fixture/crewai/code_execution.yaml
@@ -1,0 +1,62 @@
+policy:
+  id: crewai_code_execution
+  name: CrewAI code-execution safety
+  category: crewai
+  description: >
+    Flags CrewAI agents wired with the code-interpreter built-in and CrewAI
+    tools whose body evaluates code at runtime. Model-selected code execution is
+    a direct arbitrary-execution path and the root of CrewAI's published RCE
+    advisories.
+
+rules:
+  - id: CREW-103
+    title: CrewAI agent wires the code-interpreter built-in tool
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - crewai_agent
+    scope: agent
+    match:
+      agent_uses_hosted_tool_class:
+        - CodeInterpreterTool
+    explanation: >
+      This agent's tools list includes CodeInterpreterTool, CrewAI's built-in that
+      executes Python the model generates. It is the same arbitrary-execution
+      capability that allow_code_execution=True auto-injects (CREW-101), reached
+      here by wiring the tool by hand. Once it is in the tool set, a prompt
+      injection or a confused model can run attacker-chosen code in the agent
+      process — the vector behind CVE-2026-2275 (SandboxPython ctypes escape) and
+      CVE-2026-2287 (Docker-availability fallback to host execution). The CERT
+      remediation for those advisories is literally to remove or disable the Code
+      Interpreter Tool.
+    fix: >
+      Remove CodeInterpreterTool from production agents. If code execution is a
+      genuine requirement, run it outside CrewAI in a hardened external sandbox
+      (no filesystem, no network, no credentials, hard timeout) and gate it behind
+      an explicit human approval rather than exposing an in-process interpreter to
+      the model.
+
+  - id: CREW-003
+    title: CrewAI tool body evaluates dynamic code
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - crewai_tool
+    scope: tool
+    match:
+      has_code_exec_call: true
+    explanation: >
+      This CrewAI tool's body calls eval(), exec(), or compile() — Python's
+      dynamic-code-execution builtins. Because the tool is exposed to the model, a
+      prompt injection can steer it to run attacker-chosen Python in the agent
+      process. This is the same mechanism behind CrewAI's CodeInterpreterTool;
+      hand-rolling it inside a @tool body carries the identical risk while bypassing
+      whatever sandboxing the built-in would have applied.
+    fix: >
+      Remove eval/exec/compile from agent-callable tool bodies. If the tool must
+      compute over structured input, parse it with a real parser (ast.literal_eval
+      for data, a typed schema for arguments). If running code is genuinely the
+      product, isolate it in a locked-down sandbox with no filesystem or network
+      and a hard timeout.

--- a/testdata/rules-fixture/crewai/dangerous_tools.yaml
+++ b/testdata/rules-fixture/crewai/dangerous_tools.yaml
@@ -1,0 +1,73 @@
+policy:
+  id: crewai_dangerous_tools
+  name: CrewAI dangerous built-in tools
+  category: crewai
+  description: >
+    Flags CrewAI agents wired with high-risk crewai_tools built-ins: an
+    unconstrained file reader, and the web-fetching / RAG tools that retrieve
+    model-chosen URLs. Both are vectors in CrewAI's published file-read and SSRF
+    advisories.
+
+rules:
+  - id: CREW-106
+    title: CrewAI agent grants an unconstrained FileReadTool
+    severity: high
+    confidence: 0.7
+    language: python
+    applies_to:
+      - crewai_agent
+    scope: agent
+    match:
+      all:
+        - agent_uses_hosted_tool_class: [FileReadTool]
+        - not:
+            agent_hosted_tool_kwarg_present:
+              class: FileReadTool
+              kwarg: file_path
+    explanation: >
+      This agent wires FileReadTool with no file_path= pin, so the tool reads
+      whatever path the model names at call time. Because the tool is
+      model-callable, a prompt injection can make it read any file the agent
+      process can see — /etc/passwd, ~/.ssh/id_rsa, application secrets — which is
+      the arbitrary-file-read exposure tracked as CVE-2026-2285 (path traversal in
+      the file-read tool). Pinning the tool to a specific file at construction
+      removes the model's control over the target, so FileReadTool(file_path="...")
+      is the safe form and does not fire.
+    fix: >
+      Construct FileReadTool(file_path="...") bound to the one file the agent
+      needs, so the model cannot choose the path. If the agent must read several
+      files, validate every candidate path against an allow-list of directories,
+      resolve symlinks, and reject any path that escapes the intended root.
+
+  - id: CREW-107
+    title: CrewAI agent wires a tool that fetches model-chosen URLs
+    severity: medium
+    confidence: 0.7
+    language: python
+    applies_to:
+      - crewai_agent
+    scope: agent
+    match:
+      agent_uses_hosted_tool_class:
+        - ScrapeWebsiteTool
+        - SeleniumScrapingTool
+        - WebsiteSearchTool
+        - SerperDevTool
+        - JSONSearchTool
+        - PDFSearchTool
+        - CSVSearchTool
+    explanation: >
+      This agent wires a crewai_tools built-in that issues outbound requests to a
+      URL the model supplies (a scraper, a search tool, or a RAG retriever). Because
+      the destination is model-controlled, a prompt injection can point it at
+      internal services or the cloud metadata endpoint (169.254.169.254) to exfil
+      credentials — the server-side request forgery exposure tracked as
+      CVE-2026-2286. The retrieved page content then re-enters the conversation as
+      untrusted text, giving the fetched site a second-order prompt-injection
+      channel into the agent.
+    fix: >
+      Constrain the destination: validate every URL against an allow-list of hosts,
+      reject private and link-local IP ranges (and redirects into them), and forbid
+      raw model-supplied URLs. Treat any retrieved content as untrusted input —
+      keep it out of the system prompt and do not let it silently expand the agent's
+      tool permissions.

--- a/testdata/rules-fixture/crewai/idempotency.yaml
+++ b/testdata/rules-fixture/crewai/idempotency.yaml
@@ -1,0 +1,45 @@
+policy:
+  id: crewai_idempotency
+  name: CrewAI mutating-tool idempotency
+  category: crewai
+  description: >
+    Rules that flag mutating tools (create/send/refund/...) without an
+    idempotency key. CrewAI retries tool calls under timeouts and ambiguous
+    failures; without a key the same side-effecting action can fire twice.
+
+rules:
+  - id: CREW-006
+    title: Mutating CrewAI tool has no idempotency key
+    severity: medium
+    confidence: 0.55
+    language: python
+    applies_to:
+      - crewai_tool
+    scope: tool
+    match:
+      all:
+        - name_has_prefix:
+            - create_
+            - send_
+            - delete_
+            - post_
+            - update_
+            - refund_
+            - charge_
+            - issue_
+        - not:
+            param_name_matches:
+              contains:
+                - idempot
+              exact:
+                - request_id
+                - txn_id
+    explanation: >
+      Tool name suggests a side effect (create/send/refund/…). CrewAI retries tool
+      calls under timeouts and ambiguous failures; without an idempotency key the
+      same action can fire twice — a duplicate charge, a double-sent message, a
+      repeated delete. Downstream services must also honor the key for this
+      protection to be effective.
+    fix: >
+      Add an `idempotency_key: str` parameter and pass it through to the backing
+      API so a retried call is recognized and deduplicated rather than re-executed.

--- a/testdata/rules-fixture/crewai/repo_hygiene.yaml
+++ b/testdata/rules-fixture/crewai/repo_hygiene.yaml
@@ -1,0 +1,40 @@
+policy:
+  id: crewai_repo_hygiene
+  name: CrewAI repo hygiene
+  category: crewai
+  description: >
+    Repo-scoped hygiene rules for projects that use CrewAI. Fire once per scan
+    against the repo manifest and inventory.
+
+rules:
+  - id: CREW-201
+    title: CrewAI project ships no agent-guidance doc (AGENTS.md/CLAUDE.md)
+    severity: low
+    confidence: 0.9
+    applies_to:
+      - crewai
+    scope: repo
+    match:
+      all:
+        - repo_has_sdk_in_code:
+            - crewai
+        - not:
+            repo_component_present:
+              - agents_md
+              - claude_md
+    explanation: >
+      The project uses CrewAI in code but ships no agent-guidance doc (AGENTS.md or
+      CLAUDE.md) at the repo root. AGENTS.md is the cross-vendor convention an
+      editing coding agent reads before it acts; with neither file present, any
+      agent that opens this repo has no project-specific guidance on how agents and
+      tools must be configured — in particular, whether allow_code_execution or the
+      CodeInterpreterTool are permitted, how tools must be defined and guarded, and
+      the local test and build commands. The likely consequence is generated code
+      that violates the project's safety contract because nothing in-tree teaches
+      the agent the local rules.
+    fix: >
+      Add an AGENTS.md at the repo root (a CLAUDE.md also satisfies this rule).
+      State whether code execution is permitted and under what guard, how tools must
+      be defined and constrained, any required human-in-the-loop gates, and the
+      exact test, lint, and build commands. Keep it short and concrete so an editing
+      agent can act on it without re-deriving the conventions.

--- a/testdata/rules-fixture/crewai/shell_safety.yaml
+++ b/testdata/rules-fixture/crewai/shell_safety.yaml
@@ -1,0 +1,35 @@
+policy:
+  id: crewai_shell_safety
+  name: CrewAI shell-execution safety
+  category: crewai
+  description: >
+    Flags CrewAI tools whose body shells out to the operating system. A
+    model-callable tool that runs shell commands is the most direct
+    prompt-injection path to arbitrary code execution, and CrewAI ships no
+    dedicated shell-tool class, so this hand-rolled shape is the real shell
+    surface to watch.
+
+rules:
+  - id: CREW-004
+    title: CrewAI tool body spawns a subprocess
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - crewai_tool
+    scope: tool
+    match:
+      has_shell_call: true
+    explanation: >
+      This CrewAI tool's body invokes a shell primitive (subprocess.*, os.system,
+      os.popen, or os.spawn*). Because the tool is exposed to the model, a
+      prompt-injected or confused model can drive it to run arbitrary commands with
+      the agent process's privileges — shell execution selected by model output is
+      the most direct path from prompt injection to remote code execution. CrewAI
+      ships no built-in shell-tool class, so a tool that shells out by hand is the
+      shell surface a reviewer must inspect.
+    fix: >
+      Do not let model-controlled input reach a shell. Replace shell-outs with a
+      typed library call; if a subprocess is unavoidable, pass an argument list
+      (never shell=True), allow-list the exact commands, and run it in a sandbox
+      with no ambient credentials. Keep shell logic out of any agent-callable tool.

--- a/testdata/rules-fixture/crewai/ssrf.yaml
+++ b/testdata/rules-fixture/crewai/ssrf.yaml
@@ -1,0 +1,33 @@
+policy:
+  id: crewai_ssrf
+  name: CrewAI SSRF safety
+  category: crewai
+  description: >
+    Flags CrewAI tools that issue an outbound HTTP request to a
+    caller-controlled (non-literal) URL — the server-side request forgery
+    surface a model-callable tool exposes.
+
+rules:
+  - id: CREW-005
+    title: CrewAI tool fetches a caller-controlled URL (SSRF)
+    severity: high
+    confidence: 0.8
+    language: python
+    applies_to:
+      - crewai_tool
+    scope: tool
+    match:
+      has_dynamic_url_call: true
+    explanation: >
+      This CrewAI tool issues an HTTP request whose URL is built from a parameter
+      or interpolated value rather than a fixed literal. Because the tool is
+      model-callable, the model (or a prompt injection) controls the destination —
+      it can reach internal services, the cloud metadata endpoint
+      (169.254.169.254), or localhost admin ports the agent host can see but an
+      external caller cannot. This is a classic server-side request forgery
+      primitive handed to the model.
+    fix: >
+      Constrain the destination: validate the URL against an allow-list of hosts,
+      reject private and link-local IP ranges (and redirects into them), and forbid
+      raw model-supplied URLs. If the tool only ever talks to one service, hard-code
+      the base URL and accept only a path or query from the model.

--- a/testdata/rules-fixture/crewai/tool_behavior.yaml
+++ b/testdata/rules-fixture/crewai/tool_behavior.yaml
@@ -1,0 +1,34 @@
+policy:
+  id: crewai_tool_behavior
+  name: CrewAI tool behavior safety
+  category: crewai
+  description: >
+    Flags CrewAI tool configuration that alters the agent's control flow in ways
+    that bypass the model's reasoning and any post-tool validation.
+
+rules:
+  - id: CREW-108
+    title: CrewAI tool returns its output as the final answer
+    severity: medium
+    confidence: 0.6
+    language: python
+    applies_to:
+      - crewai_tool
+    scope: tool
+    match:
+      tool_decorator_kwarg_value:
+        kwarg: result_as_answer
+        value: "True"
+    explanation: >
+      This tool sets result_as_answer=True, so CrewAI takes the tool's raw output
+      as the agent's final answer and stops — the model never reviews the result,
+      cannot validate or summarize it, and no post-tool step runs. If the tool
+      returns model- or attacker-influenced content (a scraped page, a file read, a
+      search result), that unvalidated output flows straight to the caller. This is
+      the CrewAI analog of LangChain's return_direct: convenient for a deterministic
+      passthrough, dangerous when the tool's output is not already trusted.
+    fix: >
+      Leave result_as_answer at its default (False) unless you specifically intend
+      to short-circuit the agent with a tool whose output is already trusted and
+      sanitized. If you do use it, shape and sanitize the tool's output inside the
+      tool body, since no model step or guardrail runs after it.

--- a/testdata/rules-fixture/crewai/tool_definition.yaml
+++ b/testdata/rules-fixture/crewai/tool_definition.yaml
@@ -1,0 +1,54 @@
+policy:
+  id: crewai_tool_definition
+  name: CrewAI tool definition hygiene
+  category: crewai
+  description: >
+    Hygiene rules for CrewAI tools defined with the @tool decorator from
+    crewai.tools. The docstring and the parameter type hints are what CrewAI
+    turns into the tool's description and argument schema for the model.
+
+rules:
+  - id: CREW-001
+    title: CrewAI tool has no description
+    severity: low
+    confidence: 0.9
+    language: python
+    applies_to:
+      - crewai_tool
+    scope: tool
+    match:
+      has_docstring: false
+    explanation: >
+      CrewAI exposes a @tool-decorated function to the model through its docstring:
+      that string becomes the tool's description in the prompt. A tool with no
+      docstring reaches the model as a bare name, so the model cannot tell what the
+      tool does or when to call it — it will skip the tool or invoke it with the
+      wrong arguments. This is the single highest-leverage authoring fix.
+    fix: >
+      Add a one-paragraph docstring to the decorated function describing what the
+      tool does, the inputs it expects, and what it returns. CrewAI passes this
+      string to the model verbatim, so write it for the model rather than a human
+      maintainer.
+
+  - id: CREW-002
+    title: CrewAI tool parameters are not type-annotated
+    severity: medium
+    confidence: 0.85
+    language: python
+    applies_to:
+      - crewai_tool
+    scope: tool
+    match:
+      all:
+        - has_params: true
+        - has_typed_params: false
+    explanation: >
+      CrewAI builds a tool's argument schema from the decorated function's type
+      hints. A tool whose parameters carry no annotations produces an
+      underspecified schema: the model gets no type guidance and passes arguments
+      of the wrong shape, which Pydantic then rejects at validation time — a silent
+      reliability tax on every call.
+    fix: >
+      Annotate every parameter with a concrete type (str, int, list[str], a
+      Pydantic model, etc.). CrewAI propagates these annotations into the schema the
+      model sees, so the model emits correctly-shaped arguments.

--- a/testdata/rules-fixture/pydantic_ai/agent_safety.yaml
+++ b/testdata/rules-fixture/pydantic_ai/agent_safety.yaml
@@ -1,0 +1,122 @@
+policy:
+  id: pydantic_ai_agent_safety
+  name: Pydantic AI agent safety
+  category: pydantic_ai
+  description: >
+    Agent-scope safety rules for Pydantic AI agents (the Agent(...) constructor).
+    These flag missing output validation, model-driven code execution and URL
+    fetching wired as native tools, and a retry strategy that re-runs an
+    already-executed tool.
+
+rules:
+  - id: PYD-101
+    title: Pydantic AI agent has no structured output validation
+    severity: low
+    confidence: 0.7
+    language: python
+    applies_to:
+      - pydantic_ai_agent
+    scope: agent
+    match:
+      any:
+        - agent_kwarg_missing:
+            - output_type
+        - agent_kwarg_value:
+            kwarg: output_type
+            value: str
+    explanation: >
+      This agent does not constrain its output to a validated type: output_type is
+      absent (defaulting to free-form str) or set explicitly to str. Pydantic AI's
+      core value is that output_type can be a Pydantic model the framework
+      validates and, on failure, asks the model to correct — turning model output
+      into a typed contract. Without it, the agent returns whatever text the model
+      produced, so downstream code parses unvalidated strings and a prompt
+      injection or a confused model can return malformed or unexpected content
+      that is consumed as if it were trusted.
+    fix: >
+      Set output_type to a Pydantic model (or a typed union) describing the
+      result the agent must return. Pydantic AI then validates each run against
+      that schema and re-prompts the model on a validation failure, so callers
+      receive a checked, typed object instead of raw text.
+
+  - id: PYD-102
+    title: Pydantic AI agent wires the code-execution native tool
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - pydantic_ai_agent
+    scope: agent
+    match:
+      agent_uses_hosted_tool_class:
+        - CodeExecutionTool
+    explanation: >
+      This agent wires Pydantic AI's CodeExecutionTool (via capabilities= or
+      builtin_tools=), a provider-native tool that executes code the model
+      generates. Once it is in the tool set, a prompt injection or a confused
+      model can run attacker-chosen code in the execution environment the provider
+      grants the tool. Because the agent's instructions, tool outputs, and any
+      retrieved content are all model-reachable, this is a direct path from prompt
+      injection to arbitrary code execution.
+    fix: >
+      Remove CodeExecutionTool from production agents. If code execution is a
+      genuine requirement, run it outside the agent in a hardened sandbox (no
+      filesystem, no network, no credentials, hard timeout) and gate it behind an
+      explicit human approval rather than exposing a model-invokable code runner.
+
+  - id: PYD-103
+    title: Pydantic AI agent wires a model-driven URL-fetching native tool
+    severity: medium
+    confidence: 0.75
+    language: python
+    applies_to:
+      - pydantic_ai_agent
+    scope: agent
+    match:
+      agent_uses_hosted_tool_class:
+        - WebFetchTool
+        - UrlContextTool
+    explanation: >
+      This agent wires a native URL-fetching tool (WebFetchTool or UrlContextTool)
+      that retrieves model-chosen URLs. The model controls the destination, so a
+      prompt injection can point it at internal services, the cloud metadata
+      endpoint (169.254.169.254), or localhost admin ports the agent host can
+      reach — a server-side request forgery surface — and can also exfiltrate
+      retrieved or in-context data to an attacker-controlled URL. Pydantic AI's
+      built-in fetchers have already needed SSRF hardening (CVE-2026-46678,
+      CVE-2026-25580), so enabling one without network egress controls reintroduces
+      that exposure.
+    fix: >
+      Only enable a native fetch tool when the agent genuinely needs open web
+      access, and put network egress controls around the agent process: an
+      allow-list of permitted hosts, blocked private/link-local IP ranges, and a
+      proxy that rejects requests to internal addresses. Prefer a purpose-built
+      tool that fetches from a fixed, vetted set of endpoints over an open URL
+      fetcher.
+
+  - id: PYD-105
+    title: Pydantic AI agent retries with the exhaustive end strategy
+    severity: low
+    confidence: 0.7
+    language: python
+    applies_to:
+      - pydantic_ai_agent
+    scope: agent
+    match:
+      agent_kwarg_value:
+        kwarg: end_strategy
+        value: exhaustive
+    explanation: >
+      This agent sets end_strategy="exhaustive". When the model emits a final
+      result alongside still-pending tool calls, the exhaustive strategy runs
+      those remaining tool calls anyway before ending the run, instead of
+      returning immediately (the "early" default). If any of those pending calls
+      is side-effecting — a write, a charge, a send — exhaustive mode executes it
+      even though the model already considered the task done, widening the blast
+      radius of a single run and making duplicate or unintended side effects more
+      likely.
+    fix: >
+      Leave end_strategy at its "early" default so the run ends as soon as the
+      model produces a final result, skipping pending tool calls. Only choose
+      exhaustive when every tool the agent can call is side-effect-free and you
+      specifically need the remaining calls to complete.

--- a/testdata/rules-fixture/pydantic_ai/code_execution.yaml
+++ b/testdata/rules-fixture/pydantic_ai/code_execution.yaml
@@ -1,0 +1,32 @@
+policy:
+  id: pydantic_ai_code_execution
+  name: Pydantic AI code-execution safety
+  category: pydantic_ai
+  description: >
+    Flags Pydantic AI tools whose body evaluates code at runtime. Model-selected
+    dynamic code execution is a direct arbitrary-execution path.
+
+rules:
+  - id: PYD-004
+    title: Pydantic AI tool body evaluates dynamic code
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - pydantic_ai_tool
+    scope: tool
+    match:
+      has_code_exec_call: true
+    explanation: >
+      This Pydantic AI tool's body calls eval(), exec(), or compile() — Python's
+      dynamic-code-execution builtins. Because the tool is exposed to the model, a
+      prompt injection can steer it to run attacker-chosen Python in the agent
+      process. This is the same arbitrary-execution capability as Pydantic AI's
+      built-in CodeExecutionTool, hand-rolled inside a tool body, and it bypasses
+      whatever sandboxing the built-in would have applied.
+    fix: >
+      Remove eval/exec/compile from agent-callable tool bodies. If the tool must
+      compute over structured input, parse it with a real parser
+      (ast.literal_eval for data, a typed Pydantic schema for arguments). If
+      running code is genuinely the product, isolate it in a locked-down sandbox
+      with no filesystem or network and a hard timeout.

--- a/testdata/rules-fixture/pydantic_ai/idempotency.yaml
+++ b/testdata/rules-fixture/pydantic_ai/idempotency.yaml
@@ -1,0 +1,47 @@
+policy:
+  id: pydantic_ai_idempotency
+  name: Pydantic AI mutating-tool idempotency
+  category: pydantic_ai
+  description: >
+    Flags mutating tools (create/send/refund/...) without an idempotency key.
+    Pydantic AI retries tool calls under validation failures and the agent loop
+    re-invokes tools, so without a key the same side-effecting action can fire
+    twice.
+
+rules:
+  - id: PYD-007
+    title: Mutating Pydantic AI tool has no idempotency key
+    severity: medium
+    confidence: 0.55
+    language: python
+    applies_to:
+      - pydantic_ai_tool
+    scope: tool
+    match:
+      all:
+        - name_has_prefix:
+            - create_
+            - send_
+            - delete_
+            - post_
+            - update_
+            - refund_
+            - charge_
+            - issue_
+        - not:
+            param_name_matches:
+              contains:
+                - idempot
+              exact:
+                - request_id
+                - txn_id
+    explanation: >
+      Tool name suggests a side effect (create/send/refund/…). Pydantic AI retries
+      a tool call when the model's arguments fail validation, and the agent loop
+      can re-select the same tool across turns; without an idempotency key the
+      same action can fire twice — a duplicate charge, a double-sent message, a
+      repeated delete. The downstream service must also honor the key for this
+      protection to be effective.
+    fix: >
+      Add an idempotency_key: str parameter and pass it through to the backing API
+      so a retried call is recognized and deduplicated rather than re-executed.

--- a/testdata/rules-fixture/pydantic_ai/network.yaml
+++ b/testdata/rules-fixture/pydantic_ai/network.yaml
@@ -1,0 +1,47 @@
+policy:
+  id: pydantic_ai_network
+  name: Pydantic AI tool network hygiene
+  category: pydantic_ai
+  description: >
+    Network-call hygiene inside Pydantic AI tool functions. A tool that makes a
+    network request without a timeout can hang the agent run indefinitely.
+
+rules:
+  - id: PYD-006
+    title: Pydantic AI tool network call has no timeout
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - pydantic_ai_tool
+    scope: tool
+    match:
+      call_without_kwarg:
+        callees:
+          - requests.get
+          - requests.post
+          - requests.put
+          - requests.delete
+          - requests.patch
+          - requests.head
+          - requests.request
+          - httpx.get
+          - httpx.post
+          - httpx.put
+          - httpx.delete
+          - httpx.patch
+          - httpx.head
+          - httpx.request
+        missing: timeout
+    explanation: >
+      This Pydantic AI tool makes a network request without a timeout, so it will
+      hang indefinitely on a slow or unresponsive remote. The tool call runs
+      inside the agent's run loop; a request with no timeout blocks that run until
+      the remote eventually responds or the connection dies, and under load this
+      ties up whatever runtime the agent is hosted on without ever surfacing the
+      failure to the model.
+    fix: >
+      Pass timeout= (typically 5–30 seconds) to the request. Choose a value tight
+      enough to fail fast and loose enough to allow legitimate slow responses for
+      this endpoint, and surface failures as a structured error the model can
+      react to rather than letting the call hang.

--- a/testdata/rules-fixture/pydantic_ai/repo_hygiene.yaml
+++ b/testdata/rules-fixture/pydantic_ai/repo_hygiene.yaml
@@ -1,0 +1,42 @@
+policy:
+  id: pydantic_ai_repo_hygiene
+  name: Pydantic AI repo hygiene
+  category: pydantic_ai
+  description: >
+    Repo-scoped hygiene rules for projects that use Pydantic AI. Fire once per
+    scan against the repo manifest and inventory.
+
+rules:
+  - id: PYD-201
+    title: Pydantic AI project ships no agent-guidance doc (AGENTS.md/CLAUDE.md)
+    severity: low
+    confidence: 0.9
+    applies_to:
+      - pydantic_ai
+    scope: repo
+    match:
+      all:
+        - repo_has_sdk_in_code:
+            - pydantic_ai
+        - not:
+            repo_component_present:
+              - agents_md
+              - claude_md
+    explanation: >
+      The project uses Pydantic AI in code but ships no agent-guidance doc
+      (AGENTS.md or CLAUDE.md) at the repo root. AGENTS.md is the cross-vendor
+      convention an editing coding agent reads before it acts; with neither file
+      present, any agent that opens this repo has no project-specific guidance on
+      how agents and tools must be configured — in particular, whether
+      CodeExecutionTool or native URL fetchers are permitted, how tools must be
+      typed and documented, whether output_type must be a validated model, and the
+      local test and build commands. The likely consequence is generated code that
+      violates the project's safety contract because nothing in-tree teaches the
+      agent the local rules.
+    fix: >
+      Add an AGENTS.md at the repo root (a CLAUDE.md also satisfies this rule).
+      State whether code execution and open URL fetching are permitted and under
+      what guard, how tools must be defined and typed, whether structured
+      output_type is required, any human-in-the-loop gates, and the exact test,
+      lint, and build commands. Keep it short and concrete so an editing agent can
+      act on it without re-deriving the conventions.

--- a/testdata/rules-fixture/pydantic_ai/shell_safety.yaml
+++ b/testdata/rules-fixture/pydantic_ai/shell_safety.yaml
@@ -1,0 +1,35 @@
+policy:
+  id: pydantic_ai_shell_safety
+  name: Pydantic AI shell-execution safety
+  category: pydantic_ai
+  description: >
+    Flags Pydantic AI tools whose body shells out to the operating system. A
+    model-callable tool that runs shell commands is the most direct
+    prompt-injection path to arbitrary code execution.
+
+rules:
+  - id: PYD-003
+    title: Pydantic AI tool body spawns a subprocess
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - pydantic_ai_tool
+    scope: tool
+    match:
+      has_shell_call: true
+    explanation: >
+      This Pydantic AI tool's body invokes a shell primitive (subprocess.*,
+      os.system, os.popen, or os.spawn*). Because the tool is registered with the
+      agent and therefore model-callable, a prompt-injected or confused model can
+      drive it to run arbitrary commands with the agent process's privileges —
+      shell execution selected by model output is the most direct path from
+      prompt injection to remote code execution. The model controls both whether
+      the tool is called and the arguments it receives, so any command string
+      assembled from those arguments is attacker-influenced.
+    fix: >
+      Do not let model-controlled input reach a shell. Replace shell-outs with a
+      typed library call; if a subprocess is unavoidable, pass an argument list
+      (never shell=True), allow-list the exact commands, and run it in a sandbox
+      with no ambient credentials. Keep shell logic out of any agent-callable
+      tool.

--- a/testdata/rules-fixture/pydantic_ai/ssrf.yaml
+++ b/testdata/rules-fixture/pydantic_ai/ssrf.yaml
@@ -1,0 +1,39 @@
+policy:
+  id: pydantic_ai_ssrf
+  name: Pydantic AI SSRF safety
+  category: pydantic_ai
+  description: >
+    Flags Pydantic AI tools that issue an outbound HTTP request to a
+    caller-controlled (non-literal) URL — the server-side request forgery
+    surface a model-callable tool exposes.
+
+rules:
+  - id: PYD-005
+    title: Pydantic AI tool fetches a caller-controlled URL (SSRF)
+    severity: high
+    confidence: 0.8
+    language: python
+    applies_to:
+      - pydantic_ai_tool
+    scope: tool
+    match:
+      has_dynamic_url_call: true
+    explanation: >
+      This Pydantic AI tool issues an HTTP request whose URL is built from a
+      parameter or interpolated value rather than a fixed literal. Because the
+      tool is model-callable, the model (or a prompt injection) controls the
+      destination — it can reach internal services, the cloud metadata endpoint
+      (169.254.169.254), or localhost admin ports the agent host can see but an
+      external caller cannot. This is a classic server-side request forgery
+      primitive handed to the model. Pydantic AI's own built-in URL fetchers have
+      had to harden against exactly this: CVE-2026-46678 and CVE-2026-25580
+      cover a metadata-endpoint blocklist that could be bypassed (e.g. via DNS
+      rebinding or alternate IP encodings), so a hand-rolled fetch that does no
+      validation at all is strictly more exposed.
+    fix: >
+      Constrain the destination: validate the URL against an allow-list of hosts,
+      reject private and link-local IP ranges (and redirects into them), and
+      forbid raw model-supplied URLs. Resolve the hostname and re-check the
+      resolved IP to defeat DNS rebinding. If the tool only ever talks to one
+      service, hard-code the base URL and accept only a path or query from the
+      model.

--- a/testdata/rules-fixture/pydantic_ai/tool_definition.yaml
+++ b/testdata/rules-fixture/pydantic_ai/tool_definition.yaml
@@ -1,0 +1,64 @@
+policy:
+  id: pydantic_ai_tool_definition
+  name: Pydantic AI tool definition hygiene
+  category: pydantic_ai
+  description: >
+    Hygiene rules for Pydantic AI tools defined with the @agent.tool /
+    @agent.tool_plain decorators or the Tool(...) factory. Pydantic AI builds the
+    tool's description from the function docstring and its argument schema from
+    the parameter type hints, so a missing docstring or untyped parameters
+    degrade exactly what the model sees.
+
+rules:
+  - id: PYD-001
+    title: Pydantic AI tool has no description
+    severity: low
+    confidence: 0.9
+    language: python
+    applies_to:
+      - pydantic_ai_tool
+    scope: tool
+    match:
+      has_docstring: false
+    explanation: >
+      Pydantic AI turns a tool function's docstring into the tool description it
+      sends to the model. A tool with no docstring reaches the model as a bare
+      name with no guidance on what it does or when to call it, so the model
+      skips it or invokes it with the wrong arguments. The docstring is also where
+      Pydantic AI extracts per-parameter descriptions (it parses Google/NumPy/
+      Sphinx styles), so an absent docstring strips both the tool- and
+      argument-level guidance at once.
+    fix: >
+      Add a docstring to the tool function describing what it does, the inputs it
+      expects, and what it returns. Pydantic AI passes this to the model verbatim
+      and parses the parameter sections into the argument schema, so write it for
+      the model rather than only a human maintainer.
+
+  - id: PYD-002
+    title: Pydantic AI tool parameters are not type-annotated
+    severity: medium
+    confidence: 0.85
+    language: python
+    applies_to:
+      - pydantic_ai_tool
+    scope: tool
+    match:
+      all:
+        - has_params: true
+        - has_typed_params: false
+    explanation: >
+      Pydantic AI builds a tool's JSON argument schema from the function's
+      parameter type hints. A tool whose parameters carry no annotations produces
+      an underspecified schema: the model gets no type guidance and emits
+      arguments of the wrong shape, which Pydantic then rejects at validation
+      time — a silent reliability tax on every call, and on a retrying agent a
+      source of wasted turns. Note for reviewers: a context tool's leading
+      ctx: RunContext[...] parameter is itself typed, so an @agent.tool whose
+      business parameters are untyped but whose ctx is annotated may not be
+      flagged here (a false negative, never a false positive); @agent.tool_plain
+      tools and no-arg tools are unaffected.
+    fix: >
+      Annotate every business parameter with a concrete type (str, int,
+      list[str], a Pydantic model, etc.). Pydantic AI propagates these
+      annotations into the schema the model sees, so the model emits
+      correctly-shaped arguments and validation stops rejecting them.

--- a/testdata/rules-fixture/vercel_ai/agent_safety.yaml
+++ b/testdata/rules-fixture/vercel_ai/agent_safety.yaml
@@ -1,0 +1,110 @@
+policy:
+  id: vercel_ai_agent_safety
+  name: Vercel AI SDK agent safety
+  category: vercel_ai
+  description: >
+    Agent-scope safety rules for Vercel AI SDK agents — the generateText /
+    streamText / generateObject / streamObject tool-loop calls and the
+    ToolLoopAgent class. These flag agents wired with provider tools that hand
+    the model shell, computer-control, or code-execution reach, and agents whose
+    tool loop has no bound, the two ways a Vercel agent turns a prompt injection
+    into runaway or arbitrary execution.
+
+rules:
+  - id: VAI-006
+    title: Vercel AI agent wires a provider shell / computer / code-execution tool
+    severity: high
+    confidence: 0.85
+    language: typescript
+    applies_to:
+      - vercel_ai_agent
+    scope: agent
+    match:
+      agent_uses_hosted_tool_class:
+        - anthropic.tools.bash
+        - anthropic.tools.computer
+        - anthropic.tools.codeExecution
+        - openai.tools.localShell
+        - openai.tools.computerUsePreview
+        - openai.tools.codeInterpreter
+        - google.tools.codeExecution
+    explanation: >
+      This agent's tools record includes a Vercel-provider tool that gives the
+      model shell, full computer control, or a code interpreter — anthropic's
+      bash / computer / codeExecution, openai's localShell / computerUsePreview /
+      codeInterpreter, or google's codeExecution. The Vercel AI SDK ships and
+      markets these provider tools as first-class, so wiring one is a single line
+      that hands a model-driven loop direct execution on the host or sandbox.
+      Because the agent's prompts and prior tool outputs are model-reachable, a
+      prompt injection has a direct path to running attacker-chosen commands or
+      code with the agent's privileges.
+    fix: >
+      Drop the provider execution tool unless the workflow truly requires it. If
+      it is essential, run it against an isolated, ephemeral sandbox with no
+      credentials, no private-network reach, and a hard timeout; constrain which
+      commands or code may run; and gate every invocation behind an explicit
+      human approval rather than letting the tool loop call it autonomously.
+
+  - id: VAI-007
+    title: Vercel AI agent tool loop has no step bound
+    severity: medium
+    confidence: 0.6
+    language: typescript
+    applies_to:
+      - vercel_ai_agent
+    scope: agent
+    match:
+      all:
+        - agent_kwarg_missing:
+            - stopWhen
+        - agent_kwarg_missing:
+            - maxSteps
+    explanation: >
+      This agent runs a multi-step tool loop (generateText / streamText /
+      ToolLoopAgent with a tools record) but sets neither stopWhen nor maxSteps,
+      so the loop's only stopping condition is the model deciding to stop calling
+      tools. A prompt injection or a model that loops on a tool whose output keeps
+      re-triggering it can run the loop unbounded — burning tokens, hammering the
+      wired tools (including any side-effecting or billed ones), and stalling the
+      request. The SDK does not impose a default ceiling.
+    fix: >
+      Set an explicit bound: pass maxSteps (a small integer ceiling on tool
+      round-trips) or a stopWhen condition (e.g. stepCountIs(n) or a predicate
+      that ends the loop once the task is done). Choose the lowest bound the
+      workflow tolerates so a misbehaving loop fails fast instead of running away.
+
+  - id: VAI-008
+    title: Vercel AI agent forces a provider execution tool every step
+    severity: medium
+    confidence: 0.65
+    language: typescript
+    applies_to:
+      - vercel_ai_agent
+    scope: agent
+    match:
+      all:
+        - agent_kwarg_value:
+            kwarg: toolChoice
+            value: required
+        - agent_uses_hosted_tool_class:
+            - anthropic.tools.bash
+            - anthropic.tools.computer
+            - anthropic.tools.codeExecution
+            - openai.tools.localShell
+            - openai.tools.computerUsePreview
+            - openai.tools.codeInterpreter
+            - google.tools.codeExecution
+    explanation: >
+      This agent sets toolChoice: "required" while wiring a provider shell /
+      computer / code-execution tool. "required" forces the model to call a tool
+      on every step instead of letting it answer directly, so the high-risk
+      execution tool is far more likely to be invoked — and on a step the model
+      had no real need for it. Combined with a model-reachable prompt surface,
+      forcing a tool call narrows the model's options toward exactly the
+      capability you least want it reaching for.
+    fix: >
+      Use toolChoice: "auto" (the default) so the model calls the execution tool
+      only when the task needs it, or pin toolChoice to a specific safe tool when
+      a call is genuinely mandatory. Keep shell / computer / code-execution tools
+      out of any agent that forces a tool call, and gate their use behind an
+      explicit approval.

--- a/testdata/rules-fixture/vercel_ai/code_execution.yaml
+++ b/testdata/rules-fixture/vercel_ai/code_execution.yaml
@@ -1,0 +1,33 @@
+policy:
+  id: vercel_ai_code_execution
+  name: Vercel AI SDK code-execution safety
+  category: vercel_ai
+  description: >
+    Flags Vercel AI SDK tools whose execute() body evaluates code with eval or
+    the Function constructor. Either turns model-supplied text into executing
+    code with no sandbox.
+
+rules:
+  - id: VAI-002
+    title: Vercel AI tool execute() evaluates code (eval / new Function)
+    severity: high
+    confidence: 0.9
+    language: typescript
+    applies_to:
+      - vercel_ai_tool
+    scope: tool
+    match:
+      has_code_exec_call: true
+    explanation: >
+      This Vercel AI SDK tool's execute() handler calls eval(...) or constructs
+      a function with new Function(...). Because the tool is model-callable, a
+      string the model emits becomes executing JavaScript in the agent process —
+      a single prompt injection yields arbitrary code execution with no sandbox
+      between the model and the host. This is strictly more dangerous than a
+      shell-out: there is not even a separate process boundary to constrain.
+    fix: >
+      Remove eval / new Function from the tool. If the tool must interpret a
+      model-provided expression, parse it with a real parser into a constrained
+      AST you evaluate yourself, or hand it to an isolated sandbox (a separate
+      process or a hardened runner with no filesystem, network, or credentials)
+      gated behind an explicit allow-list. Never feed model output to eval.

--- a/testdata/rules-fixture/vercel_ai/repo_hygiene.yaml
+++ b/testdata/rules-fixture/vercel_ai/repo_hygiene.yaml
@@ -1,0 +1,42 @@
+policy:
+  id: vercel_ai_repo_hygiene
+  name: Vercel AI SDK repo hygiene
+  category: vercel_ai
+  description: >
+    Repo-scoped hygiene rules for projects that use the Vercel AI SDK. Fire once
+    per scan against the repo manifest and inventory.
+
+rules:
+  - id: VAI-012
+    title: Vercel AI project ships no agent-guidance doc (AGENTS.md/CLAUDE.md)
+    severity: low
+    confidence: 0.9
+    applies_to:
+      - vercel_ai
+    scope: repo
+    match:
+      all:
+        - repo_has_sdk_in_code:
+            - vercel_ai
+        - not:
+            repo_component_present:
+              - agents_md
+              - claude_md
+    explanation: >
+      The project uses the Vercel AI SDK in code but ships no agent-guidance doc
+      (AGENTS.md or CLAUDE.md) at the repo root. AGENTS.md is the cross-vendor
+      convention an editing coding agent reads before it acts; with neither file
+      present, any agent that opens this repo has no project-specific guidance on
+      how tools and agents must be configured — in particular, whether provider
+      execution tools (anthropic bash/computer, openai localShell/codeInterpreter)
+      are permitted, how tools must be typed and guarded, and the local test and
+      build commands. The likely consequence is generated code that violates the
+      project's safety contract because nothing in-tree teaches the agent the
+      local rules.
+    fix: >
+      Add an AGENTS.md at the repo root (a CLAUDE.md also satisfies this rule).
+      State whether provider execution tools are permitted and under what guard,
+      how tools must be defined and constrained, any required human-in-the-loop
+      gates, and the exact test, lint, and build commands. Keep it short and
+      concrete so an editing agent can act on it without re-deriving the
+      conventions.

--- a/testdata/rules-fixture/vercel_ai/shell_safety.yaml
+++ b/testdata/rules-fixture/vercel_ai/shell_safety.yaml
@@ -1,0 +1,37 @@
+policy:
+  id: vercel_ai_shell_safety
+  name: Vercel AI SDK shell-execution safety
+  category: vercel_ai
+  description: >
+    Flags Vercel AI SDK tools whose execute() body shells out to the operating
+    system. A model-callable tool that runs shell commands is the most direct
+    prompt-injection path to arbitrary code execution. The Vercel AI SDK ships
+    no dedicated shell-tool primitive in the `ai` core, so a hand-rolled
+    execute() that spawns a subprocess is the real shell surface to watch.
+
+rules:
+  - id: VAI-001
+    title: Vercel AI tool execute() spawns a subprocess
+    severity: high
+    confidence: 0.85
+    language: typescript
+    applies_to:
+      - vercel_ai_tool
+    scope: tool
+    match:
+      has_shell_call: true
+    explanation: >
+      This Vercel AI SDK tool's execute() handler invokes a Node shell primitive
+      (child_process exec / execSync / spawn / spawnSync / execFile / fork).
+      Because the tool is exposed to the model via the agent's tools record, a
+      prompt-injected or confused model can drive it to run arbitrary commands
+      with the agent process's privileges — shell execution selected by model
+      output is the most direct path from prompt injection to remote code
+      execution. The `ai` package has no built-in shell tool, so a tool that
+      shells out by hand is the shell surface a reviewer must inspect.
+    fix: >
+      Do not let model-controlled input reach a shell. Replace the shell-out with
+      a typed library call; if a subprocess is unavoidable, use execFile with a
+      fixed argument list (never a shell string), allow-list the exact commands,
+      and run it in a sandbox with no ambient credentials. Keep shell logic out
+      of any model-callable tool.

--- a/testdata/rules-fixture/vercel_ai/ssrf.yaml
+++ b/testdata/rules-fixture/vercel_ai/ssrf.yaml
@@ -1,0 +1,35 @@
+policy:
+  id: vercel_ai_ssrf
+  name: Vercel AI SDK server-side request forgery
+  category: vercel_ai
+  description: >
+    Flags Vercel AI SDK tools whose execute() body fetches a URL the model
+    controls. A model-chosen request target is a server-side request forgery
+    vector into internal services and the cloud metadata endpoint.
+
+rules:
+  - id: VAI-003
+    title: Vercel AI tool execute() fetches a model-controlled URL
+    severity: high
+    confidence: 0.75
+    language: typescript
+    applies_to:
+      - vercel_ai_tool
+    scope: tool
+    match:
+      has_dynamic_url_call: true
+    explanation: >
+      This Vercel AI SDK tool's execute() handler issues an outbound HTTP call
+      (fetch / axios / got / undici) whose URL is not a constant — it comes from
+      the tool's arguments, a template string, or a concatenation, all of which
+      the model controls at call time. A prompt injection can point the request
+      at internal services or the cloud metadata endpoint (169.254.169.254) to
+      exfiltrate credentials, and the fetched body then re-enters the
+      conversation as untrusted text, opening a second-order prompt-injection
+      channel.
+    fix: >
+      Do not let the model choose the request target. Validate the URL against an
+      allow-list of permitted hosts, reject private and link-local IP ranges
+      (and redirects into them), and forbid raw model-supplied URLs. Treat any
+      retrieved content as untrusted — keep it out of the system prompt and do
+      not let it expand the agent's permissions.

--- a/testdata/rules-fixture/vercel_ai/tool_definition.yaml
+++ b/testdata/rules-fixture/vercel_ai/tool_definition.yaml
@@ -1,0 +1,60 @@
+policy:
+  id: vercel_ai_tool_definition
+  name: Vercel AI SDK tool definition hygiene
+  category: vercel_ai
+  description: >
+    Hygiene rules for Vercel AI SDK tools built with tool({...}) / dynamicTool({...})
+    from the `ai` package. The `description` is the only model-visible account of
+    what the tool does (the SDK has no docstring fallback), and the inputSchema
+    is what the SDK turns into the model's argument schema.
+
+rules:
+  - id: VAI-004
+    title: Vercel AI tool has no description
+    severity: low
+    confidence: 0.9
+    language: typescript
+    applies_to:
+      - vercel_ai_tool
+    scope: tool
+    match:
+      has_docstring: false
+    explanation: >
+      The Vercel AI SDK exposes a tool to the model through its `description`
+      field — that string is the entire account of what the tool does in the
+      prompt. Unlike Python frameworks there is no docstring fallback, so a tool
+      defined with no `description` (or an empty one) reaches the model as a bare
+      name: the model cannot tell what the tool does or when to call it, and it
+      will skip the tool or invoke it with the wrong arguments. This is the
+      single highest-leverage authoring fix.
+    fix: >
+      Add a `description` to the tool({...}) options describing what the tool
+      does, the inputs it expects, and what it returns. The SDK passes this
+      string to the model verbatim, so write it for the model rather than a human
+      maintainer.
+
+  - id: VAI-005
+    title: Vercel AI tool accepts untyped input
+    severity: medium
+    confidence: 0.8
+    language: typescript
+    applies_to:
+      - vercel_ai_tool
+    scope: tool
+    match:
+      all:
+        - has_params: true
+        - has_typed_params: false
+    explanation: >
+      The Vercel AI SDK builds a tool's argument schema from its inputSchema (or
+      the v4 `parameters`). This tool takes input but imposes no field types — it
+      either uses dynamicTool (whose input is always `unknown`) or an open schema
+      (z.any(), z.unknown(), or an empty z.object({})). The model then gets no
+      argument-shape guidance and passes values of the wrong shape, which the SDK
+      rejects at validation time or, worse, forwards unchecked into execute() — a
+      reliability and injection tax on every call.
+    fix: >
+      Give the tool a concrete Zod object schema in inputSchema with a typed
+      field per argument (z.object({ city: z.string(), units: z.enum([...]) })).
+      Reserve dynamicTool for the rare case where the input genuinely cannot be
+      typed, and even then validate the shape inside execute() before using it.


### PR DESCRIPTION
## Summary

Adds Trustabl coverage for four agent SDKs — **CrewAI**, **AutoGen/AG2**, and **Pydantic AI** (Python), and **Vercel AI SDK** (TypeScript) — taking the rule set from 117 to 164.

| SDK | Lang | Rules |
|---|---|---|
| CrewAI | Python | 14 (`CREW-*`) |
| AutoGen/AG2 | Python | 12 (`AG2-*`) |
| Vercel AI SDK | TypeScript | 9 (`VAI-*`) |
| Pydantic AI | Python | 12 (`PYD-*`) |

All discovery is import-gated so the shared `Agent` / `@tool` / `tool()` names never cross-fire between SDKs. Each SDK ships tool-, agent-, and repo-scope rules with fire/silent cases. The rule YAML lives in the test fixture here and is mirrored to `trustabl-rules` (companion PR).

## Shared spine

SDK/Category/ToolKind enums, loader allow-lists (`validAppliesToForScope`, the category list, `validRepoHasSDKInCode`), `deriveSDKsDetected`, `agentKindMatches`, and `LoadFor` pack selection extended for the four SDKs. Dep needles added — Vercel uses the quoted `"ai"` key + `@ai-sdk/` (the bare `ai` package name would over-match); Pydantic uses `pydantic-ai`, not the ubiquitous `pydantic`.

## Latent fixes (folded in)

- **LangChain false META-001** — LangChain was never registered in `policy_selection.go`'s `shippedPolicySDKs`/`sdkToCategory`, so every LangChain repo emitted a bogus "unaudited SDK" info finding and never got the META-004 honest-coverage signal.
- **`exprFromNode` dict descent** — nested dict-literal kwargs (e.g. `code_execution_config={"use_docker": False}`) now resolve via dotted paths.
- **`FindFunctionNode` line-primary** — body-scan predicates now survive a `name=` override (also fixes a documented LangChain limitation).

## Deferred to v2 (documented in COVERAGE.md gaps)

CrewAI `class X(BaseTool)` + `Crew(...)`; AutoGen AG2-003 (v0.4 executor-class) + `register_function` caller/executor edge + AG2 `@tool`; Vercel VAI-009/010 (tools carry no `Name`) + VAI-011 (needs a TS abort-signal predicate) + `.js`/`.mjs` parsing; Pydantic PYD-104 (needs `call_with_kwarg_value`) + bare-`tools=[fn]` + RunContext-strip.

## Tests

`go test ./...` green — 47 fire/silent predicate cases plus per-SDK discovery collision-guard tests (incl. the Pydantic↔Claude `@agent.tool` regression). `gofmt` clean, `rules-sync` in sync (83 files).

## Companion PRs

- **trustabl-rules** — the four rule packs (the production rule source).
- **trustabl-rulebook** — 30 paired rationale docs.

_No Jira ticket was supplied; add a `Refs: TR-XXX` to the commits/PR if one applies._
