### PR TITLE
feat(rules): skip unknown scope/applies_to leniently + META-005 finding

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -157,10 +157,15 @@ only when its manifest is missing / unparseable / non-positive
 eagerly without scanning.
 
 **Lenient rule loading (forward compatibility).** The deployed scanner loads the
-pack via `rules.LoadLenient`: a rule whose `match` references a predicate this
-build does not understand (a rule from a newer schema) is **dropped whole** —
-its ID collected into `ScanResult.RulesSkipped` and surfaced as a stderr
-warning — and the scan proceeds with the rules it understands. Likewise, a pack
+pack via `rules.LoadLenient`: a rule that references a `scope`, an `applies_to`
+value, or a `match` predicate this build does not understand (a rule from a newer
+schema — e.g. a future `skill`-scoped rule on a binary that predates skill
+support) is **dropped whole** — its ID collected into `ScanResult.RulesSkipped`,
+surfaced as a stderr warning, and summarized in a single deterministic
+`META-005` info finding in the report — and the scan proceeds with the rules it
+understands. The unknown-value check (`rules.ruleNeedsNewerEngine`) is narrow: an
+*empty* scope/applies_to is a missing required field, not a newer-engine signal,
+so it still hard-fails. Likewise, a pack
 whose `category` this build does not recognize — an SDK a *newer* rules release
 added — is **skipped as a whole file** (its rule IDs collected into
 `RulesSkipped` the same way) rather than hard-failing the entire load and taking
@@ -170,8 +175,10 @@ authoring. The whole rule is
 dropped, not partially decoded, because a silently-omitted predicate would
 collapse the rule's `match` to vacuous-true (firing on every entity). Authoring
 and CI use the **strict** `rules.Load` (`KnownFields(true)`), so typos and bad
-rules are still caught against the in-repo fixture; only the runtime path
-degrades. The engine exits `2` only when *no* rule is usable: a genuinely empty
+rules — including a malformed *known* rule (missing required field, out-of-range
+confidence, duplicate ID) — are still caught against the in-repo fixture; the
+runtime path degrades only for genuinely-newer rules, never for real authoring
+errors, which it still hard-fails in both modes. The engine exits `2` only when *no* rule is usable: a genuinely empty
 pack (`ErrNoRulesInPack`) or one whose every rule is forward-incompatible
 (`ErrAllRulesIncompatible`, which hints "upgrade Trustabl"). This decouples
 additive rule updates from binary upgrades — see the `SupportedSchemaVersion`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,8 +98,12 @@ resolution path fetches the configured ref, caches the clone under
 the network is unreachable. Rule loading is **forward-compatible**: a pack
 whose `manifest.yaml` `schema_version` exceeds the engine's
 `rules.SupportedSchemaVersion` is loaded leniently rather than refused — a rule
-referencing a predicate this build lacks is skipped (recorded on
-`ScanResult.RulesSkipped` and warned on stderr) and the scan runs the rest. A
+referencing a `scope`, an `applies_to` value, or a predicate this build lacks is
+skipped (recorded on `ScanResult.RulesSkipped`, warned on stderr, and summarized
+in a `META-005` info finding) and the scan runs the rest. A malformed *known*
+rule — empty/missing required field, out-of-range confidence, duplicate ID — is
+**not** forward-incompatible and still hard-fails, in both strict and lenient
+loading. A
 hard exit 2 happens only when *nothing* is usable: no pack cached or fetchable
 (`ErrNoRules`), an unreadable manifest (`ErrNoCompatibleRules`), a genuinely
 empty pack (`ErrNoRulesInPack`), or one whose every rule is forward-incompatible

--- a/README.md
+++ b/README.md
@@ -542,6 +542,16 @@ on stderr (and recording the skipped rule IDs on `ScanResult.RulesSkipped`):
 warning: the rules target schema version 9 but this Trustabl build supports up to 8; 2 rule(s) newer than this build were skipped. Upgrade Trustabl to evaluate them.
 ```
 
+The same per-rule skip happens for any *individual* rule that references a
+`scope`, an `applies_to` value, or a predicate your build does not understand —
+that rule is dropped while its siblings still run, so a newer rules release never
+forces a lockstep binary upgrade. Every skip is also surfaced **in the report
+itself** as a single `META-005` info finding ("N rules require a newer Trustabl
+engine"), so a degraded scan is never mistaken for a clean one. A *malformed*
+rule your build does understand (a missing field, a bad value) is **not**
+forward-skipped — it still hard-fails the load, so real authoring errors are
+never silently dropped.
+
 To evaluate the skipped rules, **upgrade Trustabl** to a build whose
 `SupportedSchemaVersion` (see `internal/rules/schema_version.go`) covers the
 pack. No action is needed if you're comfortable running the subset.

--- a/cmd/trustabl/scan.go
+++ b/cmd/trustabl/scan.go
@@ -293,7 +293,7 @@ func finishScan(result models.ScanResult, jobErr error, f scanFlags) error {
 				result.RulesSchemaVersion, rules.SupportedSchemaVersion, len(result.RulesSkipped))
 		} else {
 			fmt.Fprintf(os.Stderr,
-				"warning: %d rule(s) were skipped because they use predicates this Trustabl build does not understand.\n",
+				"warning: %d rule(s) were skipped because they use a scope, applies_to value, or predicate this Trustabl build does not understand.\n",
 				len(result.RulesSkipped))
 		}
 		const maxShownRules = 10

--- a/internal/rules/loader.go
+++ b/internal/rules/loader.go
@@ -30,12 +30,15 @@ func Load(fsys fs.FS) ([]PolicyFile, error) {
 
 // LoadLenient is the forward-compatible runtime path. It behaves like Load but
 // tolerates a rules pack from a NEWER schema than this build: a rule whose
-// match references a predicate key this engine does not understand is dropped
-// whole (its ID collected into the returned skipped slice) instead of failing
-// the entire pack. This lets a deployed binary degrade gracefully against an
-// updated rules repo — scanning with the rules it understands — rather than
-// refusing to run. All other validation stays strict, so a genuine defect in a
-// rule this build CAN evaluate still fails the load.
+// scope, applies_to value, or match predicate this engine does not understand
+// is dropped whole (its ID collected into the returned skipped slice) instead
+// of failing the entire pack. This lets a deployed binary degrade gracefully
+// against an updated rules repo — scanning with the rules it understands —
+// rather than refusing to run. All other validation stays strict, so a genuine
+// defect in a rule this build CAN evaluate (a missing required field, an
+// out-of-range confidence, a duplicate ID, a degenerate match) still fails the
+// load. Forward-incompatibility is narrow by design: an EMPTY scope/applies_to
+// is a missing required field, not a newer-engine signal, so it still hard-fails.
 func LoadLenient(fsys fs.FS) ([]PolicyFile, []string, error) {
 	return loadPolicies(fsys, true)
 }
@@ -383,14 +386,14 @@ func decodePolicyFile(fsys fs.FS, name string) (PolicyFile, error) {
 
 // decodePolicyFileLenient decodes one YAML policy file in forward-compatible
 // mode. It parses to a yaml.Node (malformed YAML is still a hard error),
-// identifies rules whose match references a predicate key not in `known` (a
-// newer rule schema this build cannot evaluate), decodes the file leniently
-// (unknown keys ignored — additive forward-compat for non-match fields too),
-// and drops the forward-incompatible rules wholesale. Returns the dropped rule
-// IDs. Dropping the WHOLE rule is essential: a lenient struct decode silently
-// omits the unknown predicate, which would collapse the rule's match to
-// vacuous-true (firing on every entity) — so the rule must be removed, not
-// half-decoded.
+// identifies rules that reference a scope, applies_to value, or match predicate
+// this build does not understand (a newer rule schema this build cannot
+// evaluate — see ruleNeedsNewerEngine), decodes the file leniently (unknown keys
+// ignored — additive forward-compat for non-match fields too), and drops the
+// forward-incompatible rules wholesale. Returns the dropped rule IDs. Dropping
+// the WHOLE rule is essential: a lenient struct decode silently omits the
+// unknown predicate, which would collapse the rule's match to vacuous-true
+// (firing on every entity) — so the rule must be removed, not half-decoded.
 func decodePolicyFileLenient(fsys fs.FS, name string, known map[string]bool) (PolicyFile, []string, error) {
 	var pf PolicyFile
 	if err := checkRuleFileSize(fsys, name); err != nil {
@@ -415,8 +418,10 @@ func decodePolicyFileLenient(fsys fs.FS, name string, known map[string]bool) (Po
 }
 
 // forwardIncompatibleRules returns the indices (into the rules sequence, which
-// align 1:1 with pf.Rules after a lenient decode) and IDs of rules whose match
-// tree references a key outside `known`. fileName labels rules missing an id.
+// align 1:1 with pf.Rules after a lenient decode) and IDs of rules that
+// reference a scope, applies_to value, or match predicate outside this build's
+// vocabulary — i.e. rules authored against a newer engine (see
+// ruleNeedsNewerEngine). fileName labels rules missing an id.
 func forwardIncompatibleRules(root *yaml.Node, known map[string]bool, fileName string) ([]int, []string) {
 	doc := root
 	if doc.Kind == yaml.DocumentNode && len(doc.Content) > 0 {
@@ -431,11 +436,7 @@ func forwardIncompatibleRules(root *yaml.Node, known map[string]bool, fileName s
 		ids []string
 	)
 	for i, ruleNode := range rulesNode.Content {
-		matchNode := mappingValue(ruleNode, "match")
-		if matchNode == nil || matchNode.Kind != yaml.MappingNode {
-			continue
-		}
-		if !matchHasUnknownKey(matchNode, known, 0) {
+		if !ruleNeedsNewerEngine(ruleNode, known) {
 			continue
 		}
 		idx = append(idx, i)
@@ -449,6 +450,46 @@ func forwardIncompatibleRules(root *yaml.Node, known map[string]bool, fileName s
 		ids = append(ids, id)
 	}
 	return idx, ids
+}
+
+// ruleNeedsNewerEngine reports whether a rule node references a scope,
+// applies_to value, or match predicate this build does not understand — the
+// signal that the rule was authored against a newer engine and so must be
+// skipped (not evaluated) by the lenient runtime loader. The three checks mirror
+// the strict validation in loadPolicies, but here an unknown value means "skip"
+// instead of "fail".
+//
+// Crucially, an EMPTY scope or applies_to is NOT forward-incompatible: it is a
+// missing required field — a real authoring defect — which the strict validation
+// loop must still hard-fail in BOTH modes (this is what the ticket means by "not
+// a license to silently drop real authoring errors"). So each check fires only
+// on a NON-empty, unrecognized value, never on absence.
+func ruleNeedsNewerEngine(ruleNode *yaml.Node, known map[string]bool) bool {
+	// Unknown scope: a scope kind (e.g. a future `skill`) this build lacks. An
+	// unknown scope also makes applies_to unvalidatable (validAppliesToForScope
+	// keys off the scope), so it is checked first and short-circuits.
+	scope := models.Scope(scalarValue(ruleNode, "scope"))
+	if scope != "" && !models.ValidScope(scope) {
+		return true
+	}
+	// Unknown applies_to value for an otherwise-known scope: a tool/agent kind a
+	// newer engine added. Only meaningful once the scope is known (above).
+	if scope != "" {
+		for _, kind := range sequenceValues(ruleNode, "applies_to") {
+			if !validAppliesToForScope(scope, kind) {
+				return true
+			}
+		}
+	}
+	// Unknown predicate key anywhere in the match tree: a predicate from a newer
+	// schema. A known predicate's nested struct keys are NOT match-level keys, so
+	// matchHasUnknownKey does not descend into them (see its doc).
+	if matchNode := mappingValue(ruleNode, "match"); matchNode != nil && matchNode.Kind == yaml.MappingNode {
+		if matchHasUnknownKey(matchNode, known, 0) {
+			return true
+		}
+	}
+	return false
 }
 
 // matchHasUnknownKey reports whether a match mapping (recursing through the
@@ -498,6 +539,28 @@ func mappingValue(m *yaml.Node, key string) *yaml.Node {
 		}
 	}
 	return nil
+}
+
+// scalarValue returns the scalar string at key in a YAML mapping node, or "".
+func scalarValue(m *yaml.Node, key string) string {
+	if v := mappingValue(m, key); v != nil {
+		return v.Value
+	}
+	return ""
+}
+
+// sequenceValues returns the scalar values of the sequence at key in a YAML
+// mapping node, or nil if the key is absent or not a sequence.
+func sequenceValues(m *yaml.Node, key string) []string {
+	v := mappingValue(m, key)
+	if v == nil || v.Kind != yaml.SequenceNode {
+		return nil
+	}
+	out := make([]string, 0, len(v.Content))
+	for _, el := range v.Content {
+		out = append(out, el.Value)
+	}
+	return out
 }
 
 // dropRulesAt returns rules with the entries at the given indices removed.

--- a/internal/rules/loader_lenient_test.go
+++ b/internal/rules/loader_lenient_test.go
@@ -173,3 +173,179 @@ func TestLoadLenient_MalformedYAMLStillErrors(t *testing.T) {
 		t.Error("LoadLenient must still error on malformed YAML")
 	}
 }
+
+// TestLoadLenient_SkipsUnknownScope is the forward-compat contract for a NEW
+// scope: a rule whose scope this build does not know — e.g. a future `skill`
+// scope shipped by a newer rules release on a binary that predates skill support
+// — is dropped whole (its ID returned in skipped) while its known-scope sibling
+// loads. The unknown-scope rule deliberately uses a KNOWN predicate and a known
+// applies_to value, so the ONLY reason it is skipped is the scope itself —
+// isolating this from the predicate-drop path. Strict Load still rejects it, so
+// the typo-vs-new ambiguity is resolved at authoring time, not at runtime.
+func TestLoadLenient_SkipsUnknownScope(t *testing.T) {
+	const pack = `
+policy:
+  id: len
+  name: Lenient
+  category: claude_sdk
+  description: t
+rules:
+  - id: LEN-100
+    title: Known scope rule
+    scope: tool
+    severity: low
+    confidence: 0.8
+    applies_to: [claude_sdk_tool]
+    match:
+      has_docstring: true
+    explanation: x
+    fix: y
+  - id: LEN-101
+    title: Future scope rule
+    scope: skill
+    severity: high
+    confidence: 0.9
+    applies_to: [claude_sdk_tool]
+    match:
+      has_docstring: true
+    explanation: x
+    fix: y
+`
+	fsys := makeFS(map[string]string{"len.yaml": pack})
+	policies, skipped, err := rules.LoadLenient(fsys)
+	if err != nil {
+		t.Fatalf("LoadLenient unexpected error: %v", err)
+	}
+	ids := ruleIDs(policies)
+	if !ids["LEN-100"] {
+		t.Error("LEN-100 (known scope) should have loaded")
+	}
+	if ids["LEN-101"] {
+		t.Error("LEN-101 (unknown scope `skill`) should have been skipped, not loaded")
+	}
+	if len(skipped) != 1 || skipped[0] != "LEN-101" {
+		t.Errorf("skipped = %v, want [LEN-101]", skipped)
+	}
+
+	if _, err := rules.Load(fsys); err == nil {
+		t.Error("strict Load must error on an unknown scope")
+	} else if !strings.Contains(err.Error(), "scope") {
+		t.Errorf("strict Load error should name the scope problem, got: %v", err)
+	}
+}
+
+// TestLoadLenient_SkipsUnknownAppliesTo: a rule with a KNOWN scope but an
+// applies_to value this build does not recognize (a tool/agent kind a newer
+// engine added) is skipped at runtime, not hard-failed, while a sibling loads.
+// As with predicates and scope, strict Load rejects it so an authoring typo is
+// caught in CI rather than silently degrading every deployed scan.
+func TestLoadLenient_SkipsUnknownAppliesTo(t *testing.T) {
+	const pack = `
+policy:
+  id: len
+  name: Lenient
+  category: claude_sdk
+  description: t
+rules:
+  - id: LEN-110
+    title: Known applies_to rule
+    scope: tool
+    severity: low
+    confidence: 0.8
+    applies_to: [claude_sdk_tool]
+    match:
+      has_docstring: true
+    explanation: x
+    fix: y
+  - id: LEN-111
+    title: Future applies_to rule
+    scope: tool
+    severity: low
+    confidence: 0.8
+    applies_to: [future_sdk_tool]
+    match:
+      has_docstring: true
+    explanation: x
+    fix: y
+`
+	fsys := makeFS(map[string]string{"len.yaml": pack})
+	policies, skipped, err := rules.LoadLenient(fsys)
+	if err != nil {
+		t.Fatalf("LoadLenient unexpected error: %v", err)
+	}
+	ids := ruleIDs(policies)
+	if !ids["LEN-110"] {
+		t.Error("LEN-110 (known applies_to) should have loaded")
+	}
+	if ids["LEN-111"] {
+		t.Error("LEN-111 (unknown applies_to `future_sdk_tool`) should have been skipped")
+	}
+	if len(skipped) != 1 || skipped[0] != "LEN-111" {
+		t.Errorf("skipped = %v, want [LEN-111]", skipped)
+	}
+
+	if _, err := rules.Load(fsys); err == nil {
+		t.Error("strict Load must error on an unknown applies_to value")
+	}
+}
+
+// TestLoadLenient_MalformedKnownRuleStillErrors is the AC#3 regression: lenient
+// loading is forward-compat ONLY — it must NOT swallow a real authoring error in
+// a rule this build fully understands. A rule with a known scope, known
+// applies_to, and a known predicate but a genuine defect still hard-fails
+// LoadLenient, exactly as strict Load does. This is the "not a license to
+// silently drop real authoring errors" line from the ticket: only an UNKNOWN
+// scope/applies_to/predicate is forward-incompatible; a malformed KNOWN rule is
+// a defect, not a newer-engine signal.
+func TestLoadLenient_MalformedKnownRuleStillErrors(t *testing.T) {
+	cases := map[string]string{
+		// Missing the required `explanation` field.
+		"missing required field": `
+policy:
+  id: len
+  name: Lenient
+  category: claude_sdk
+  description: t
+rules:
+  - id: LEN-120
+    title: Known but missing explanation
+    scope: tool
+    severity: low
+    confidence: 0.8
+    applies_to: [claude_sdk_tool]
+    match:
+      has_docstring: true
+    fix: y
+`,
+		// Confidence outside the (0,1] probability range.
+		"out-of-range confidence": `
+policy:
+  id: len
+  name: Lenient
+  category: claude_sdk
+  description: t
+rules:
+  - id: LEN-121
+    title: Known but bad confidence
+    scope: tool
+    severity: low
+    confidence: 1.7
+    applies_to: [claude_sdk_tool]
+    match:
+      has_docstring: true
+    explanation: x
+    fix: y
+`,
+	}
+	for name, pack := range cases {
+		t.Run(name, func(t *testing.T) {
+			fsys := makeFS(map[string]string{"m.yaml": pack})
+			if _, _, err := rules.LoadLenient(fsys); err == nil {
+				t.Errorf("LoadLenient must still hard-fail a malformed KNOWN rule (%s)", name)
+			}
+			if _, err := rules.Load(fsys); err == nil {
+				t.Errorf("strict Load must also hard-fail a malformed KNOWN rule (%s)", name)
+			}
+		})
+	}
+}

--- a/internal/rules/schema_version.go
+++ b/internal/rules/schema_version.go
@@ -6,10 +6,10 @@ package rules
 //
 // Forward-compatible loading (see rules.LoadLenient): the engine NO LONGER
 // rejects a pack just because its schema_version exceeds this constant. It
-// loads the pack leniently — a rule whose match references a predicate this
-// build lacks is skipped (surfaced as a stderr warning and
-// ScanResult.RulesSkipped), and the scan proceeds with the rules it does
-// understand. A pack is refused only when it has no usable manifest
+// loads the pack leniently — a rule that references a scope, applies_to value,
+// or predicate this build lacks is skipped (surfaced as a stderr warning, the
+// META-005 info finding, and ScanResult.RulesSkipped), and the scan proceeds
+// with the rules it does understand. A pack is refused only when it has no usable manifest
 // (ErrNoCompatibleRules) or when NO rule is evaluable at all
 // (ErrAllRulesIncompatible). This decouples additive rule updates from binary
 // upgrades: shipping a new predicate no longer locks every older binary out of

--- a/internal/scanner/policy_selection.go
+++ b/internal/scanner/policy_selection.go
@@ -2,6 +2,7 @@ package scanner
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/trustabl/trustabl/internal/models"
 )
@@ -155,4 +156,34 @@ func EmitCoverageMETA(applicable map[models.DetectorCategory]bool, inv models.Re
 		})
 	}
 	return out
+}
+
+// EmitSkippedRulesMETA emits META-005 when the lenient loader dropped one or
+// more rules as forward-incompatible — rules referencing a scope, applies_to
+// value, or predicate this Trustabl build does not understand (a rules pack
+// authored against a newer engine). The skip would otherwise be invisible in the
+// report itself (it surfaces only on stderr and the JSON RulesSkipped field);
+// this honest info finding makes a degraded scan visible in the report,
+// upholding the "honest coverage > silent clean bill" principle. The skipped IDs
+// are sorted+deduped so the finding text is byte-stable regardless of the order
+// the loader returned them in.
+func EmitSkippedRulesMETA(skipped []string) []models.Finding {
+	if len(skipped) == 0 {
+		return nil
+	}
+	ids := sortedUnique(skipped)
+	return []models.Finding{{
+		RuleID:   "META-005",
+		Severity: models.SeverityInfo,
+		Title:    "Rules skipped — newer Trustabl engine required",
+		Explanation: fmt.Sprintf(
+			"%d rule(s) in the loaded pack reference a scope, applies_to value, or "+
+				"predicate that this Trustabl build does not understand, so they were "+
+				"skipped and did not run. The absence of findings from these rules does "+
+				"NOT mean this code is clean — this scan is incomplete for them. Skipped "+
+				"rule IDs: %s.", len(ids), strings.Join(ids, ", ")),
+		SuggestedFix: "Upgrade Trustabl to a build whose supported rule-schema version is at " +
+			"least the rules pack's, then re-scan to evaluate these rules.",
+		Confidence: 1.0,
+	}}
 }

--- a/internal/scanner/policy_selection_test.go
+++ b/internal/scanner/policy_selection_test.go
@@ -1,6 +1,7 @@
 package scanner_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/trustabl/trustabl/internal/models"
@@ -97,5 +98,56 @@ func TestEmitCoverageMETA_SilentForUnmappedSDK(t *testing.T) {
 	inv := models.RepoInventory{SDKsDetected: []models.SDK{models.SDKMCP, models.SDK("langgraph")}}
 	if f := scanner.EmitCoverageMETA(map[models.DetectorCategory]bool{}, inv); len(f) != 0 {
 		t.Errorf("expected no META-004 for unmapped SDKs, got %+v", f)
+	}
+}
+
+func TestEmitSkippedRulesMETA_SilentWhenNothingSkipped(t *testing.T) {
+	if f := scanner.EmitSkippedRulesMETA(nil); len(f) != 0 {
+		t.Errorf("expected no META-005 when nothing was skipped, got %+v", f)
+	}
+	if f := scanner.EmitSkippedRulesMETA([]string{}); len(f) != 0 {
+		t.Errorf("expected no META-005 for an empty skip slice, got %+v", f)
+	}
+}
+
+func TestEmitSkippedRulesMETA_EmitsInfoFinding(t *testing.T) {
+	findings := scanner.EmitSkippedRulesMETA([]string{"CSKILL-001", "CSKILL-002"})
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly one META-005 finding, got %+v", findings)
+	}
+	f := findings[0]
+	if f.RuleID != "META-005" {
+		t.Errorf("RuleID = %q, want META-005", f.RuleID)
+	}
+	if f.Severity != models.SeverityInfo {
+		t.Errorf("Severity = %q, want info", f.Severity)
+	}
+	// The finding must name how many rules were skipped and which ones, so the
+	// report itself (not just the JSON RulesSkipped field) is honest about the
+	// degraded scan.
+	if !strings.Contains(f.Explanation, "2 rule(s)") {
+		t.Errorf("explanation should state the count, got: %q", f.Explanation)
+	}
+	if !strings.Contains(f.Explanation, "CSKILL-001") || !strings.Contains(f.Explanation, "CSKILL-002") {
+		t.Errorf("explanation should list the skipped IDs, got: %q", f.Explanation)
+	}
+}
+
+// TestEmitSkippedRulesMETA_Deterministic guards the byte-stable-report contract:
+// the finding text must not depend on the order (or duplication) of the IDs the
+// loader returned. Two differently-ordered, differently-deduped inputs naming the
+// same set of rules must produce identical findings.
+func TestEmitSkippedRulesMETA_Deterministic(t *testing.T) {
+	a := scanner.EmitSkippedRulesMETA([]string{"B-2", "A-1", "C-3"})
+	b := scanner.EmitSkippedRulesMETA([]string{"C-3", "A-1", "B-2", "A-1"})
+	if len(a) != 1 || len(b) != 1 {
+		t.Fatalf("expected one finding each, got %d and %d", len(a), len(b))
+	}
+	if a[0].Explanation != b[0].Explanation {
+		t.Errorf("explanation is order/dup-sensitive:\n a=%q\n b=%q", a[0].Explanation, b[0].Explanation)
+	}
+	// Deduped: three distinct IDs, reported as "3 rule(s)".
+	if !strings.Contains(b[0].Explanation, "3 rule(s)") {
+		t.Errorf("duplicate IDs should be deduped to 3, got: %q", b[0].Explanation)
 	}
 }

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -276,6 +276,10 @@ func Run(cfg Config) (models.ScanResult, error) {
 	metaFindings := SelectAndEmitMETA(profile, inventory)
 	metaFindings = append(metaFindings,
 		EmitCoverageMETA(registry.ApplicableCategories(profile, inventory), inventory)...)
+	// Honest-coverage signal for forward-incompatible rules the lenient loader
+	// dropped (scope/applies_to/predicate this build predates). META-005 fires
+	// only when something was actually skipped, so an in-sync pack adds nothing.
+	metaFindings = append(metaFindings, EmitSkippedRulesMETA(rulesSkipped)...)
 
 	// Step 4: analysis
 	rep.StartPhase("analysis", "Analysis")

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"testing/fstest"
 
 	"github.com/trustabl/trustabl/internal/models"
 	"github.com/trustabl/trustabl/internal/scanner"
@@ -60,6 +61,101 @@ export const q = query({ options: { agents: { analyst: { description: "a", promp
 	}
 	if !sawClaudeSDK {
 		t.Errorf("SDKsDetected missing claude_agent_sdk: %+v", res.SDKs)
+	}
+}
+
+// TestScanRun_EmitsMETA005ForSkippedRule is the end-to-end forward-compat
+// contract (TR-200): when the lenient loader drops a forward-incompatible rule
+// from a pack that otherwise loads, the scan still succeeds, records the dropped
+// ID on RulesSkipped, and emits a single honest META-005 info finding in the
+// report — so a degraded scan is visible in the report itself, not just on
+// stderr. The custom rules FS pairs one valid claude_sdk rule with one rule
+// using an unknown `skill` scope (a rule a future engine could evaluate but this
+// build cannot).
+func TestScanRun_EmitsMETA005ForSkippedRule(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite := func(rel, content string) {
+		t.Helper()
+		full := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustWrite("package.json", `{"dependencies": {"@anthropic-ai/claude-agent-sdk": "^1.0.0"}}`)
+	mustWrite("src/agent.ts", `
+import { tool } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+export const searchTool = tool("search", "Search", { q: z.string() }, async () => ({ content: [] }));
+`)
+
+	// One valid rule (so the pack is not entirely incompatible — that would be a
+	// distinct hard error) plus one rule authored against a newer engine (unknown
+	// `skill` scope). LoadFor walks the FS for *.yaml; a manifest is not required.
+	rulesFS := fstest.MapFS{
+		"claude_sdk/pack.yaml": &fstest.MapFile{Data: []byte(`
+policy:
+  id: cs
+  name: Claude SDK
+  category: claude_sdk
+  description: t
+rules:
+  - id: GOOD-001
+    title: Known rule
+    scope: tool
+    severity: low
+    confidence: 0.8
+    applies_to: [claude_sdk_tool]
+    match:
+      has_docstring: true
+    explanation: x
+    fix: y
+  - id: FUTURE-001
+    title: Future-engine rule
+    scope: skill
+    severity: high
+    confidence: 0.9
+    applies_to: [claude_sdk_tool]
+    match:
+      has_docstring: true
+    explanation: x
+    fix: y
+`)},
+	}
+
+	res, err := scanner.Run(scanner.Config{Target: dir, RulesFS: rulesFS})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// The forward-incompatible rule is recorded as skipped...
+	var sawSkipped bool
+	for _, id := range res.RulesSkipped {
+		if id == "FUTURE-001" {
+			sawSkipped = true
+		}
+	}
+	if !sawSkipped {
+		t.Errorf("RulesSkipped should contain FUTURE-001, got %v", res.RulesSkipped)
+	}
+
+	// ...and surfaced as exactly one META-005 info finding that names it.
+	var meta005 []models.Finding
+	for _, f := range res.Findings {
+		if f.RuleID == "META-005" {
+			meta005 = append(meta005, f)
+		}
+	}
+	if len(meta005) != 1 {
+		t.Fatalf("expected exactly one META-005 finding, got %d: %+v", len(meta005), meta005)
+	}
+	if meta005[0].Severity != models.SeverityInfo {
+		t.Errorf("META-005 severity = %q, want info", meta005[0].Severity)
+	}
+	if !strings.Contains(meta005[0].Explanation, "FUTURE-001") {
+		t.Errorf("META-005 should name the skipped rule, got: %q", meta005[0].Explanation)
 	}
 }
 


### PR DESCRIPTION
## Summary

Completes **Option C** forward-compatible rule loading (TR-200). The lenient runtime loader already skipped rules with an unknown *predicate* or *category* (#23); this extends it to an unknown **`scope`** or **`applies_to`** value, and surfaces every skip in the report as an honest **`META-005`** info finding.

The motivating case: a future `skill`-scoped rule pack must degrade gracefully on already-deployed engines instead of hard-failing the whole load — without those engines needing to know `skill` exists. The engine never hard-codes `skill`; it generically skips *any* unknown scope, so when skill support later lands those rules simply start evaluating.

## What changed

- **`rules.ruleNeedsNewerEngine`** (`internal/rules/loader.go`): a YAML-node pre-pass that drops a rule whose non-empty `scope` / `applies_to` / match predicate this build does not understand, recording it as skipped instead of failing the pack. An **empty** scope/applies_to is *not* forward-incompatible — it's a missing required field that still hard-fails.
- **`META-005`** (`internal/scanner/policy_selection.go`, wired in `scanner.go`): one deterministic `info` finding ("N rules require a newer Trustabl engine") listing the sorted, deduped skipped IDs. It fires only when something was actually skipped, so an in-sync pack adds nothing and the report stays byte-stable.
- CLI stderr wording + docs (`README.md`, `ARCHITECTURE.md`, `CLAUDE.md`, `schema_version.go`) updated to cover scope/applies_to skipping and the META-005 finding.

## Tests

- `TestLoadLenient_SkipsUnknownScope`, `TestLoadLenient_SkipsUnknownAppliesTo` — lenient skips the rule, strict `Load` still rejects it.
- `TestLoadLenient_MalformedKnownRuleStillErrors` — AC#3 regression: a malformed *known* rule (missing field, out-of-range confidence) still hard-fails in **both** strict and lenient modes.
- `TestEmitSkippedRulesMETA_*` — emitter silent / emit / deterministic.
- `TestScanRun_EmitsMETA005ForSkippedRule` — end-to-end: a skipped rule flows through `scanner.Run` to `ScanResult.RulesSkipped` and a single `META-005` finding.
- `go test ./...` green; `gofmt` / `go vet` clean.

## Reviewer notes

- Branched off `main`, so the diff is exactly the one commit.
- **Honest caveat:** the broad class of authoring errors (missing required field, bad enum, out-of-range confidence, duplicate ID, degenerate match) hard-fails in both modes. A typo'd *sub-key of a known predicate* (e.g. `param_name_matches: {exatc: ...}`) is silently ignored at runtime and caught only by strict `Load` in CI — inherent to lenient decoding, the same trade-off #23 accepted for predicates. Every shipped pack passes strict via the fixture test + the `rules-sync` job, so it's caught before it ships.
- Should land **before** the `claude_skill` rule pack ships, so older deployed engines degrade gracefully (honest `META-005`) rather than breaking.

Refs: TR-200
