### PR TITLE
chore(rules-fixture): mirror rule recalibration + refresh CLAUDE.md status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -330,12 +330,12 @@ When changing a rule (add / remove / edit severity, confidence, match, text):
 6. Commit and push the rules repo **and** the rulebook (the user pushes engine
    commits manually; confirm before pushing any of the three).
 
-> **Rulebook status (2026-06-04):** the rulebook documents all shipped rules —
-> production ships **117** rules (the 102-rule pack plus the 15 LangChain LC-*
-> rules) across the four SDK categories plus `langchain`, and the rulebook carries
-> a rationale doc for every one (52 docs). `check_rulebook.py --strict` and
-> `gen_index.py --check` both pass against the live pack with zero warnings. The
-> earlier MCP-doc backfill gap is closed.
+> **Rulebook status (2026-06-06):** production ships **165** rules across nine
+> SDK categories (`autogen`, `claude_sdk`, `crewai`, `google_adk`, `langchain`,
+> `mcp`, `openai_sdk`, `pydantic_ai`, `vercel_ai`). The rulebook carries a
+> rationale doc for every shipped rule except the newly-added VAI-011 (82 docs);
+> `check_rulebook.py` flags that single gap until the vercel network rationale
+> doc lands.
 
 The rule-authoring contract (required fields, ID conventions, per-scope
 `applies_to` values, framing discipline) lives in

--- a/testdata/rules-fixture/autogen/agent_safety.yaml
+++ b/testdata/rules-fixture/autogen/agent_safety.yaml
@@ -69,9 +69,9 @@ rules:
       the AutoGen executor.
 
   - id: AG2-004
-    title: AutoGen GroupChatManager has no max_round bound
-    severity: medium
-    confidence: 0.8
+    title: AutoGen GroupChatManager has no explicit max_round bound
+    severity: low
+    confidence: 0.6
     language: python
     applies_to:
       - autogen_group_chat_manager
@@ -80,13 +80,14 @@ rules:
       agent_kwarg_missing:
         - max_round
     explanation: >
-      This group chat does not set max_round, so the speaker-selection loop has no
-      upper bound on the number of turns. A degenerate conversation — two agents that
-      keep handing work back and forth, or a model that never emits the termination
-      signal — runs until something else stops it, burning token budget the whole
-      time. When the participating agents wield side-effecting tools (file writes,
-      shell, network), an unbounded loop is not just a cost incident but a
-      correctness one: the same mutation can be applied many times over.
+      This group chat does not set max_round explicitly, so the speaker-selection
+      loop falls back to AutoGen's built-in max_round default rather than running
+      unbounded. That default bounds the loop, but generically — not at a value
+      sized to this workflow: a degenerate conversation (two agents handing work
+      back and forth, or a model that never emits the termination signal) still
+      runs to the default ceiling, burning token budget, and when the participating
+      agents wield side-effecting tools (file writes, shell, network) the same
+      mutation can be applied repeatedly up to that bound.
     fix: >
       Pass max_round= to GroupChat / GroupChatManager with a concrete cap sized to
       the workflow (often 10–25). Pair it with a clear termination condition so the
@@ -118,7 +119,7 @@ rules:
       human_input_mode) on that proxy rather than on the assistant.
 
   - id: AG2-006
-    title: AutoGen executor with code execution has no auto-reply cap
+    title: AutoGen executor with code execution has no explicit auto-reply cap
     severity: medium
     confidence: 0.7
     language: python
@@ -134,11 +135,11 @@ rules:
             - max_consecutive_auto_reply
     explanation: >
       This executor enables code execution (code_execution_config is set) but does
-      not set max_consecutive_auto_reply, so there is no cap on how many times it will
-      auto-respond — and therefore auto-execute model-emitted code — in a single
-      exchange. An agent that keeps replying without limit can run generated code an
-      unbounded number of times, amplifying both the cost and the blast radius of a
-      single injected instruction.
+      not set max_consecutive_auto_reply, so it falls back to AutoGen's class
+      default of 100 (MAX_CONSECUTIVE_AUTO_REPLY). That is a cap, but a very loose
+      one for an agent that auto-executes model-emitted code: up to 100 consecutive
+      auto-replies — each able to run generated code — in a single exchange amplify
+      both the cost and the blast radius of a single injected instruction.
     fix: >
       Set max_consecutive_auto_reply= to a small integer on any code-executing agent
       so the auto-reply loop is bounded, and combine it with human_input_mode and

--- a/testdata/rules-fixture/autogen/network.yaml
+++ b/testdata/rules-fixture/autogen/network.yaml
@@ -10,8 +10,8 @@ policy:
 rules:
   - id: AG2-012
     title: AutoGen tool network call has no timeout
-    severity: medium
-    confidence: 0.8
+    severity: high
+    confidence: 0.85
     language: python
     applies_to:
       - autogen_tool

--- a/testdata/rules-fixture/claude_sdk/agent_safety.yaml
+++ b/testdata/rules-fixture/claude_sdk/agent_safety.yaml
@@ -37,7 +37,7 @@ rules:
 
   - id: CSDK-102
     title: Claude subagent is granted the WebSearch tool
-    severity: high
+    severity: medium
     confidence: 0.8
     language: python
     applies_to:

--- a/testdata/rules-fixture/claude_sdk/error_handling.yaml
+++ b/testdata/rules-fixture/claude_sdk/error_handling.yaml
@@ -10,7 +10,7 @@ policy:
 rules:
   - id: CSDK-005
     title: Tool raises exceptions without a structured error contract
-    severity: medium
+    severity: low
     confidence: 0.6
     language: python
     applies_to:

--- a/testdata/rules-fixture/claude_sdk/idempotency.yaml
+++ b/testdata/rules-fixture/claude_sdk/idempotency.yaml
@@ -35,11 +35,14 @@ rules:
                 - request_id
                 - txn_id
     explanation: >
-      Tool name suggests a side effect (create/send/refund/…). Agents retry
-      tool calls under timeouts and ambiguous failures; without an
-      idempotency key the same action can fire twice. The hook generator can
-      stamp a key into the request, but the downstream service has to honor
-      it.
+      Tool name suggests a side effect (create/send/refund/…). A mutating tool
+      with no idempotency key cannot tell a new request from a retry of one whose
+      result was lost, and retries happen for reasons outside the tool — the model
+      re-invokes it when a result reads as inconclusive, an orchestrator or your
+      own retry policy re-issues after a timeout, or a response is lost after the
+      side effect already committed (at-least-once delivery). Without a key the
+      same action can fire twice. The hook generator can stamp a key into the
+      request, but the downstream service has to honor it.
     fix: >
       Add an `idempotency_key: str` parameter; verify the receiving API
       respects it.
@@ -74,11 +77,14 @@ rules:
                 - txn_id
     explanation: >
       This TypeScript tool's name implies a side effect (create/send/refund/…)
-      but its Zod schema exposes no idempotency parameter. Agents re-issue tool
-      calls after timeouts and ambiguous failures, so the same charge, send, or
-      delete can fire twice. Without a key the model and the SDK cannot make the
-      retry safe. The prefix set matches both `create_charge` and `createCharge`
-      naming, so it fires on idiomatic TypeScript tool names.
+      but its Zod schema exposes no idempotency parameter. Retries happen for
+      reasons outside the tool — the model re-invokes it when a result reads as
+      inconclusive, an orchestrator or your own retry policy re-issues after a
+      timeout, or a response is lost after the side effect already committed
+      (at-least-once delivery) — so the same charge, send, or delete can fire
+      twice. Without a key the model and the SDK cannot make the retry safe. The
+      prefix set matches both `create_charge` and `createCharge` naming, so it
+      fires on idiomatic TypeScript tool names.
     fix: >
       Add an `idempotencyKey` (or `requestId`) field to the tool's Zod schema,
       thread it to the downstream API, and confirm that API treats a repeated

--- a/testdata/rules-fixture/claude_sdk/path_safety.yaml
+++ b/testdata/rules-fixture/claude_sdk/path_safety.yaml
@@ -40,7 +40,7 @@ rules:
 
   - id: CSDK-012
     title: TypeScript Claude SDK tool writes to the filesystem
-    severity: medium
+    severity: low
     confidence: 0.5
     language: typescript
     applies_to:

--- a/testdata/rules-fixture/crewai/idempotency.yaml
+++ b/testdata/rules-fixture/crewai/idempotency.yaml
@@ -4,8 +4,9 @@ policy:
   category: crewai
   description: >
     Rules that flag mutating tools (create/send/refund/...) without an
-    idempotency key. CrewAI retries tool calls under timeouts and ambiguous
-    failures; without a key the same side-effecting action can fire twice.
+    idempotency key. Retries (model re-invocation, an orchestrator or your own
+    retry policy, or a lost response) can re-run a side-effecting call; without a
+    key the same action can fire twice.
 
 rules:
   - id: CREW-006
@@ -35,9 +36,13 @@ rules:
                 - request_id
                 - txn_id
     explanation: >
-      Tool name suggests a side effect (create/send/refund/…). CrewAI retries tool
-      calls under timeouts and ambiguous failures; without an idempotency key the
-      same action can fire twice — a duplicate charge, a double-sent message, a
+      Tool name suggests a side effect (create/send/refund/…). A mutating tool
+      with no idempotency key cannot tell a new request from a retry of one whose
+      result was lost, and retries happen for reasons outside the tool — the model
+      re-invokes it when a result reads as inconclusive, an orchestrator or your
+      own retry policy re-issues after a timeout, or a response is lost after the
+      side effect already committed (at-least-once delivery). Without a key the
+      same action fires twice — a duplicate charge, a double-sent message, a
       repeated delete. Downstream services must also honor the key for this
       protection to be effective.
     fix: >

--- a/testdata/rules-fixture/google_adk/error_handling.yaml
+++ b/testdata/rules-fixture/google_adk/error_handling.yaml
@@ -10,7 +10,7 @@ policy:
 rules:
   - id: ADK-005
     title: Tool raises exceptions without a structured error contract
-    severity: medium
+    severity: low
     confidence: 0.6
     language: python
     applies_to:

--- a/testdata/rules-fixture/google_adk/idempotency.yaml
+++ b/testdata/rules-fixture/google_adk/idempotency.yaml
@@ -4,8 +4,9 @@ policy:
   category: google_adk
   description: >
     Rules that flag mutating tools (create/send/refund/...) without an
-    idempotency key. ADK agents retry tool calls under timeouts and ambiguous
-    failures; without a key the same side-effecting action can fire twice.
+    idempotency key. Retries (model re-invocation, an orchestrator or your own
+    retry policy, or a lost response) can re-run a side-effecting call; without a
+    key the same action can fire twice.
 
 rules:
   - id: ADK-006
@@ -35,9 +36,13 @@ rules:
                 - request_id
                 - txn_id
     explanation: >
-      Tool name suggests a side effect (create/send/refund/…). ADK agents
-      retry tool calls under timeouts and ambiguous failures; without an
-      idempotency key the same action can fire twice. Downstream services
-      must also honor the key for this protection to be effective.
+      Tool name suggests a side effect (create/send/refund/…). A mutating tool
+      with no idempotency key cannot tell a new request from a retry of one whose
+      result was lost, and retries happen for reasons outside the tool — the model
+      re-invokes it when a result reads as inconclusive, an orchestrator or your
+      own retry policy re-issues after a timeout, or a response is lost after the
+      side effect already committed (at-least-once delivery). Without a key the
+      same action fires twice. Downstream services must also honor the key for
+      this protection to be effective.
     fix: >
       Add an `idempotency_key: str` parameter and pass it to the backing API.

--- a/testdata/rules-fixture/langchain/agent_safety.yaml
+++ b/testdata/rules-fixture/langchain/agent_safety.yaml
@@ -36,9 +36,9 @@ rules:
       rather than letting the model invoke it unattended.
 
   - id: LC-102
-    title: LangChain AgentExecutor has no max_iterations limit
-    severity: medium
-    confidence: 0.8
+    title: LangChain AgentExecutor has no explicit max_iterations limit
+    severity: low
+    confidence: 0.6
     language: python
     applies_to:
       - langchain_agent_executor
@@ -47,20 +47,22 @@ rules:
       agent_kwarg_missing:
         - max_iterations
     explanation: >
-      This AgentExecutor sets no max_iterations, so a model that never emits a
-      final answer (it loops calling tools, or oscillates between two) runs until
-      it exhausts the API budget or wall-clock — there is no built-in ceiling. A
-      runaway tool-calling loop is a cost incident and, when the tools have side
-      effects, a correctness and safety one.
+      This AgentExecutor sets no explicit max_iterations, so it falls back to
+      LangChain's default of 15 iterations. That default prevents a true runaway,
+      but it is a generic ceiling rather than one sized to this task: a model that
+      loops or oscillates still runs up to 15 tool round-trips — a cost the
+      workflow may not tolerate — and the implicit cap can shift between versions.
+      Relying on the default also means a malformed model step is retried up to the
+      limit instead of surfaced.
     fix: >
       Pass max_iterations= (and optionally max_execution_time=) to AgentExecutor,
       sized to the task. Also set handle_parsing_errors= so a malformed model step
       is surfaced rather than retried indefinitely.
 
   - id: LC-111
-    title: TypeScript LangChain AgentExecutor has no maxIterations limit
-    severity: medium
-    confidence: 0.8
+    title: TypeScript LangChain AgentExecutor has no explicit maxIterations limit
+    severity: low
+    confidence: 0.6
     language: typescript
     applies_to:
       - langchain_agent_executor
@@ -69,11 +71,13 @@ rules:
       agent_kwarg_missing:
         - maxIterations
     explanation: >
-      This AgentExecutor sets no maxIterations, so a model that never returns a
-      final answer (it loops calling tools, or oscillates) runs until it exhausts
-      the API budget or wall-clock — there is no built-in ceiling. A runaway loop
-      is a cost incident and, when the tools have side effects, a correctness and
-      safety one.
+      This AgentExecutor sets no explicit maxIterations, so it falls back to
+      LangChain's built-in default iteration cap rather than running unbounded.
+      That default prevents a true runaway, but it is a generic ceiling rather than
+      one sized to this task: a model that loops or oscillates still runs up to the
+      default number of tool round-trips — a cost the workflow may not tolerate —
+      and relying on it means a malformed model step is retried up to the limit
+      instead of surfaced.
     fix: >
       Pass maxIterations to the AgentExecutor options, sized to the task, and set
       handleParsingErrors so a malformed step is surfaced rather than retried

--- a/testdata/rules-fixture/mcp/error_handling.yaml
+++ b/testdata/rules-fixture/mcp/error_handling.yaml
@@ -10,7 +10,7 @@ policy:
 rules:
   - id: MCP-006
     title: Tool raises exceptions without a structured error contract
-    severity: medium
+    severity: low
     confidence: 0.6
     language: python
     applies_to:

--- a/testdata/rules-fixture/mcp/idempotency.yaml
+++ b/testdata/rules-fixture/mcp/idempotency.yaml
@@ -35,11 +35,13 @@ rules:
                 - request_id
                 - txn_id
     explanation: >
-      The tool name signals a side effect (create/send/refund/…). MCP clients
-      retry tool calls under timeouts and ambiguous failures, and the same
-      model may be driven to repeat an action; without an idempotency key the
-      handler executes the mutation twice — a duplicate charge, order, or
-      message.
+      The tool name signals a side effect (create/send/refund/…). A retry of a
+      call whose result was lost re-runs the mutation: an MCP client or
+      orchestrator may re-issue after a timeout, the model may repeat the action
+      when a result reads as inconclusive, or a response may be lost after the
+      side effect already committed (at-least-once delivery). Without an
+      idempotency key the handler executes the mutation twice — a duplicate
+      charge, order, or message.
     fix: >
       Accept an idempotency key parameter (idempotency_key / request_id) and
       de-duplicate server-side so a retried call is a no-op after the first

--- a/testdata/rules-fixture/openai_sdk/agent_safety.yaml
+++ b/testdata/rules-fixture/openai_sdk/agent_safety.yaml
@@ -139,7 +139,7 @@ rules:
 
   - id: OAI-110
     title: Agent wires a content-fetching tool without output_guardrails
-    severity: high
+    severity: medium
     confidence: 0.6
     language: python
     applies_to:

--- a/testdata/rules-fixture/openai_sdk/decorator_config.yaml
+++ b/testdata/rules-fixture/openai_sdk/decorator_config.yaml
@@ -32,7 +32,7 @@ rules:
 
   - id: OAI-004
     title: Tool has no failure_error_function
-    severity: medium
+    severity: low
     confidence: 0.7
     language: python
     applies_to:

--- a/testdata/rules-fixture/openai_sdk/error_handling.yaml
+++ b/testdata/rules-fixture/openai_sdk/error_handling.yaml
@@ -10,7 +10,7 @@ policy:
 rules:
   - id: OAI-008
     title: Tool raises exceptions without a structured error contract
-    severity: medium
+    severity: low
     confidence: 0.6
     language: python
     applies_to:

--- a/testdata/rules-fixture/openai_sdk/idempotency.yaml
+++ b/testdata/rules-fixture/openai_sdk/idempotency.yaml
@@ -35,10 +35,14 @@ rules:
                 - request_id
                 - txn_id
     explanation: >
-      Tool name suggests a side effect (create/send/refund/…). The OpenAI
-      Agents SDK retries tool calls on timeout and ambiguous failures; without
-      an idempotency key the same action can fire twice. Downstream services
-      must also honor the key for this protection to be effective.
+      Tool name suggests a side effect (create/send/refund/…). A mutating tool
+      with no idempotency key cannot tell a new request from a retry of one whose
+      result was lost. Retries are not automatic in the OpenAI Agents SDK, but
+      they still happen — the model re-invokes a tool when a result reads as
+      inconclusive, an orchestrator or your own retry policy re-issues after a
+      timeout, or a response is lost after the side effect already committed
+      (at-least-once delivery). Without a key the same action fires twice; the
+      downstream service must also honor the key for this to help.
     fix: >
       Add an `idempotency_key: str` parameter and pass it to the backing API.
 
@@ -73,11 +77,13 @@ rules:
     explanation: >
       An OpenAI Agents SDK tool authored in TypeScript whose name implies a
       side effect (create_/send_/delete_/refund_/...) has no idempotency token
-      visible in its body. The SDK retries tool calls on timeouts and
-      ambiguous failures and the model itself will retry whenever a tool
-      result reads as inconclusive; without a key threaded through to the
-      backing API the same action fires twice, producing duplicate tickets,
-      payments, emails, or deletions. Provisional: this rule loads and
+      visible in its body. The SDK does not retry tool calls for you by default,
+      but retries still happen — the model re-invokes the tool whenever a result
+      reads as inconclusive, and an orchestrator, your own retry policy, or a
+      lost response (at-least-once delivery) can re-issue the call; without a key
+      threaded through to the backing API the same action fires twice, producing
+      duplicate tickets, payments, emails, or deletions. Provisional: this rule
+      loads and
       validates today but will not fire until the engine's TypeScript tool
       parser ships.
     fix: >

--- a/testdata/rules-fixture/vercel_ai/agent_safety.yaml
+++ b/testdata/rules-fixture/vercel_ai/agent_safety.yaml
@@ -46,8 +46,8 @@ rules:
       human approval rather than letting the tool loop call it autonomously.
 
   - id: VAI-007
-    title: Vercel AI agent tool loop has no step bound
-    severity: medium
+    title: Vercel AI agent tool loop has no explicit step bound
+    severity: low
     confidence: 0.6
     language: typescript
     applies_to:
@@ -61,12 +61,15 @@ rules:
             - maxSteps
     explanation: >
       This agent runs a multi-step tool loop (generateText / streamText /
-      ToolLoopAgent with a tools record) but sets neither stopWhen nor maxSteps,
-      so the loop's only stopping condition is the model deciding to stop calling
-      tools. A prompt injection or a model that loops on a tool whose output keeps
-      re-triggering it can run the loop unbounded — burning tokens, hammering the
-      wired tools (including any side-effecting or billed ones), and stalling the
-      request. The SDK does not impose a default ceiling.
+      ToolLoopAgent with a tools record) but sets neither stopWhen nor maxSteps.
+      The SDK is not unbounded by default: a bare generateText / streamText call
+      runs a single step and does not continue the tool loop without stopWhen, and
+      the Agent / ToolLoopAgent class defaults to stopWhen: stepCountIs(20). What
+      this flags is the missing explicit bound — the loop either silently does not
+      iterate or inherits a generic 20-step ceiling not sized to this task. A
+      prompt injection, or a tool whose output keeps re-triggering it, can then run
+      up to that default ceiling, burning tokens and hammering the wired tools
+      (including any side-effecting or billed ones) before it stops.
     fix: >
       Set an explicit bound: pass maxSteps (a small integer ceiling on tool
       round-trips) or a stopWhen condition (e.g. stepCountIs(n) or a predicate


### PR DESCRIPTION
## Summary

Mirrors the 21-rule severity/rationale recalibration from `trustabl/trustabl-rules` (companion PR #12) into the engine test fixture so `go test` validates the updated severities and rationale text, and refreshes the stale rulebook-status note in `CLAUDE.md`.

**No `match:` logic changed — `go test ./...` passes.**

## CI note — `rules-sync` red on pre-existing v9 drift

`rules-sync` compares the fixture to the rules pack. The fixture is the current schema-8 state; rules `main` (and the matching `fix/rule-recalibration` branch) carry the in-flight **schema_version 9** network work (VAI-011, OAI-016 `has_http_call_without_timeout`, manifest bump) that has not been landed in the engine. So the gate flags those network files as drift — **pre-existing, unrelated to this recalibration.** It clears when the v9 sync lands (engine predicate + `SupportedSchemaVersion` bump + fixture mirror of the network rules).

> ⚠️ Separately and more urgently: rules `main` is at `schema_version: 9` while the released engine (v0.1.2) is at `8`, and the default scan path pulls `main` — so default `trustabl scan` / the GitHub Action are **currently failing** with "rules are newer than this version." Independent of this PR; worth prioritizing.

Companion PRs: `trustabl/trustabl-rules#12`, `trustabl/trustabl-rulebook#9`.
