### PR TITLE
feat(plugin): auto-install the trustabl binary and scan via a bundled MCP server

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,29 @@
+{
+  "name": "trustabl",
+  "owner": {
+    "name": "Trustabl",
+    "url": "https://github.com/trustabl"
+  },
+  "metadata": {
+    "description": "Trustabl's Claude Code plugin marketplace."
+  },
+  "plugins": [
+    {
+      "name": "trustabl",
+      "source": "./",
+      "description": "Self-audit AI agent, tool, and MCP-server code for security and reliability misconfigurations with Trustabl, the static analyzer for the OpenAI Agents SDK, Claude Agent SDK, Google ADK, and MCP.",
+      "homepage": "https://github.com/trustabl/trustabl",
+      "license": "Apache-2.0",
+      "category": "security",
+      "keywords": [
+        "security",
+        "static-analysis",
+        "agents",
+        "mcp",
+        "openai-agents-sdk",
+        "claude-agent-sdk",
+        "google-adk"
+      ]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,5 +3,6 @@
   "version": "0.1.2",
   "description": "Self-audit AI agent, tool, and MCP-server code for security and reliability misconfigurations with Trustabl, the static analyzer for the OpenAI Agents SDK, Claude Agent SDK, Google ADK, and MCP. Ships two skills: trustabl-scan runs the trustabl CLI right after you write or change agent code before you commit, and trustabl-enrich applies the scan findings directly to your source files as targeted code edits.",
   "homepage": "https://github.com/trustabl/trustabl",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "hooks": "./hooks/hooks.json"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "trustabl",
   "version": "0.1.2",
-  "description": "Self-audit AI agent, tool, and MCP-server code for security and reliability misconfigurations with Trustabl, the static analyzer for the OpenAI Agents SDK, Claude Agent SDK, Google ADK, and MCP. Ships two skills: trustabl-scan runs the trustabl CLI right after you write or change agent code before you commit, and trustabl-enrich applies the scan findings directly to your source files as targeted code edits.",
+  "description": "Self-audit AI agent, tool, and MCP-server code for security and reliability misconfigurations with Trustabl, the static analyzer for the OpenAI Agents SDK, Claude Agent SDK, Google ADK, and MCP. Ships two skills: trustabl-scan scans your agent code with Trustabl (via a bundled MCP server) right after you write or change it, before you commit, and trustabl-enrich applies the scan findings directly to your source files as targeted code edits.",
   "homepage": "https://github.com/trustabl/trustabl",
   "license": "Apache-2.0",
   "hooks": "./hooks/hooks.json"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,6 +3,7 @@
   "version": "0.1.2",
   "description": "Self-audit AI agent, tool, and MCP-server code for security and reliability misconfigurations with Trustabl, the static analyzer for the OpenAI Agents SDK, Claude Agent SDK, Google ADK, and MCP. Ships two skills: trustabl-scan scans your agent code with Trustabl (via a bundled MCP server) right after you write or change it, before you commit, and trustabl-enrich applies the scan findings directly to your source files as targeted code edits.",
   "homepage": "https://github.com/trustabl/trustabl",
+  "author": { "name": "Trustabl", "url": "https://github.com/trustabl" },
   "license": "Apache-2.0",
   "hooks": "./hooks/hooks.json"
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "trustabl": {
+      "type": "stdio",
+      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/trustabl-mcp.sh"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -512,8 +512,14 @@ with two skills that form a scan-and-fix loop:
   `trustabl-scan` first, then invoke `trustabl-enrich` with the results.
 
 Both skills shell out to the same `trustabl` binary, so the binary must be
-installed and on `PATH`. Neither runs a network service or modifies files
-outside the scan target.
+installed and on `PATH`. A non-destructive `SessionStart` hook
+([`hooks/hooks.json`](hooks/hooks.json) →
+[`scripts/check-trustabl.sh`](scripts/check-trustabl.sh)) checks at session
+start whether the binary is present and meets the minimum version the skills
+need, surfacing an install hint when it is missing or outdated. The hook never
+installs anything itself — the install stays a consented step inside
+`trustabl-scan`. Neither skill runs a network service or modifies files outside
+the scan target.
 
 ### "no schema-compatible rules available"
 

--- a/README.md
+++ b/README.md
@@ -503,27 +503,33 @@ Trustabl ships a Claude Code plugin under [`.claude-plugin/`](.claude-plugin/)
 with two skills that form a scan-and-fix loop:
 
 - **[`trustabl-scan`](skills/trustabl-scan/)** — triggers right after agent,
-  tool, subagent, or MCP-server code is written or changed and runs
-  `trustabl scan` to self-audit it before committing, upstream of CI.
+  tool, subagent, or MCP-server code is written or changed and calls Trustabl's
+  `scan` tool (the bundled MCP server, `mcp__trustabl__scan`) to self-audit it
+  before committing, upstream of CI.
 - **[`trustabl-enrich`](skills/trustabl-enrich/)** — takes the output of a
   `trustabl scan` run (JSON, SARIF, or pasted terminal text) and applies each
   finding as a targeted code edit, guided entirely by the scan's own
   `explanation` and `suggested_fix` fields. It does not re-run the scanner; use
   `trustabl-scan` first, then invoke `trustabl-enrich` with the results.
 
-Both skills shell out to the same `trustabl` binary. A `SessionStart` hook
+Scanning runs through a **bundled MCP server**: [`.mcp.json`](.mcp.json)
+registers a `trustabl` server whose command is a launcher
+([`scripts/trustabl-mcp.sh`](scripts/trustabl-mcp.sh)) exposing the
+`mcp__trustabl__scan` tool. The launcher and a `SessionStart` hook
 ([`hooks/hooks.json`](hooks/hooks.json) →
-[`scripts/check-trustabl.sh`](scripts/check-trustabl.sh)) keeps that binary
-current automatically: at session start it downloads the pinned CLI version from
-GitHub Releases, verifies it against the release `checksums.txt`, installs it
-into the plugin's private data directory (`$CLAUDE_PLUGIN_DATA` — no `sudo`, and
-nothing outside that dir is touched), and exposes it to the skills as
-`$TRUSTABL_BIN`. The install is idempotent: it re-runs only when the pin changes
-or the copy is missing/corrupt. When auto-install cannot run (offline first
-session, an unsupported platform, or missing `curl`/`tar`) it falls back to
-whatever `trustabl` is on `PATH` and prints an install hint — the system-wide
-install then stays a consented step inside `trustabl-scan`. Neither skill runs a
-network service or modifies files outside the scan target.
+[`scripts/check-trustabl.sh`](scripts/check-trustabl.sh)) share install logic
+([`scripts/lib-trustabl.sh`](scripts/lib-trustabl.sh)) that downloads the pinned
+CLI version from GitHub Releases, verifies it against the release
+`checksums.txt`, and installs it into the plugin's private data directory
+(`$CLAUDE_PLUGIN_DATA` — no `sudo`, nothing outside that dir touched). The
+install is idempotent (re-runs only when the pin changes or the copy is
+missing/corrupt), and the launcher installs synchronously before starting the
+server, so there is no first-session race. The same binary is exposed as
+`$TRUSTABL_BIN` for the enrich skill's direct-CLI path. When auto-install cannot
+run (offline first session, an unsupported platform, or missing `curl`/`tar`) it
+falls back to whatever `trustabl` is on `PATH`; the system-wide install stays a
+consented step inside `trustabl-scan`. The plugin runs no network service of its
+own and modifies nothing outside the scan target.
 
 ### "no schema-compatible rules available"
 

--- a/README.md
+++ b/README.md
@@ -511,15 +511,19 @@ with two skills that form a scan-and-fix loop:
   `explanation` and `suggested_fix` fields. It does not re-run the scanner; use
   `trustabl-scan` first, then invoke `trustabl-enrich` with the results.
 
-Both skills shell out to the same `trustabl` binary, so the binary must be
-installed and on `PATH`. A non-destructive `SessionStart` hook
+Both skills shell out to the same `trustabl` binary. A `SessionStart` hook
 ([`hooks/hooks.json`](hooks/hooks.json) →
-[`scripts/check-trustabl.sh`](scripts/check-trustabl.sh)) checks at session
-start whether the binary is present and meets the minimum version the skills
-need, surfacing an install hint when it is missing or outdated. The hook never
-installs anything itself — the install stays a consented step inside
-`trustabl-scan`. Neither skill runs a network service or modifies files outside
-the scan target.
+[`scripts/check-trustabl.sh`](scripts/check-trustabl.sh)) keeps that binary
+current automatically: at session start it downloads the pinned CLI version from
+GitHub Releases, verifies it against the release `checksums.txt`, installs it
+into the plugin's private data directory (`$CLAUDE_PLUGIN_DATA` — no `sudo`, and
+nothing outside that dir is touched), and exposes it to the skills as
+`$TRUSTABL_BIN`. The install is idempotent: it re-runs only when the pin changes
+or the copy is missing/corrupt. When auto-install cannot run (offline first
+session, an unsupported platform, or missing `curl`/`tar`) it falls back to
+whatever `trustabl` is on `PATH` and prints an install hint — the system-wide
+install then stays a consented step inside `trustabl-scan`. Neither skill runs a
+network service or modifies files outside the scan target.
 
 ### "no schema-compatible rules available"
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/scripts/check-trustabl.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/check-trustabl.sh
+++ b/scripts/check-trustabl.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Trustabl plugin — SessionStart detector.
+#
+# Non-destructive: verifies the `trustabl` CLI is installed and recent enough for
+# the plugin's skills. Prints a single actionable line (which Claude Code injects
+# into the session at start) only when something needs attention; stays silent
+# and exits 0 when the CLI is present and current.
+#
+# This script NEVER installs anything and NEVER fails the session (always exits
+# 0). The consented install path lives in the trustabl-scan skill, which asks the
+# user before running any install command — appropriate for a security tool.
+#
+# Platform note: this is a bash script. On native Windows (PowerShell, no
+# bash) it will not run; Windows users get the install hint from the skill
+# instead. macOS/Linux and Windows-with-Git-Bash/WSL are covered.
+
+set -uo pipefail
+
+# Minimum CLI version the skills require. Bump this when a skill starts depending
+# on a newer CLI feature. 0.1.2 is the current floor: it ships `scan`,
+# `--format sarif`, and `--strict`, which the scan/enrich skills use today.
+MIN_VERSION="0.1.2"
+
+INSTALL_HINT="install with 'brew install trustabl/tap/trustabl' (macOS/Linux), 'scoop install trustabl' (Windows), or download a build from https://github.com/trustabl/trustabl/releases"
+
+if ! command -v trustabl >/dev/null 2>&1; then
+  echo "[trustabl] CLI not found on PATH — the trustabl-scan and trustabl-enrich skills cannot run until it is installed. To use them, ${INSTALL_HINT}, then confirm with 'trustabl version'."
+  exit 0
+fi
+
+have="$(trustabl version 2>/dev/null | awk 'NR==1 {print $2}')"
+if [ -z "${have:-}" ]; then
+  # CLI is present but its version line could not be read; assume it is usable
+  # rather than nag on every session.
+  exit 0
+fi
+
+# Version compare via `sort -V`: the lower of {MIN, have} equals MIN exactly when
+# have >= MIN (covers the have == MIN case too).
+lowest="$(printf '%s\n%s\n' "${MIN_VERSION}" "${have}" | sort -V | head -n1)"
+if [ "${lowest}" != "${MIN_VERSION}" ]; then
+  echo "[trustabl] CLI ${have} is older than the minimum ${MIN_VERSION} the skills need — please upgrade: ${INSTALL_HINT}."
+  exit 0
+fi
+
+# Present and current: stay silent to keep the session context clean.
+exit 0

--- a/scripts/check-trustabl.sh
+++ b/scripts/check-trustabl.sh
@@ -1,141 +1,42 @@
 #!/usr/bin/env bash
 # Trustabl plugin — SessionStart bootstrap.
 #
-# Ensures the recommended `trustabl` CLI version is available to the plugin's
-# skills, then tells the session where to find it. Two modes, tried in order:
+# Ensures the pinned trustabl CLI is installed into the plugin's private data
+# dir, so (a) the bundled MCP scan server can launch cleanly and (b) the
+# enrich skill's direct-CLI fallback has a binary to call. It then exposes the
+# binary to the session as $TRUSTABL_BIN.
 #
-#   1. Auto-install (preferred): download the pinned version from GitHub
-#      Releases into the plugin's private data dir (CLAUDE_PLUGIN_DATA),
-#      checksum-verified against the release's checksums.txt, and expose its
-#      path. Idempotent — it re-downloads only when the pin changes or the
-#      installed copy is missing/wrong. No sudo, no change to the user's system
-#      package manager or their own `trustabl`; fully reversible (everything
-#      lives under CLAUDE_PLUGIN_DATA, which is removed when the plugin is
-#      uninstalled).
+# Scanning itself goes through the MCP `scan` tool (mcp__trustabl__scan), not
+# through this hook. This hook is the install/announce step only.
 #
-#   2. Detect + hint (fallback): when auto-install cannot run — offline, no
-#      CLAUDE_PLUGIN_DATA, an unsupported OS/arch, missing curl/tar/sha256, or a
-#      failed checksum — fall back to checking for a `trustabl` already on PATH
-#      and printing an install/upgrade hint.
-#
-# How skills find the binary: this script (a) appends `export TRUSTABL_BIN=...`
-# to CLAUDE_ENV_FILE so later Bash tool calls inherit it, and (b) prints the
-# absolute path into the session. The skills prefer "$TRUSTABL_BIN", then the
-# reported path, then `trustabl` on PATH.
-#
-# This script ALWAYS exits 0 and never fails the session. It never installs into
-# system locations and never runs the user's package manager.
-
+# Install details (download from GitHub Releases into CLAUDE_PLUGIN_DATA,
+# checksum-verified, idempotent) live in lib-trustabl.sh, shared with the MCP
+# launcher. This script ALWAYS exits 0 and never fails the session.
 set -uo pipefail
 
-# --- pin ---------------------------------------------------------------------
-# The exact CLI version the plugin's skills are tested against. Bump this on a
-# plugin release to move users to a newer CLI; the next SessionStart re-installs.
-RECOMMENDED_VERSION="0.1.3"
-REPO="trustabl/trustabl"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib-trustabl.sh
+. "${DIR}/lib-trustabl.sh"
 
-INSTALL_HINT="install with 'brew install trustabl/tap/trustabl' (macOS/Linux), 'scoop install trustabl' (Windows), or download from https://github.com/${REPO}/releases"
-
-# Version string of the binary at $1 ("" if absent/unreadable).
-bin_version() { [ -x "$1" ] && "$1" version 2>/dev/null | awk 'NR==1 {print $2}'; }
-
-have_cmd() { command -v "$1" >/dev/null 2>&1; }
-
-# Fallback: report on whatever `trustabl` is on PATH (or its absence).
-fallback_detect() {
-  if ! have_cmd trustabl; then
-    echo "[trustabl] CLI not found and the plugin could not auto-install it here — ${INSTALL_HINT}, then confirm with 'trustabl version'."
-    return
+if bin="$(tdl_managed_bin)" && [ -n "$bin" ] && tdl_ensure; then
+  # Expose the managed binary to later Bash tool calls (idempotent: only append
+  # the export once per env file).
+  if [ -n "${CLAUDE_ENV_FILE:-}" ] && ! grep -q 'TRUSTABL_BIN=' "$CLAUDE_ENV_FILE" 2>/dev/null; then
+    echo "export TRUSTABL_BIN=\"$bin\"" >> "$CLAUDE_ENV_FILE"
   fi
-  local have lowest
-  have="$(trustabl version 2>/dev/null | awk 'NR==1 {print $2}')"
-  lowest="$(printf '%s\n%s\n' "$RECOMMENDED_VERSION" "$have" | sort -V | head -n1)"
-  if [ -n "$have" ] && [ "$lowest" != "$RECOMMENDED_VERSION" ]; then
-    echo "[trustabl] CLI ${have} on PATH is older than the recommended ${RECOMMENDED_VERSION} — upgrade: ${INSTALL_HINT}."
-  fi
-  # Present and adequate: stay silent.
-}
-
-# Wire the resolved binary into the session (env file + a context line).
-announce() {
-  local bin="$1" verb="$2"
-  [ -n "${CLAUDE_ENV_FILE:-}" ] && echo "export TRUSTABL_BIN=\"${bin}\"" >> "$CLAUDE_ENV_FILE"
-  echo "[trustabl] ${verb} plugin-managed trustabl ${RECOMMENDED_VERSION} at ${bin} — use this path (or \$TRUSTABL_BIN) to run trustabl this session."
-}
-
-# --- need a private dir to install into; otherwise fall back -----------------
-if [ -z "${CLAUDE_PLUGIN_DATA:-}" ]; then
-  fallback_detect; exit 0
-fi
-
-BIN_DIR="${CLAUDE_PLUGIN_DATA}/bin"
-BIN="${BIN_DIR}/trustabl"
-
-# Fast path: already the pinned version (every session after the first).
-if [ "$(bin_version "$BIN")" = "$RECOMMENDED_VERSION" ]; then
-  announce "$BIN" "Using"
+  echo "[trustabl] Plugin-managed trustabl ${TRUSTABL_VERSION} ready at ${bin}. Scanning uses the mcp__trustabl__scan tool; \$TRUSTABL_BIN is set for direct CLI use (e.g. enrich)."
   exit 0
 fi
 
-# --- map OS/arch to the release asset ---------------------------------------
-os="$(uname -s)"; arch="$(uname -m)"
-case "$os" in
-  Darwin) os=darwin ;;
-  Linux)  os=linux ;;
-  *) echo "[trustabl] auto-install is unsupported on '${os}'."; fallback_detect; exit 0 ;;
-esac
-case "$arch" in
-  x86_64|amd64)   arch=amd64 ;;
-  arm64|aarch64)  arch=arm64 ;;
-  *) echo "[trustabl] auto-install is unsupported on arch '${arch}'."; fallback_detect; exit 0 ;;
-esac
-
-if ! have_cmd curl || ! have_cmd tar; then
-  echo "[trustabl] auto-install needs curl and tar."; fallback_detect; exit 0
-fi
-if ! have_cmd sha256sum && ! have_cmd shasum; then
-  echo "[trustabl] auto-install needs a sha256 tool (sha256sum or shasum)."; fallback_detect; exit 0
-fi
-
-asset="trustabl_${RECOMMENDED_VERSION}_${os}_${arch}.tar.gz"
-base="https://github.com/${REPO}/releases/download/v${RECOMMENDED_VERSION}"
-
-tmp="$(mktemp -d 2>/dev/null)" || { echo "[trustabl] could not create a temp dir."; fallback_detect; exit 0; }
-trap 'rm -rf "$tmp"' EXIT
-
-if ! curl -fsSL "${base}/${asset}" -o "${tmp}/${asset}" \
-   || ! curl -fsSL "${base}/checksums.txt" -o "${tmp}/checksums.txt"; then
-  echo "[trustabl] could not download ${asset} (offline?) — using whatever is on PATH."
-  fallback_detect; exit 0
-fi
-
-# Verify the archive against checksums.txt before touching it.
-want_sum="$(awk -v f="$asset" '$2 == f || $2 == "*"f {print $1}' "${tmp}/checksums.txt" | head -n1)"
-if have_cmd sha256sum; then
-  got_sum="$(sha256sum "${tmp}/${asset}" | awk '{print $1}')"
+# Auto-install could not run — report on whatever is on PATH so the session
+# still knows the state.
+if command -v trustabl >/dev/null 2>&1; then
+  have="$(trustabl version 2>/dev/null | awk 'NR==1 {print $2}')"
+  lowest="$(printf '%s\n%s\n' "$TRUSTABL_VERSION" "$have" | sort -V | head -n1)"
+  if [ -n "$have" ] && [ "$lowest" != "$TRUSTABL_VERSION" ]; then
+    echo "[trustabl] CLI ${have} on PATH is older than ${TRUSTABL_VERSION}; the MCP scan server needs ${TRUSTABL_VERSION}+. Upgrade: ${TRUSTABL_INSTALL_HINT}."
+  fi
 else
-  got_sum="$(shasum -a 256 "${tmp}/${asset}" | awk '{print $1}')"
-fi
-if [ -z "$want_sum" ] || [ "$want_sum" != "$got_sum" ]; then
-  echo "[trustabl] checksum verification FAILED for ${asset} — refusing to install."
-  fallback_detect; exit 0
-fi
-
-# Extract the binary (archive root holds `trustabl` plus license/readme).
-tar -xzf "${tmp}/${asset}" -C "$tmp" trustabl 2>/dev/null || tar -xzf "${tmp}/${asset}" -C "$tmp" 2>/dev/null
-src="$(find "$tmp" -type f -name trustabl 2>/dev/null | head -n1)"
-if [ -z "$src" ]; then
-  echo "[trustabl] could not find the binary inside ${asset} — using whatever is on PATH."
-  fallback_detect; exit 0
-fi
-
-mkdir -p "$BIN_DIR"
-install -m 0755 "$src" "$BIN" 2>/dev/null || { cp "$src" "$BIN" && chmod 0755 "$BIN"; }
-
-if [ "$(bin_version "$BIN")" = "$RECOMMENDED_VERSION" ]; then
-  announce "$BIN" "Installed"
-else
-  echo "[trustabl] post-install version check failed — using whatever is on PATH."
-  fallback_detect
+  echo "[trustabl] could not provide the trustabl CLI automatically — ${TRUSTABL_INSTALL_HINT}, then confirm with 'trustabl version'."
 fi
 exit 0

--- a/scripts/check-trustabl.sh
+++ b/scripts/check-trustabl.sh
@@ -1,47 +1,141 @@
 #!/usr/bin/env bash
-# Trustabl plugin — SessionStart detector.
+# Trustabl plugin — SessionStart bootstrap.
 #
-# Non-destructive: verifies the `trustabl` CLI is installed and recent enough for
-# the plugin's skills. Prints a single actionable line (which Claude Code injects
-# into the session at start) only when something needs attention; stays silent
-# and exits 0 when the CLI is present and current.
+# Ensures the recommended `trustabl` CLI version is available to the plugin's
+# skills, then tells the session where to find it. Two modes, tried in order:
 #
-# This script NEVER installs anything and NEVER fails the session (always exits
-# 0). The consented install path lives in the trustabl-scan skill, which asks the
-# user before running any install command — appropriate for a security tool.
+#   1. Auto-install (preferred): download the pinned version from GitHub
+#      Releases into the plugin's private data dir (CLAUDE_PLUGIN_DATA),
+#      checksum-verified against the release's checksums.txt, and expose its
+#      path. Idempotent — it re-downloads only when the pin changes or the
+#      installed copy is missing/wrong. No sudo, no change to the user's system
+#      package manager or their own `trustabl`; fully reversible (everything
+#      lives under CLAUDE_PLUGIN_DATA, which is removed when the plugin is
+#      uninstalled).
 #
-# Platform note: this is a bash script. On native Windows (PowerShell, no
-# bash) it will not run; Windows users get the install hint from the skill
-# instead. macOS/Linux and Windows-with-Git-Bash/WSL are covered.
+#   2. Detect + hint (fallback): when auto-install cannot run — offline, no
+#      CLAUDE_PLUGIN_DATA, an unsupported OS/arch, missing curl/tar/sha256, or a
+#      failed checksum — fall back to checking for a `trustabl` already on PATH
+#      and printing an install/upgrade hint.
+#
+# How skills find the binary: this script (a) appends `export TRUSTABL_BIN=...`
+# to CLAUDE_ENV_FILE so later Bash tool calls inherit it, and (b) prints the
+# absolute path into the session. The skills prefer "$TRUSTABL_BIN", then the
+# reported path, then `trustabl` on PATH.
+#
+# This script ALWAYS exits 0 and never fails the session. It never installs into
+# system locations and never runs the user's package manager.
 
 set -uo pipefail
 
-# Minimum CLI version the skills require. Bump this when a skill starts depending
-# on a newer CLI feature. 0.1.2 is the current floor: it ships `scan`,
-# `--format sarif`, and `--strict`, which the scan/enrich skills use today.
-MIN_VERSION="0.1.2"
+# --- pin ---------------------------------------------------------------------
+# The exact CLI version the plugin's skills are tested against. Bump this on a
+# plugin release to move users to a newer CLI; the next SessionStart re-installs.
+RECOMMENDED_VERSION="0.1.3"
+REPO="trustabl/trustabl"
 
-INSTALL_HINT="install with 'brew install trustabl/tap/trustabl' (macOS/Linux), 'scoop install trustabl' (Windows), or download a build from https://github.com/trustabl/trustabl/releases"
+INSTALL_HINT="install with 'brew install trustabl/tap/trustabl' (macOS/Linux), 'scoop install trustabl' (Windows), or download from https://github.com/${REPO}/releases"
 
-if ! command -v trustabl >/dev/null 2>&1; then
-  echo "[trustabl] CLI not found on PATH — the trustabl-scan and trustabl-enrich skills cannot run until it is installed. To use them, ${INSTALL_HINT}, then confirm with 'trustabl version'."
+# Version string of the binary at $1 ("" if absent/unreadable).
+bin_version() { [ -x "$1" ] && "$1" version 2>/dev/null | awk 'NR==1 {print $2}'; }
+
+have_cmd() { command -v "$1" >/dev/null 2>&1; }
+
+# Fallback: report on whatever `trustabl` is on PATH (or its absence).
+fallback_detect() {
+  if ! have_cmd trustabl; then
+    echo "[trustabl] CLI not found and the plugin could not auto-install it here — ${INSTALL_HINT}, then confirm with 'trustabl version'."
+    return
+  fi
+  local have lowest
+  have="$(trustabl version 2>/dev/null | awk 'NR==1 {print $2}')"
+  lowest="$(printf '%s\n%s\n' "$RECOMMENDED_VERSION" "$have" | sort -V | head -n1)"
+  if [ -n "$have" ] && [ "$lowest" != "$RECOMMENDED_VERSION" ]; then
+    echo "[trustabl] CLI ${have} on PATH is older than the recommended ${RECOMMENDED_VERSION} — upgrade: ${INSTALL_HINT}."
+  fi
+  # Present and adequate: stay silent.
+}
+
+# Wire the resolved binary into the session (env file + a context line).
+announce() {
+  local bin="$1" verb="$2"
+  [ -n "${CLAUDE_ENV_FILE:-}" ] && echo "export TRUSTABL_BIN=\"${bin}\"" >> "$CLAUDE_ENV_FILE"
+  echo "[trustabl] ${verb} plugin-managed trustabl ${RECOMMENDED_VERSION} at ${bin} — use this path (or \$TRUSTABL_BIN) to run trustabl this session."
+}
+
+# --- need a private dir to install into; otherwise fall back -----------------
+if [ -z "${CLAUDE_PLUGIN_DATA:-}" ]; then
+  fallback_detect; exit 0
+fi
+
+BIN_DIR="${CLAUDE_PLUGIN_DATA}/bin"
+BIN="${BIN_DIR}/trustabl"
+
+# Fast path: already the pinned version (every session after the first).
+if [ "$(bin_version "$BIN")" = "$RECOMMENDED_VERSION" ]; then
+  announce "$BIN" "Using"
   exit 0
 fi
 
-have="$(trustabl version 2>/dev/null | awk 'NR==1 {print $2}')"
-if [ -z "${have:-}" ]; then
-  # CLI is present but its version line could not be read; assume it is usable
-  # rather than nag on every session.
-  exit 0
+# --- map OS/arch to the release asset ---------------------------------------
+os="$(uname -s)"; arch="$(uname -m)"
+case "$os" in
+  Darwin) os=darwin ;;
+  Linux)  os=linux ;;
+  *) echo "[trustabl] auto-install is unsupported on '${os}'."; fallback_detect; exit 0 ;;
+esac
+case "$arch" in
+  x86_64|amd64)   arch=amd64 ;;
+  arm64|aarch64)  arch=arm64 ;;
+  *) echo "[trustabl] auto-install is unsupported on arch '${arch}'."; fallback_detect; exit 0 ;;
+esac
+
+if ! have_cmd curl || ! have_cmd tar; then
+  echo "[trustabl] auto-install needs curl and tar."; fallback_detect; exit 0
+fi
+if ! have_cmd sha256sum && ! have_cmd shasum; then
+  echo "[trustabl] auto-install needs a sha256 tool (sha256sum or shasum)."; fallback_detect; exit 0
 fi
 
-# Version compare via `sort -V`: the lower of {MIN, have} equals MIN exactly when
-# have >= MIN (covers the have == MIN case too).
-lowest="$(printf '%s\n%s\n' "${MIN_VERSION}" "${have}" | sort -V | head -n1)"
-if [ "${lowest}" != "${MIN_VERSION}" ]; then
-  echo "[trustabl] CLI ${have} is older than the minimum ${MIN_VERSION} the skills need — please upgrade: ${INSTALL_HINT}."
-  exit 0
+asset="trustabl_${RECOMMENDED_VERSION}_${os}_${arch}.tar.gz"
+base="https://github.com/${REPO}/releases/download/v${RECOMMENDED_VERSION}"
+
+tmp="$(mktemp -d 2>/dev/null)" || { echo "[trustabl] could not create a temp dir."; fallback_detect; exit 0; }
+trap 'rm -rf "$tmp"' EXIT
+
+if ! curl -fsSL "${base}/${asset}" -o "${tmp}/${asset}" \
+   || ! curl -fsSL "${base}/checksums.txt" -o "${tmp}/checksums.txt"; then
+  echo "[trustabl] could not download ${asset} (offline?) — using whatever is on PATH."
+  fallback_detect; exit 0
 fi
 
-# Present and current: stay silent to keep the session context clean.
+# Verify the archive against checksums.txt before touching it.
+want_sum="$(awk -v f="$asset" '$2 == f || $2 == "*"f {print $1}' "${tmp}/checksums.txt" | head -n1)"
+if have_cmd sha256sum; then
+  got_sum="$(sha256sum "${tmp}/${asset}" | awk '{print $1}')"
+else
+  got_sum="$(shasum -a 256 "${tmp}/${asset}" | awk '{print $1}')"
+fi
+if [ -z "$want_sum" ] || [ "$want_sum" != "$got_sum" ]; then
+  echo "[trustabl] checksum verification FAILED for ${asset} — refusing to install."
+  fallback_detect; exit 0
+fi
+
+# Extract the binary (archive root holds `trustabl` plus license/readme).
+tar -xzf "${tmp}/${asset}" -C "$tmp" trustabl 2>/dev/null || tar -xzf "${tmp}/${asset}" -C "$tmp" 2>/dev/null
+src="$(find "$tmp" -type f -name trustabl 2>/dev/null | head -n1)"
+if [ -z "$src" ]; then
+  echo "[trustabl] could not find the binary inside ${asset} — using whatever is on PATH."
+  fallback_detect; exit 0
+fi
+
+mkdir -p "$BIN_DIR"
+install -m 0755 "$src" "$BIN" 2>/dev/null || { cp "$src" "$BIN" && chmod 0755 "$BIN"; }
+
+if [ "$(bin_version "$BIN")" = "$RECOMMENDED_VERSION" ]; then
+  announce "$BIN" "Installed"
+else
+  echo "[trustabl] post-install version check failed — using whatever is on PATH."
+  fallback_detect
+fi
 exit 0

--- a/scripts/lib-trustabl.sh
+++ b/scripts/lib-trustabl.sh
@@ -1,0 +1,77 @@
+# shellcheck shell=bash
+# Shared install logic for the Trustabl plugin. Sourced by check-trustabl.sh
+# (the SessionStart hook) and trustabl-mcp.sh (the MCP server launcher).
+#
+# Every function writes diagnostics to STDERR only — never stdout — so this is
+# safe to source in the MCP launcher, whose stdout is the JSON-RPC protocol
+# stream and must not be polluted.
+
+# Pinned CLI version the plugin targets. The MCP `scan` tool needs >= 0.1.3
+# (0.1.2 has no `mcp` subcommand). Bump on a plugin release to move users on.
+TRUSTABL_VERSION="0.1.3"
+TRUSTABL_REPO="trustabl/trustabl"
+TRUSTABL_INSTALL_HINT="install with 'brew install trustabl/tap/trustabl' (macOS/Linux), 'scoop install trustabl' (Windows), or download from https://github.com/${TRUSTABL_REPO}/releases"
+
+_tdl_log()  { printf '[trustabl] %s\n' "$*" >&2; }
+_tdl_have() { command -v "$1" >/dev/null 2>&1; }
+
+# Absolute path to the plugin-managed binary ("" when there is no data dir).
+tdl_managed_bin() { [ -n "${CLAUDE_PLUGIN_DATA:-}" ] && printf '%s' "${CLAUDE_PLUGIN_DATA}/bin/trustabl"; }
+
+# Version string reported by the binary at $1 ("" if absent/unreadable).
+tdl_bin_version() { [ -x "$1" ] && "$1" version 2>/dev/null | awk 'NR==1 {print $2}'; }
+
+# Ensure the pinned binary is installed at the managed path. Returns 0 when the
+# managed binary is present and is exactly TRUSTABL_VERSION, 1 otherwise.
+# Idempotent (fast-paths when already correct); all output goes to stderr.
+tdl_ensure() {
+  local bin; bin="$(tdl_managed_bin)"
+  [ -n "$bin" ] || { _tdl_log "no CLAUDE_PLUGIN_DATA set; cannot manage a private binary."; return 1; }
+  [ "$(tdl_bin_version "$bin")" = "$TRUSTABL_VERSION" ] && return 0
+
+  local os arch
+  os="$(uname -s)"; arch="$(uname -m)"
+  case "$os" in
+    Darwin) os=darwin ;;
+    Linux)  os=linux ;;
+    *) _tdl_log "auto-install is unsupported on '${os}'."; return 1 ;;
+  esac
+  case "$arch" in
+    x86_64|amd64)  arch=amd64 ;;
+    arm64|aarch64) arch=arm64 ;;
+    *) _tdl_log "auto-install is unsupported on arch '${arch}'."; return 1 ;;
+  esac
+  _tdl_have curl || { _tdl_log "auto-install needs curl."; return 1; }
+  _tdl_have tar  || { _tdl_log "auto-install needs tar."; return 1; }
+  { _tdl_have sha256sum || _tdl_have shasum; } || { _tdl_log "auto-install needs sha256sum or shasum."; return 1; }
+
+  local asset base
+  asset="trustabl_${TRUSTABL_VERSION}_${os}_${arch}.tar.gz"
+  base="https://github.com/${TRUSTABL_REPO}/releases/download/v${TRUSTABL_VERSION}"
+  mkdir -p "$(dirname "$bin")" || { _tdl_log "could not create $(dirname "$bin")."; return 1; }
+
+  # Download, verify, and stage in a subshell so its temp dir and staging file
+  # are always cleaned up. Staging is in the binary's own dir, so the final mv
+  # is atomic (same filesystem) and safe against a concurrent installer.
+  (
+    tmp="$(mktemp -d)" || exit 1
+    stage="$(dirname "$bin")/.trustabl.staging.${BASHPID:-$$}"
+    trap 'rm -rf "$tmp" "$stage"' EXIT
+    curl -fsSL "${base}/${asset}"        -o "${tmp}/${asset}"        || { _tdl_log "download of ${asset} failed (offline?)."; exit 1; }
+    curl -fsSL "${base}/checksums.txt"   -o "${tmp}/checksums.txt"   || { _tdl_log "download of checksums.txt failed."; exit 1; }
+    want="$(awk -v f="$asset" '$2==f || $2=="*"f {print $1}' "${tmp}/checksums.txt" | head -n1)"
+    if _tdl_have sha256sum; then got="$(sha256sum "${tmp}/${asset}" | awk '{print $1}')"
+    else                        got="$(shasum -a 256 "${tmp}/${asset}" | awk '{print $1}')"; fi
+    [ -n "$want" ] && [ "$want" = "$got" ] || { _tdl_log "checksum verification FAILED for ${asset}."; exit 1; }
+    tar -xzf "${tmp}/${asset}" -C "$tmp" trustabl 2>/dev/null || tar -xzf "${tmp}/${asset}" -C "$tmp" 2>/dev/null
+    src="$(find "$tmp" -type f -name trustabl 2>/dev/null | head -n1)"
+    [ -n "$src" ] || { _tdl_log "could not find the binary inside ${asset}."; exit 1; }
+    install -m 0755 "$src" "$stage" 2>/dev/null || { cp "$src" "$stage" && chmod 0755 "$stage"; } || { _tdl_log "staging the binary failed."; exit 1; }
+    mv -f "$stage" "$bin" || { _tdl_log "installing to ${bin} failed."; exit 1; }
+    exit 0
+  ) || return 1
+
+  [ "$(tdl_bin_version "$bin")" = "$TRUSTABL_VERSION" ] || { _tdl_log "post-install version check failed."; return 1; }
+  _tdl_log "installed trustabl ${TRUSTABL_VERSION} at ${bin}."
+  return 0
+}

--- a/scripts/trustabl-mcp.sh
+++ b/scripts/trustabl-mcp.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Trustabl plugin — MCP server launcher (the command referenced by .mcp.json).
+#
+# This bundled script always exists, so Claude Code never hits a "command not
+# found" when starting the server (which it would not retry). The script ensures
+# the pinned binary is installed, then execs `trustabl mcp`. Because it installs
+# synchronously before exec, it removes any race with the SessionStart hook.
+#
+# The binary's stdout is the JSON-RPC protocol stream, so NOTHING here may write
+# to stdout — all install diagnostics go to stderr (the client's server log).
+set -uo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib-trustabl.sh
+. "${DIR}/lib-trustabl.sh"
+
+BIN=""
+if managed="$(tdl_managed_bin)" && [ -n "$managed" ] && tdl_ensure; then
+  BIN="$managed"
+else
+  # Fall back to a PATH binary. It may predate the `mcp` subcommand (in which
+  # case the server will exit and Claude Code shows it as failed), but that is
+  # strictly better than refusing to launch.
+  BIN="$(command -v trustabl || true)"
+fi
+
+if [ -z "$BIN" ]; then
+  _tdl_log "no trustabl binary available to start the MCP server; ${TRUSTABL_INSTALL_HINT}."
+  exit 1
+fi
+
+exec "$BIN" mcp "$@"

--- a/skills/trustabl-enrich/SKILL.md
+++ b/skills/trustabl-enrich/SKILL.md
@@ -35,6 +35,8 @@ All three formats produced by the Trustabl CLI are accepted. The skill detects t
 | SARIF 2.1.0 | `trustabl scan --format sarif` |
 | Plain text | paste terminal output directly |
 
+> When you run `trustabl scan` yourself (e.g. to produce input, or to re-verify at the end), resolve the binary the way the **trustabl-scan** skill does: prefer `"$TRUSTABL_BIN"`, then the plugin-managed path reported by the Trustabl `SessionStart` check this session, then `trustabl` on `PATH`.
+
 If the input cannot be parsed or contains zero findings, report clearly and stop — do not proceed to enrichment.
 
 **SARIF extraction path:**

--- a/skills/trustabl-scan/SKILL.md
+++ b/skills/trustabl-scan/SKILL.md
@@ -7,7 +7,8 @@ description: >-
   committing. Triggers on adding or editing an agent definition, a tool /
   @function_tool / @tool / tool() handler, a subagent markdown file, an MCP
   server registration, agent guardrails, or .claude/settings.json permissions.
-  Runs the local `trustabl scan` CLI and guides remediation of the findings.
+  Runs Trustabl's `scan` tool via the plugin's bundled MCP server and guides
+  remediation of the findings.
 ---
 
 # Self-audit agent code with Trustabl
@@ -44,66 +45,44 @@ or agents are extracted from them.
 
 ## How to run the scan
 
-> **Which `trustabl` to run.** This plugin auto-installs a pinned CLI build at
-> session start. Resolve the binary in this order and use the first that works:
-> (1) `"$TRUSTABL_BIN"` when that environment variable is set; (2) the
-> plugin-managed path the Trustabl `SessionStart` check reported this session
-> (under the plugin data dir); (3) `trustabl` on `PATH`. In the commands below,
-> `trustabl` stands for that resolved binary — e.g. run `"$TRUSTABL_BIN" scan .`
-> when `$TRUSTABL_BIN` is set.
+Scanning runs through this plugin's **bundled MCP server** (`trustabl`), which
+exposes a `scan` tool. Call the tool **`mcp__trustabl__scan`** with the path to
+the repo you just edited:
 
-From the repo you just edited (or pass its path), run:
+- `mcp__trustabl__scan` with `{"path": "."}` — scan the current repo.
+- Optionally `{"path": ".", "rules_ref": "<branch-or-tag>"}` to pin the
+  detection-rules ref.
 
-```bash
-trustabl scan .
-```
+The tool returns the full scan result as JSON — the same `ScanResult` shape as
+the CLI's `--format json` output, with a `findings` array to reason over. There
+is no exit code: decide what is actionable by reading finding **severities**
+(`medium` and above are commit-blockers; see "How to read findings"). The server
+fetches and caches the `trustabl-rules` pack itself, falling back to its local
+cache when offline.
 
-That prints a human-readable summary to stdout and live progress to stderr. The
-process exit code is the gate:
-
-- `0` no findings of medium severity or higher (clean enough to commit).
-- `1` at least one finding of medium severity or higher (fix before committing).
-- `2` scanner or I/O error, or no usable rules available.
-
-Useful flags (all verified against `trustabl scan --help`):
+**CLI fallback.** If the `mcp__trustabl__scan` tool is not available this session
+(for example the MCP server failed to start), run the CLI directly with the
+resolved binary — `"$TRUSTABL_BIN"` when that variable is set, else `trustabl`
+on `PATH`:
 
 ```bash
-# Machine-readable output to reason over programmatically
-trustabl scan . --format json
-trustabl scan . --format sarif > trustabl.sarif
-
-# Tighten the gate: exit 1 on any finding of low severity or higher.
-# info / META signals never fail the build, even under --strict.
-trustabl scan . --strict
-
-# Narrow to the SDK you just touched (faster, focused):
-#   claude_sdk | openai_sdk | google_adk | openshell
-trustabl scan . --detectors claude_sdk
-
-# Disable progress animation / color (useful in captured logs)
-trustabl scan . --no-progress --no-color
+"$TRUSTABL_BIN" scan . --format json          # JSON, same shape the tool returns
+"$TRUSTABL_BIN" scan . --strict               # exit 1 on low+ findings (info/META never fail)
+"$TRUSTABL_BIN" scan . --detectors claude_sdk # narrow to one SDK: claude_sdk|openai_sdk|google_adk|openshell
 ```
 
-When you want findings you can parse and act on precisely, prefer
-`--format json` and read the `findings` array; the human format is for the
-developer reading along.
-
-Rules are not bundled in the binary. They are fetched from the public
-`trustabl-rules` repo on first scan and cached locally, then refreshed on later
-scans (falling back to the cache when offline). If a scan exits `2` saying no
-usable rules were found, pre-populate the cache once:
-
-```bash
-trustabl rules pull
-```
+In the CLI fallback the exit code is the gate: `0` = no findings of medium
+severity or higher, `1` = at least one, `2` = scanner/I-O error or no usable
+rules (run `"$TRUSTABL_BIN" rules pull` once to pre-populate the rules cache).
 
 ## How to read findings
 
 Each finding carries:
 
 - **severity** (`info` / `low` / `medium` / `high` / `critical`) how bad it is.
-  Only `medium` and above drive the non-zero exit code (and `low` only under
-  `--strict`).
+  Treat `medium` and above as commit-blockers; `info` / `META` never block. (In
+  the CLI fallback these map to the exit code: `medium`+ → exit 1, or `low`+
+  under `--strict`.)
 - **confidence** a heuristic score for how sure the rule is. It is not
   LLM-judged and not yet calibrated, so treat findings as signal to investigate,
   not ground truth. Look at higher-confidence findings first.
@@ -128,31 +107,33 @@ whole.
 
 ## Remediation loop
 
-1. Run `trustabl scan .` (add `--format json` when you want to act on findings
-   precisely).
+1. Call `mcp__trustabl__scan` with `{"path": "."}` and read the `findings` array.
 2. For each finding of `medium` or higher, read its `explanation` and
    `suggested_fix` and apply the fix to the code (Trustabl will not edit files
    for you).
-3. Re-run the same scan and confirm the finding is gone and the exit code
-   dropped to `0`.
-4. Repeat until the scan is clean (or only `info` / `META` signals remain). For
-   a stricter bar before committing, gate on `trustabl scan . --strict`.
+3. Call the scan tool again and confirm the finding is gone from `findings`.
+4. Repeat until only `info` / `META` signals remain. For a stricter bar before
+   committing, treat `low` findings as blockers too (or use the CLI fallback's
+   `--strict`).
 
 ## Installing the binary
 
-Normally you do not need to. At session start this plugin runs
-`scripts/check-trustabl.sh`, which downloads the pinned CLI version, verifies it
-against the release `checksums.txt`, installs it into the plugin's private data
-directory, and exposes it as `$TRUSTABL_BIN` (see "Which `trustabl` to run"
-above). This installs only into the plugin's own data dir — it never touches the
-user's system or their own `trustabl`, and is reversible.
+Normally you do not need to. The plugin installs the pinned CLI itself: the
+bundled MCP launcher (`scripts/trustabl-mcp.sh`) and the `SessionStart` hook
+(`scripts/check-trustabl.sh`) share install logic (`scripts/lib-trustabl.sh`)
+that downloads the pinned version, verifies it against the release
+`checksums.txt`, and installs it into the plugin's private data directory. That
+one binary both backs the `mcp__trustabl__scan` server and is exposed as
+`$TRUSTABL_BIN` for direct CLI use. It installs only into the plugin's own data
+dir — never the user's system or their own `trustabl` — and is reversible.
 
 Auto-install is skipped only when it cannot run: offline on the very first
 session, an unsupported platform (e.g. native Windows without bash), or missing
-`curl` / `tar`. The check then falls back to whatever `trustabl` is on `PATH` and
-prints a hint. If you see a `[trustabl] CLI not found …` notice — or no binary
-resolves at all — offer to install it system-wide, **asking the user before you
-run any install command; never install silently**:
+`curl` / `tar`. It then falls back to whatever `trustabl` is on `PATH`. If you
+see a `[trustabl] could not provide the trustabl CLI …` notice, or the
+`mcp__trustabl__scan` tool is missing and no binary resolves, offer to install it
+system-wide, **asking the user before you run any install command; never install
+silently**:
 
 ```bash
 # macOS / Linux (Homebrew)

--- a/skills/trustabl-scan/SKILL.md
+++ b/skills/trustabl-scan/SKILL.md
@@ -44,6 +44,14 @@ or agents are extracted from them.
 
 ## How to run the scan
 
+> **Which `trustabl` to run.** This plugin auto-installs a pinned CLI build at
+> session start. Resolve the binary in this order and use the first that works:
+> (1) `"$TRUSTABL_BIN"` when that environment variable is set; (2) the
+> plugin-managed path the Trustabl `SessionStart` check reported this session
+> (under the plugin data dir); (3) `trustabl` on `PATH`. In the commands below,
+> `trustabl` stands for that resolved binary — e.g. run `"$TRUSTABL_BIN" scan .`
+> when `$TRUSTABL_BIN` is set.
+
 From the repo you just edited (or pass its path), run:
 
 ```bash
@@ -132,12 +140,19 @@ whole.
 
 ## Installing the binary
 
-This plugin runs a non-destructive `SessionStart` check
-(`scripts/check-trustabl.sh`) that reports, into the session, when `trustabl` is
-missing from `PATH` or older than the minimum the skills need. When you see a
-`[trustabl] CLI not found …` or `… older than the minimum …` notice — or a scan
-fails because `trustabl` isn't found — install it (from the project README),
-**asking the user before you run any install command; never install silently**:
+Normally you do not need to. At session start this plugin runs
+`scripts/check-trustabl.sh`, which downloads the pinned CLI version, verifies it
+against the release `checksums.txt`, installs it into the plugin's private data
+directory, and exposes it as `$TRUSTABL_BIN` (see "Which `trustabl` to run"
+above). This installs only into the plugin's own data dir — it never touches the
+user's system or their own `trustabl`, and is reversible.
+
+Auto-install is skipped only when it cannot run: offline on the very first
+session, an unsupported platform (e.g. native Windows without bash), or missing
+`curl` / `tar`. The check then falls back to whatever `trustabl` is on `PATH` and
+prints a hint. If you see a `[trustabl] CLI not found …` notice — or no binary
+resolves at all — offer to install it system-wide, **asking the user before you
+run any install command; never install silently**:
 
 ```bash
 # macOS / Linux (Homebrew)

--- a/skills/trustabl-scan/SKILL.md
+++ b/skills/trustabl-scan/SKILL.md
@@ -132,7 +132,12 @@ whole.
 
 ## Installing the binary
 
-If `trustabl` is not on `PATH`, install it (from the project README):
+This plugin runs a non-destructive `SessionStart` check
+(`scripts/check-trustabl.sh`) that reports, into the session, when `trustabl` is
+missing from `PATH` or older than the minimum the skills need. When you see a
+`[trustabl] CLI not found …` or `… older than the minimum …` notice — or a scan
+fails because `trustabl` isn't found — install it (from the project README),
+**asking the user before you run any install command; never install silently**:
 
 ```bash
 # macOS / Linux (Homebrew)


### PR DESCRIPTION
## What

Makes the Trustabl Claude Code plugin **(1) ensure the right `trustabl` binary is present on its own** and **(2) run scans through a bundled MCP server** instead of shelling out to the CLI.

## Why

The plugin assumed the binary was already installed and on `PATH`, with no signal until a scan failed, and there is real version drift (the Homebrew formula lags the latest release). Routing scans through an MCP server exposes scanning as a native tool to the client.

## How

**Binary bootstrap (TR-195)**
- `hooks/hooks.json` registers a `SessionStart` hook.
- Shared install logic in `scripts/lib-trustabl.sh` downloads the pinned version (`0.1.3`) from GitHub Releases into `${CLAUDE_PLUGIN_DATA}/bin/`, **verifies it against `checksums.txt`**, installs atomically, and is idempotent (re-runs only on pin change / missing / corrupt). No `sudo`, nothing outside that dir touched, reversible. The hook exposes the binary as `$TRUSTABL_BIN` (for the enrich skill's direct-CLI path) and prints status.

**Scan via a bundled MCP server (TR-196)**
- `.mcp.json` registers a `trustabl` stdio MCP server (auto-discovered) whose `command` is a bundled launcher, `scripts/trustabl-mcp.sh`.
- The launcher ensures the pinned binary (shared lib), then `exec`s `trustabl mcp`. Because the launcher is bundled (always exists) and installs **synchronously before** starting the server, there's no "command not found" (which Claude Code would not retry) and no race with the SessionStart hook (whose ordering vs MCP launch is not guaranteed). All install diagnostics go to **stderr** so the JSON-RPC **stdout** stream stays clean.
- `skills/trustabl-scan/SKILL.md` rewritten to call **`mcp__trustabl__scan`** with `{"path":"."}` and reason over the returned `ScanResult` JSON, with a CLI fallback (`$TRUSTABL_BIN scan . --format json`, then `trustabl` on `PATH`).
- `README.md` and the `plugin.json` description updated. `skills/trustabl-enrich/SKILL.md` intentionally unchanged (enrich deferred; still CLI-based via `$TRUSTABL_BIN`).

## Verification (macOS/arm64)

- `claude plugin validate .` passes (only the pre-existing `author` warning).
- Binary install: cold (fetched + checksum-verified `0.1.3`), warm fast-path, idempotent env-file write, no-data-dir fallback (flags on-`PATH` `0.1.2` as older than the pin), tamper recovery (corrupt binary reinstalled).
- MCP end-to-end (driving the launcher over stdio): `initialize` → `serverInfo trustabl 0.1.3`; `tools/list` → `scan` + `version`; a real `tools/call` scan → `isError:false` with a genuine `ScanResult` (`findings`, `scan_id`, `rules_version`, `severity`).
- No Go code changed.

## Notes / tradeoffs

- **The MCP `scan` tool is JSON-only** — `--strict` / `--detectors` / `--format sarif` aren't exposed through it; the skill applies the medium+ bar over JSON, and the CLI fallback retains those flags.
- **Native Windows (no bash)**: the `.sh` launcher/hook won't run; the skill falls back to the CLI/install hint.
- `RECOMMENDED_VERSION` (the binary pin) is independent of the plugin `version` — no forced lockstep.
- Live plugin-load wiring (that 2.0.54 surfaces the tool as exactly `mcp__trustabl__scan` in a session) was confirmed structurally via `claude plugin validate`; the MCP server itself is proven end-to-end.

Refs: TR-195, TR-196
