### PR TITLE
feat(cli): add --verbose and --debug diagnostics

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -157,7 +157,9 @@ The resolved commit SHA is recorded on `ScanResult` (`RulesSource`,
 `scanner.Run` takes an optional `Config.Progress` (`progress.Reporter`); nil
 means no output. It emits phase events (clone for remote targets, recon
 per-file, inventory per-file, analysis per-entity) that the CLI renders to
-**stderr** — animated on a TTY, plain lines when piped, silent for JSON. The
+**stderr** — animated on a TTY, plain lines when piped, silent for JSON. (A
+second optional stderr channel, `Config.Log`, carries `--verbose`/`--debug`
+diagnostics — see the **Diagnostics** subsection below.) The
 TTY renderer is a **live multi-row panel** (`internal/progress/tty.go`): every
 stage is a row drawn together and repainted in place — finished rows show a green
 `✔ <label>  <summary>`, the active row its spinner and (where a total is known) a
@@ -191,6 +193,36 @@ live line is a running counter rather than a bar; the callback fires both on the
 tree walk and on the per-file body reads in component discovery (the slow span
 on large repos). Progress never touches stdout, preserving the determinism
 contract (§7).
+
+### Diagnostics (`--verbose` / `--debug`)
+
+Separate from progress (the phase UI) is **diagnostic logging**: opt-in
+verbose/debug narration via a small leveled logger,
+[`internal/logx`](internal/logx/logx.go). It is a leaf package (no project
+imports) holding a `Logger` with three levels — `LevelNormal` (silent),
+`LevelVerbose`, `LevelDebug` — and `Verbosef` / `Debugf` / `Enabled` / `Timer`
+methods. A **nil `*logx.Logger` is a valid silent logger** (every method
+short-circuits before touching a field), so `Config.Log` defaults to a safe
+no-op. `Timer` reads no clock unless debug is on, so per-phase timing is free on
+the normal path and cannot introduce a time-dependent value near the report.
+
+The two flags are **persistent (global)** on the root command (`-v`/`--verbose`,
+`--debug`; `--debug` implies verbose), resolved by `logLevelFor(cmd)`. `scan`
+wires the logger fully (`scanner.Config.Log`), narrating each pipeline phase —
+rule provenance, recon/inventory/policy/analysis counts, detected and unaudited
+SDKs, per-entity and per-finding detail (debug, capped at 50), output
+destinations, and a result summary; `mcp` and `rules pull` wire it lightly. Like
+progress, **diagnostics are stderr-only** and never feed `ScanResult`, so the
+report stays byte-stable even under `--format json --debug`. Diagnostic color is
+gated by `diagColor` (off under `--no-color`, `NO_COLOR`, or a non-terminal
+stderr), matching the report's color contract.
+
+Because an animated TTY panel repaints in place, interleaving log lines into that
+region on the same stderr corrupts both. `pickScanMode` therefore calls
+`modeForLogs`, which **downgrades `ModeTTY` to `ModePlain` whenever verbose is
+on** (other modes pass through). A verbose run thus always takes the synchronous
+path, so the logger and the plain reporter write to stderr in order from one
+goroutine.
 
 ### Steps
 
@@ -1339,6 +1371,8 @@ internal/
 │   ├── reporter.go              Reporter iface, Mode, PickMode, nop.
 │   ├── plain.go                 Static-line reporter (piped human).
 │   └── tty.go                   bubbletea model + TTYReporter (interactive).
+├── logx/                        Leveled --verbose/--debug diagnostics (stderr-only,
+│                                nil-safe, leaf package).
 ├── analysis/
 │   ├── astutil/                 Tiny tree-sitter ergonomic layer (NodeText,
 │   │                            Walk, FindAll, FunctionName, FunctionParams,
@@ -1708,6 +1742,9 @@ trustabl scan <target> [--detectors=…] [--format=human|json|sarif]
 trustabl mcp           [--rules-repo=URL] [--rules-ref=REF] [--no-rules-update]
 trustabl rules pull    [--rules-repo=URL] [--rules-ref=REF]
 trustabl version
+
+Global (persistent) flags, valid on every subcommand:
+                       [-v|--verbose] [--debug]   stderr diagnostics; --debug implies --verbose
 ```
 
 `--rules-repo` (env `TRUSTABL_RULES_REPO`) overrides the rules repository URL;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ to follow Semantic Versioning once it reaches 1.0.
 
 ### Added
 
+- **`--verbose` / `--debug` diagnostics.** New global (persistent) flags on the
+  root command, valid on every subcommand and placeable before or after it
+  (`-v`/`--verbose`, `--debug`; `--debug` implies `--verbose`). `--verbose`
+  narrates the scan on stderr — rule provenance (repo, ref, resolved SHA, cache
+  fallback), per-phase discovery counts (languages, tools, agents, detected and
+  unaudited SDKs, loaded detectors), output destinations, and a result summary
+  (scan ID, score, findings by severity, exit code). `--debug` adds per-phase
+  timing and capped per-entity / per-finding detail. Backed by a new leaf
+  package `internal/logx` (nil-safe leveled logger). All diagnostics are
+  **stderr-only**, so the report on stdout and the JSON/SARIF byte-stability
+  contract are unaffected (`--format json --debug` still emits a clean
+  document). Diagnostic color follows the report's rules (off under
+  `--no-color`, `NO_COLOR`, or a non-terminal stderr). Because an animated
+  progress panel and interleaved log lines would corrupt each other,
+  `--verbose`/`--debug` render progress as plain `[phase]` lines.
+
 - **`trustabl llm provider` — provider switching.** New subcommand group for
   managing which LLM provider is active:
   - `trustabl llm provider set <provider>` — switch the active provider;

--- a/README.md
+++ b/README.md
@@ -290,6 +290,27 @@ terminal (TTY vs pipe, `NO_COLOR`), so the same scan can render with or without
 color. Use `--no-color`, or diff the JSON/SARIF output, when byte-stability
 matters.
 
+### Diagnostics (`--verbose` / `--debug`)
+
+`--verbose` (`-v`) narrates the scan on **stderr**: rule provenance (repo, ref,
+resolved SHA, and any cache fallback), per-phase discovery counts (languages,
+tools, agents, detected SDKs, loaded detectors, unaudited SDKs), output
+destinations, and a final result summary (scan ID, score, findings by severity,
+exit code). `--debug` adds everything `--verbose` shows plus per-phase timing and
+capped per-entity / per-finding detail (each discovered tool/agent and each
+finding with its `file:line`).
+
+Both are **global** flags — they work on `scan`, `mcp`, and `rules pull`, and may
+appear before or after the subcommand (`trustabl -v scan …` or `trustabl scan -v
+…`). `--debug` implies `--verbose`. Both write **only to stderr**, so they never
+perturb the report on stdout or the JSON/SARIF byte-stability contract:
+`--format json --debug` still emits a clean document on stdout while the
+diagnostics stream to stderr. Diagnostic color follows the same rules as the
+report (off under `--no-color`, `NO_COLOR`, or when stderr is not a terminal).
+Because an animated progress panel and interleaved log lines would corrupt each
+other on the same stderr, `--verbose`/`--debug` automatically render progress as
+plain `[phase]` lines instead of the live spinner.
+
 Exit codes:
 - `0` — no findings ≥ medium severity (or no findings at all).
 - `1` — at least one finding ≥ medium severity, OR `--strict` with any
@@ -406,6 +427,11 @@ trustabl scan ./repo --no-rules-update
 # Progress output (human format): animated on a terminal, plain lines when piped
 trustabl scan ./repo                 # spinner + bars on a TTY; "[phase] summary" lines when piped
 trustabl scan ./repo --no-progress   # disable progress entirely
+
+# Diagnostics on stderr (global flags; stdout/report unaffected)
+trustabl scan ./repo --verbose       # -v: rule provenance, discovery counts, result summary
+trustabl scan ./repo --debug         # + per-phase timing and per-entity/per-finding detail
+trustabl scan ./repo --debug --format json > out.json   # clean JSON on stdout, diagnostics on stderr
 
 # Run as a stdio MCP server so an MCP client (Claude Code, Cursor, Claude
 # Desktop) can scan code an agent just wrote (see "Run as an MCP server" below)

--- a/cmd/trustabl/main.go
+++ b/cmd/trustabl/main.go
@@ -25,6 +25,8 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+
+	"github.com/trustabl/trustabl/internal/logx"
 )
 
 // Build metadata, injected at release time via -ldflags -X (see .goreleaser.yaml).
@@ -51,6 +53,13 @@ func main() {
 		SilenceUsage:  true,
 		SilenceErrors: true, // we handle error printing ourselves below
 	}
+	// Persistent (global) diagnostics flags, inherited by every subcommand. All
+	// diagnostics go to stderr only, so they never perturb the byte-stable report
+	// on stdout. --debug implies --verbose (see logLevelFor).
+	rootCmd.PersistentFlags().BoolP("verbose", "v", false,
+		"verbose diagnostics on stderr: rule provenance, discovery counts, phase summaries")
+	rootCmd.PersistentFlags().Bool("debug", false,
+		"debug diagnostics on stderr: everything --verbose shows plus per-phase timing and per-entity/per-finding detail (implies --verbose)")
 	rootCmd.AddCommand(newScanCommand())
 	rootCmd.AddCommand(newVersionCommand())
 	rootCmd.AddCommand(newRulesCommand())
@@ -65,4 +74,27 @@ func main() {
 		fmt.Fprintln(os.Stderr, "Error:", err)
 		os.Exit(2)
 	}
+}
+
+// logLevelFor reads the persistent --verbose / --debug flags off cmd (they are
+// defined on the root command and inherited by every subcommand) and maps them
+// to a logx.Level. --debug wins: it is strictly more output than --verbose, so
+// it implies it.
+func logLevelFor(cmd *cobra.Command) logx.Level {
+	if debug, _ := cmd.Flags().GetBool("debug"); debug {
+		return logx.LevelDebug
+	}
+	if verbose, _ := cmd.Flags().GetBool("verbose"); verbose {
+		return logx.LevelVerbose
+	}
+	return logx.LevelNormal
+}
+
+// refOrDefault renders a rules ref for a diagnostic line, naming the empty ref
+// (resolve the repo's default branch) explicitly so the line is not blank.
+func refOrDefault(ref string) string {
+	if ref == "" {
+		return "default branch"
+	}
+	return ref
 }

--- a/cmd/trustabl/main_test.go
+++ b/cmd/trustabl/main_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/trustabl/trustabl/internal/models"
+	"github.com/trustabl/trustabl/internal/progress"
 	"github.com/trustabl/trustabl/internal/sarif"
 )
 
@@ -21,7 +22,8 @@ func TestFinishScan_GenericErrorNotDoublePrinted(t *testing.T) {
 	genErr := errors.New("boom")
 
 	// Plain mode (human format, non-tty in tests): reporter already showed it.
-	errPlain := finishScan(models.ScanResult{}, genErr, scanFlags{format: "human"})
+	// A nil logger is passed deliberately — finishScan must be nil-safe.
+	errPlain := finishScan(models.ScanResult{}, genErr, scanFlags{format: "human"}, nil)
 	var ec exitCodeError
 	if !errors.As(errPlain, &ec) {
 		t.Errorf("plain mode: got %v, want silent exitCodeError", errPlain)
@@ -29,9 +31,58 @@ func TestFinishScan_GenericErrorNotDoublePrinted(t *testing.T) {
 
 	// Off mode (json format forces progress off): main must print it, so the
 	// raw error propagates.
-	errOff := finishScan(models.ScanResult{}, genErr, scanFlags{format: "json"})
+	errOff := finishScan(models.ScanResult{}, genErr, scanFlags{format: "json"}, nil)
 	if !errors.Is(errOff, genErr) {
 		t.Errorf("off mode: got %v, want the raw error to propagate", errOff)
+	}
+}
+
+// modeForLogs downgrades only the animated TTY panel (which would corrupt
+// interleaved log lines) to plain; every other mode passes through unchanged,
+// and a non-verbose run is never downgraded.
+func TestModeForLogs(t *testing.T) {
+	cases := []struct {
+		name    string
+		base    progress.Mode
+		verbose bool
+		want    progress.Mode
+	}{
+		{"tty downgrades under verbose", progress.ModeTTY, true, progress.ModePlain},
+		{"tty unchanged without verbose", progress.ModeTTY, false, progress.ModeTTY},
+		{"plain unchanged under verbose", progress.ModePlain, true, progress.ModePlain},
+		{"off unchanged under verbose", progress.ModeOff, true, progress.ModeOff},
+		{"off unchanged without verbose", progress.ModeOff, false, progress.ModeOff},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := modeForLogs(c.base, c.verbose); got != c.want {
+				t.Errorf("modeForLogs(%v, %v) = %v, want %v", c.base, c.verbose, got, c.want)
+			}
+		})
+	}
+}
+
+func TestSeveritySummary(t *testing.T) {
+	f := func(s models.Severity) models.Finding { return models.Finding{Severity: s} }
+	cases := []struct {
+		name     string
+		findings []models.Finding
+		want     string
+	}{
+		{"empty is none", nil, "none"},
+		{"single high", []models.Finding{f(models.SeverityHigh)}, "1 high"},
+		{
+			"ordered highest first, zeros omitted",
+			[]models.Finding{f(models.SeverityInfo), f(models.SeverityHigh), f(models.SeverityHigh), f(models.SeverityMedium)},
+			"2 high, 1 medium, 1 info",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := severitySummary(c.findings); got != c.want {
+				t.Errorf("severitySummary = %q, want %q", got, c.want)
+			}
+		})
 	}
 }
 

--- a/cmd/trustabl/mcp.go
+++ b/cmd/trustabl/mcp.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/trustabl/trustabl/internal/logx"
 	"github.com/trustabl/trustabl/internal/mcpserver"
 	"github.com/trustabl/trustabl/internal/models"
 	"github.com/trustabl/trustabl/internal/progress"
@@ -43,7 +44,7 @@ func newMCPCommand() *cobra.Command {
 			"writes nothing else to stdout; diagnostics go to stderr.",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runMCP(cmd.Context(), f)
+			return runMCP(cmd.Context(), f, logLevelFor(cmd))
 		},
 	}
 	cmd.Flags().StringVar(&f.rulesRepo, "rules-repo", "",
@@ -59,16 +60,26 @@ func newMCPCommand() *cobra.Command {
 // scanner.Run exactly like the CLI scan path, but with progress disabled (the
 // nop reporter) so nothing touches stdout. A per-call rules_ref overrides the
 // command-level --rules-ref when the client supplies one.
-func runMCP(ctx context.Context, f mcpFlags) error {
+func runMCP(ctx context.Context, f mcpFlags, level logx.Level) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	// Diagnostics go to stderr; stdout is the JSON-RPC stream. diagColor keeps the
+	// output plain when stderr is captured into a client's server log (the common
+	// case) and only dims the tag when an operator runs the server in a terminal.
+	log := logx.New(os.Stderr, level, diagColor(false))
+	repo := rulesRepoFromFlag(f.rulesRepo)
+	if repo == "" {
+		repo = rulesource.DefaultRepoURL
+	}
+	log.Verbosef("mcp: rules repo %s", repo)
 
 	scan := func(ctx context.Context, req mcpserver.ScanRequest) (models.ScanResult, error) {
 		ref := f.rulesRef
 		if req.RulesRef != "" {
 			ref = req.RulesRef
 		}
+		log.Debugf("mcp: scan request path=%s rules_ref=%q", req.Path, ref)
 		rcfg := rulesource.Config{
 			RepoURL:  rulesRepoFromFlag(f.rulesRepo),
 			Ref:      ref,
@@ -80,7 +91,9 @@ func runMCP(ctx context.Context, f mcpFlags) error {
 		}
 		// Progress is the nop reporter: the MCP transport owns stdout, and even
 		// stderr progress would interleave noisily into a client's server log
-		// for every tool call. The scan stays a pure function over its config.
+		// for every tool call. Log is wired through, but it is silent unless the
+		// operator started the server with --verbose/--debug — an explicit opt-in
+		// to the per-call diagnostic stream (stderr only, never the RPC stream).
 		cfg := scanner.Config{
 			Target:         req.Path,
 			RulesFS:        res.FS,
@@ -88,6 +101,7 @@ func runMCP(ctx context.Context, f mcpFlags) error {
 			RulesVersion:   res.SHA,
 			RulesFromCache: res.FromCache,
 			Progress:       progress.NewNop(),
+			Log:            log,
 			Ctx:            ctx,
 		}
 		return scanner.Run(cfg)

--- a/cmd/trustabl/rules.go
+++ b/cmd/trustabl/rules.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/trustabl/trustabl/internal/logx"
 	"github.com/trustabl/trustabl/internal/rules"
 	"github.com/trustabl/trustabl/internal/rulesource"
 )
@@ -22,10 +23,17 @@ func newRulesCommand() *cobra.Command {
 		Use:   "pull",
 		Short: "Download the detection rule packs into the local cache",
 		Args:  cobra.NoArgs,
-		RunE: func(_ *cobra.Command, _ []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			log := logx.New(os.Stderr, logLevelFor(cmd), diagColor(false))
 			if repo == "" {
 				repo = os.Getenv("TRUSTABL_RULES_REPO")
 			}
+			src := repo
+			if src == "" {
+				src = rulesource.DefaultRepoURL
+			}
+			log.Verbosef("rules pull: fetching %s @ %s", src, refOrDefault(ref))
+			defer log.Timer("rules pull")()
 			res, err := rulesource.Pull(
 				rulesource.Config{RepoURL: repo, Ref: ref},
 				rules.SupportedSchemaVersion,
@@ -39,6 +47,7 @@ func newRulesCommand() *cobra.Command {
 				}
 				return fmt.Errorf("rules pull: %w", err)
 			}
+			log.Verbosef("rules pull: resolved %s from %s", res.SHA, res.RepoURL)
 			fmt.Printf("Pulled rules from %s at %s\n", res.RepoURL, res.SHA)
 			return nil
 		},

--- a/cmd/trustabl/scan.go
+++ b/cmd/trustabl/scan.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 
+	"github.com/trustabl/trustabl/internal/logx"
 	"github.com/trustabl/trustabl/internal/models"
 	"github.com/trustabl/trustabl/internal/progress"
 	"github.com/trustabl/trustabl/internal/review"
@@ -43,7 +44,7 @@ func newScanCommand() *cobra.Command {
 		Short: "Scan a local repo or GitHub URL",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runScan(args[0], f)
+			return runScan(args[0], f, logLevelFor(cmd))
 		},
 	}
 	cmd.Flags().StringVar(&f.detectors, "detectors", "",
@@ -71,11 +72,18 @@ func newScanCommand() *cobra.Command {
 	return cmd
 }
 
-func runScan(target string, f scanFlags) error {
+func runScan(target string, f scanFlags, level logx.Level) error {
 	if err := validateOutputFlags(f); err != nil {
 		return err
 	}
-	cfg := scanner.Config{Target: target}
+	// Diagnostics are stderr-only. A LevelNormal logger emits nothing; color is
+	// gated like the report (see diagColor).
+	log := logx.New(os.Stderr, level, diagColor(f.noColor))
+	log.Verbosef("scan: target %s", target)
+	log.Debugf("scan: flags format=%s strict=%v no-color=%v no-progress=%v output=%q json-out=%q sarif-out=%q detectors=%q",
+		f.format, f.strict, f.noColor, f.noProgress, f.output, f.jsonOut, f.sarifOut, f.detectors)
+
+	cfg := scanner.Config{Target: target, Log: log}
 	if f.detectors != "" {
 		cats, err := parseCategories(f.detectors)
 		if err != nil {
@@ -84,9 +92,12 @@ func runScan(target string, f scanFlags) error {
 		cfg.Categories = cats
 	}
 
-	mode := pickScanMode(f)
+	mode := pickScanMode(f, log)
+	log.Debugf("scan: progress mode %s", modeName(mode))
 
-	// Non-TTY paths run synchronously: resolve, scan, render.
+	// Non-TTY paths run synchronously: resolve, scan, render. Verbose/debug always
+	// land here — pickScanMode downgrades an animated TTY panel to plain lines so
+	// it cannot fight interleaved diagnostic output on the same stderr.
 	if mode != progress.ModeTTY {
 		var rep progress.Reporter = progress.NewNop()
 		if mode == progress.ModePlain {
@@ -144,7 +155,7 @@ func runScan(target string, f scanFlags) error {
 		return err
 	}
 	out := <-done
-	return finishScan(out.result, out.err, f)
+	return finishScan(out.result, out.err, f, log)
 }
 
 // validateOutputFlags rejects output destinations that collide. --output writes
@@ -167,21 +178,57 @@ func validateOutputFlags(f scanFlags) error {
 	return nil
 }
 
-// pickScanMode maps flags + stderr TTY state to a progress mode.
-func pickScanMode(f scanFlags) progress.Mode {
+// pickScanMode maps flags + stderr TTY state to a progress mode, then downgrades
+// the animated panel when verbose/debug logging is on (see modeForLogs).
+func pickScanMode(f scanFlags, log *logx.Logger) progress.Mode {
 	isTTY := isatty.IsTerminal(os.Stderr.Fd())
-	return progress.PickMode(f.format, isTTY, f.noColor, f.noProgress)
+	base := progress.PickMode(f.format, isTTY, f.noColor, f.noProgress)
+	return modeForLogs(base, log.Verbose())
+}
+
+// modeForLogs forces an animated TTY panel down to plain lines when verbose is
+// true: bubbletea repaints its panel in place, and interleaving diagnostic log
+// lines into that region on the same stderr corrupts both. ModeOff (JSON/SARIF)
+// and ModePlain are returned unchanged — the logger writes alongside them fine.
+func modeForLogs(base progress.Mode, verbose bool) progress.Mode {
+	if verbose && base == progress.ModeTTY {
+		return progress.ModePlain
+	}
+	return base
+}
+
+// diagColor decides whether logx diagnostics get a dim ANSI tag. Mirroring the
+// human report's color contract, color is suppressed by --no-color, by the
+// NO_COLOR convention, and whenever stderr is not a terminal (piped / CI) — so
+// diagnostics stay plain ASCII wherever a machine or a log file is reading them.
+func diagColor(noColor bool) bool {
+	return !noColor && os.Getenv("NO_COLOR") == "" && isatty.IsTerminal(os.Stderr.Fd())
+}
+
+// modeName renders a progress.Mode for a --debug line.
+func modeName(m progress.Mode) string {
+	switch m {
+	case progress.ModeOff:
+		return "off"
+	case progress.ModePlain:
+		return "plain"
+	case progress.ModeTTY:
+		return "tty"
+	default:
+		return "unknown"
+	}
 }
 
 // runScanSync runs resolution + scan + render inline (plain/nop modes).
 func runScanSync(f scanFlags, cfg scanner.Config, rep progress.Reporter) error {
 	result, err := resolveAndScan(&cfg, f, rep)
-	return finishScan(result, err, f)
+	return finishScan(result, err, f, cfg.Log)
 }
 
 // resolveAndScan resolves rules (reporting a "rules" phase) and runs the scan
 // with the reporter attached.
 func resolveAndScan(cfg *scanner.Config, f scanFlags, rep progress.Reporter) (models.ScanResult, error) {
+	log := cfg.Log
 	rep.StartPhase("rules", "Resolving rules")
 	// Resolve makes a network round-trip (and a full clone on a cold cache) with
 	// no internal progress; without a detail line the pre-flight spinner reads as
@@ -191,8 +238,19 @@ func resolveAndScan(cfg *scanner.Config, f scanFlags, rep progress.Reporter) (mo
 	if rulesRepo == "" {
 		rulesRepo = rulesource.DefaultRepoURL
 	}
+	noUpdateNote := ""
+	if rcfg.NoUpdate {
+		noUpdateNote = " (no-update: cache only)"
+	}
+	log.Verbosef("rules: resolving %s @ %s%s", rulesRepo, refOrDefault(rcfg.Ref), noUpdateNote)
+	log.Debugf("rules: engine supports rule schema version <= %d", rules.SupportedSchemaVersion)
+	if dir, err := os.UserCacheDir(); err == nil {
+		log.Debugf("rules: cache root %s", filepath.Join(dir, "trustabl", "rules"))
+	}
 	rep.SetDetail("fetching " + rulesRepo)
+	stop := log.Timer("rules resolution")
 	res, err := rulesource.Resolve(rcfg, rules.SupportedSchemaVersion)
+	stop()
 	if err != nil {
 		rep.Fatal(err)
 		return models.ScanResult{}, err
@@ -200,6 +258,9 @@ func resolveAndScan(cfg *scanner.Config, f scanFlags, rep progress.Reporter) (mo
 	summary := res.SHA
 	if res.FromCache {
 		summary = res.SHA + " (cached, offline)"
+		log.Verbosef("rules: resolved %s from %s (cached, offline — could not fetch newer)", res.SHA, res.RepoURL)
+	} else {
+		log.Verbosef("rules: resolved %s from %s", res.SHA, res.RepoURL)
 	}
 	rep.EndPhase(summary)
 
@@ -218,7 +279,7 @@ func resolveAndScan(cfg *scanner.Config, f scanFlags, rep progress.Reporter) (mo
 }
 
 // finishScan turns a job outcome into output + the process exit code.
-func finishScan(result models.ScanResult, jobErr error, f scanFlags) error {
+func finishScan(result models.ScanResult, jobErr error, f scanFlags, log *logx.Logger) error {
 	if jobErr != nil {
 		if errors.Is(jobErr, rulesource.ErrNoCompatibleRules) {
 			fmt.Fprintf(os.Stderr,
@@ -255,7 +316,7 @@ func finishScan(result models.ScanResult, jobErr error, f scanFlags) error {
 		// Returning it raw here would make main() print "Error: …" a second
 		// time. Only in silent (off) mode did nothing present it, so let main
 		// be the single presenter there.
-		if pickScanMode(f) != progress.ModeOff {
+		if pickScanMode(f, log) != progress.ModeOff {
 			return exitCodeError{2}
 		}
 		return jobErr
@@ -264,7 +325,7 @@ func finishScan(result models.ScanResult, jobErr error, f scanFlags) error {
 	// In silent mode (JSON or --no-progress) the "(cached, offline)" rules
 	// phase line is suppressed, so surface the cache-fallback as a stderr
 	// warning — stale rules should never be used without a human-visible signal.
-	if result.RulesFromCache && pickScanMode(f) == progress.ModeOff {
+	if result.RulesFromCache && pickScanMode(f, log) == progress.ModeOff {
 		fmt.Fprintf(os.Stderr,
 			"warning: using cached rules %s; could not fetch or use newer rules\n",
 			result.RulesVersion)
@@ -298,6 +359,9 @@ func finishScan(result models.ScanResult, jobErr error, f scanFlags) error {
 	if err := writeReport(report, f.output); err != nil {
 		return err
 	}
+	if f.output != "" {
+		log.Verbosef("output: wrote %s report to %s", f.format, f.output)
+	}
 
 	// --json-out / --sarif-out persist the respective format to a file
 	// independent of --format, so one scan can print the human panel to stdout
@@ -306,11 +370,44 @@ func finishScan(result models.ScanResult, jobErr error, f scanFlags) error {
 	if err := writeSideOutputs(result, f); err != nil {
 		return err
 	}
+	if f.jsonOut != "" {
+		log.Verbosef("output: wrote JSON to %s", f.jsonOut)
+	}
+	if f.sarifOut != "" {
+		log.Verbosef("output: wrote SARIF to %s", f.sarifOut)
+	}
 
-	if code := exitCode(result, f.strict); code != 0 {
+	code := exitCode(result, f.strict)
+	log.Verbosef("result: scan_id %s · overall %.0f%% · %d findings (%s) · exit %d",
+		result.ScanID, result.OverallScore*100, len(result.Findings), severitySummary(result.Findings), code)
+	if code != 0 {
 		return exitCodeError{code}
 	}
 	return nil
+}
+
+// severitySummary renders a deterministic, human-legible severity histogram for
+// a finding set, e.g. "2 high, 1 medium, 3 info" — highest severity first, zero
+// tiers omitted. Used in the verbose result line. "none" for an empty set.
+func severitySummary(findings []models.Finding) string {
+	counts := map[models.Severity]int{}
+	for _, f := range findings {
+		counts[f.Severity]++
+	}
+	order := []models.Severity{
+		models.SeverityCritical, models.SeverityHigh, models.SeverityMedium,
+		models.SeverityLow, models.SeverityInfo,
+	}
+	var parts []string
+	for _, s := range order {
+		if n := counts[s]; n > 0 {
+			parts = append(parts, fmt.Sprintf("%d %s", n, s))
+		}
+	}
+	if len(parts) == 0 {
+		return "none"
+	}
+	return strings.Join(parts, ", ")
 }
 
 // renderReport turns a ScanResult into the report bytes for the chosen format.

--- a/internal/logx/logx.go
+++ b/internal/logx/logx.go
@@ -1,0 +1,107 @@
+// Package logx is a tiny leveled diagnostic logger for the CLI.
+//
+// It writes ONLY to the configured writer (always os.Stderr in production) and
+// never to stdout, so it cannot perturb the byte-stable human report or the
+// JSON/SARIF streams — the determinism contract (see the repo CLAUDE.md). The
+// progress package owns the phase UI on stderr; logx owns opt-in verbose/debug
+// detail. They are separate streams of intent that happen to share stderr.
+//
+// A nil *Logger is a valid, silent logger: every method short-circuits before
+// touching any field, so call sites can hold a nil logger (the zero value of a
+// Config.Log field) without guarding each call.
+package logx
+
+import (
+	"fmt"
+	"io"
+	"sync"
+	"time"
+)
+
+// Level is the diagnostic verbosity. Each level includes everything below it,
+// so LevelDebug also emits verbose lines.
+type Level int
+
+const (
+	LevelNormal  Level = iota // default: no diagnostics
+	LevelVerbose              // --verbose / -v: provenance, discovery counts, phase summaries
+	LevelDebug                // --debug: everything verbose shows, plus timing and per-entity / per-finding detail
+)
+
+// ANSI dim/reset, applied to the level tag only when color is enabled so the
+// diagnostic prefix recedes behind the actual report. The message body is left
+// unstyled. The tag text is ASCII so stripping color leaves readable output.
+const (
+	ansiDim   = "\x1b[2m"
+	ansiReset = "\x1b[0m"
+)
+
+// Logger writes leveled diagnostic lines to an io.Writer (stderr). It is safe
+// for concurrent use: in the non-verbose TTY path the scan runs on a goroutine
+// while the main goroutine renders, and the mutex keeps their writes whole.
+type Logger struct {
+	mu    sync.Mutex
+	w     io.Writer
+	level Level
+	color bool
+}
+
+// New returns a Logger writing to w at the given level. color enables a dim
+// ANSI tag on each line; pass false (for --no-color, a non-terminal, or a
+// server log) for plain ASCII output. A LevelNormal logger satisfies every
+// method but emits nothing.
+func New(w io.Writer, level Level, color bool) *Logger {
+	return &Logger{w: w, level: level, color: color}
+}
+
+// Enabled reports whether a message at lvl would be emitted. Use it to guard
+// expensive message construction, e.g. a capped per-entity debug dump. Returns
+// false for a nil logger and for LevelNormal (which is never emitted).
+func (l *Logger) Enabled(lvl Level) bool {
+	return l != nil && lvl > LevelNormal && l.level >= lvl
+}
+
+// Verbose reports whether verbose (or debug) output is on. Callers use it to
+// decide unrelated behavior — notably downgrading the animated progress panel
+// to plain lines so it does not fight interleaved log lines on stderr.
+func (l *Logger) Verbose() bool { return l.Enabled(LevelVerbose) }
+
+// Verbosef emits one line at verbose level (also shown under --debug).
+func (l *Logger) Verbosef(format string, args ...any) {
+	l.emit(LevelVerbose, "verbose", format, args...)
+}
+
+// Debugf emits one line at debug level only.
+func (l *Logger) Debugf(format string, args ...any) {
+	l.emit(LevelDebug, "debug", format, args...)
+}
+
+// Timer starts a debug-level stopwatch for a named operation and returns a stop
+// function that logs the elapsed time. When debug logging is off it reads no
+// clock and the returned stop is a no-op, so timing is free on the normal path
+// and cannot introduce a time-dependent value anywhere near the report. Typical
+// use: defer log.Timer("phase")().
+func (l *Logger) Timer(name string) func() {
+	if !l.Enabled(LevelDebug) {
+		return func() {}
+	}
+	start := time.Now()
+	// Microsecond resolution: millisecond rounding renders a sub-ms phase as a
+	// confusing "0s", while nanoseconds are noise. µs reads cleanly across the
+	// range a scan spans (a fast phase as "412µs", a slow one as "1.4s").
+	return func() { l.Debugf("%s took %s", name, time.Since(start).Round(time.Microsecond)) }
+}
+
+func (l *Logger) emit(lvl Level, tag, format string, args ...any) {
+	if !l.Enabled(lvl) {
+		return
+	}
+	prefix := "[" + tag + "] "
+	if l.color {
+		prefix = ansiDim + "[" + tag + "]" + ansiReset + " "
+	}
+	line := prefix + fmt.Sprintf(format, args...) + "\n"
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	fmt.Fprint(l.w, line)
+}

--- a/internal/logx/logx_test.go
+++ b/internal/logx/logx_test.go
@@ -1,0 +1,99 @@
+package logx
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// At each level, only messages at or below that level are emitted, and
+// LevelNormal stays completely silent.
+func TestLevelGating(t *testing.T) {
+	cases := []struct {
+		level       Level
+		wantVerbose bool
+		wantDebug   bool
+	}{
+		{LevelNormal, false, false},
+		{LevelVerbose, true, false},
+		{LevelDebug, true, true},
+	}
+	for _, c := range cases {
+		var buf bytes.Buffer
+		l := New(&buf, c.level, false)
+		l.Verbosef("v-line")
+		l.Debugf("d-line")
+		out := buf.String()
+		if got := strings.Contains(out, "v-line"); got != c.wantVerbose {
+			t.Errorf("level %d: verbose emitted=%v, want %v (out=%q)", c.level, got, c.wantVerbose, out)
+		}
+		if got := strings.Contains(out, "d-line"); got != c.wantDebug {
+			t.Errorf("level %d: debug emitted=%v, want %v (out=%q)", c.level, got, c.wantDebug, out)
+		}
+	}
+}
+
+// A nil *Logger is a silent no-op: every method must be safe to call.
+func TestNilLoggerIsSafeAndSilent(t *testing.T) {
+	var l *Logger // nil
+	// None of these may panic.
+	l.Verbosef("x")
+	l.Debugf("y")
+	stop := l.Timer("z")
+	stop()
+	if l.Enabled(LevelVerbose) || l.Enabled(LevelDebug) || l.Verbose() {
+		t.Error("nil logger reported enabled")
+	}
+}
+
+// LevelNormal is never enabled, even when asked about itself.
+func TestNormalNeverEnabled(t *testing.T) {
+	l := New(&bytes.Buffer{}, LevelDebug, false)
+	if l.Enabled(LevelNormal) {
+		t.Error("Enabled(LevelNormal) = true, want false (normal is never emitted)")
+	}
+}
+
+// Each emitted line carries a greppable level tag and a trailing newline.
+func TestLineFormat(t *testing.T) {
+	var buf bytes.Buffer
+	l := New(&buf, LevelDebug, false)
+	l.Verbosef("hello %d", 42)
+	got := buf.String()
+	if got != "[verbose] hello 42\n" {
+		t.Errorf("line = %q, want %q", got, "[verbose] hello 42\n")
+	}
+}
+
+// color=false emits no ANSI escapes; color=true wraps the tag in a dim escape.
+func TestColorToggle(t *testing.T) {
+	var plain, colored bytes.Buffer
+	New(&plain, LevelVerbose, false).Verbosef("m")
+	New(&colored, LevelVerbose, true).Verbosef("m")
+
+	if strings.Contains(plain.String(), "\x1b[") {
+		t.Errorf("no-color output contains ANSI: %q", plain.String())
+	}
+	if !strings.Contains(colored.String(), ansiDim) {
+		t.Errorf("colored output missing dim escape: %q", colored.String())
+	}
+	// The message body is identical once color is stripped.
+	if strings.Contains(colored.String(), "m\n") != true {
+		t.Errorf("colored output missing message body: %q", colored.String())
+	}
+}
+
+// Timer is a no-op (emits nothing) below debug, and emits one line at debug.
+func TestTimer(t *testing.T) {
+	var off bytes.Buffer
+	New(&off, LevelVerbose, false).Timer("phase")() // verbose < debug: silent
+	if off.Len() != 0 {
+		t.Errorf("Timer emitted at verbose level: %q", off.String())
+	}
+
+	var on bytes.Buffer
+	New(&on, LevelDebug, false).Timer("phase")()
+	if !strings.Contains(on.String(), "phase took") {
+		t.Errorf("Timer at debug = %q, want a 'phase took ...' line", on.String())
+	}
+}

--- a/internal/scanner/diagnostics.go
+++ b/internal/scanner/diagnostics.go
@@ -1,0 +1,108 @@
+package scanner
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/trustabl/trustabl/internal/logx"
+	"github.com/trustabl/trustabl/internal/models"
+)
+
+// maxDebugEntities caps the per-entity and per-finding debug dumps so a
+// pathologically large repo cannot flood stderr; the remainder is summarized as
+// "... and N more". The cap is generous — debug output is opt-in.
+const maxDebugEntities = 50
+
+// sdkListLabel renders a slice of SDKs as a stable comma list, or "none".
+func sdkListLabel(sdks []models.SDK) string {
+	if len(sdks) == 0 {
+		return "none"
+	}
+	parts := make([]string, len(sdks))
+	for i, s := range sdks {
+		parts[i] = string(s)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// categoryListLabel renders a slice of detector categories as a comma list.
+func categoryListLabel(cats []models.DetectorCategory) string {
+	parts := make([]string, len(cats))
+	for i, c := range cats {
+		parts[i] = string(c)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// severitySummary renders a deterministic severity histogram for a finding set,
+// e.g. "2 high, 1 medium, 3 info" — highest severity first, zero tiers omitted.
+// "none" for an empty set.
+func severitySummary(findings []models.Finding) string {
+	counts := map[models.Severity]int{}
+	for _, f := range findings {
+		counts[f.Severity]++
+	}
+	order := []models.Severity{
+		models.SeverityCritical, models.SeverityHigh, models.SeverityMedium,
+		models.SeverityLow, models.SeverityInfo,
+	}
+	var parts []string
+	for _, s := range order {
+		if n := counts[s]; n > 0 {
+			parts = append(parts, fmt.Sprintf("%d %s", n, s))
+		}
+	}
+	if len(parts) == 0 {
+		return "none"
+	}
+	return strings.Join(parts, ", ")
+}
+
+// unauditedSDKs returns the detected SDKs that ship no policy pack — the ones
+// META-001 flags as unaudited. Order follows the input (already sorted by Run).
+func unauditedSDKs(sdks []models.SDK) []models.SDK {
+	var out []models.SDK
+	for _, s := range sdks {
+		if !shippedPolicySDKs[s] {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// logDiscoveredEntities dumps each discovered tool and agent at debug level,
+// capped. Caller guards with log.Enabled(LevelDebug) to skip the work entirely
+// on the normal/verbose paths.
+func logDiscoveredEntities(log *logx.Logger, tools []models.ToolDef, agents []models.AgentDef) {
+	for i, t := range tools {
+		if i == maxDebugEntities {
+			log.Debugf("inventory: ... and %d more tools", len(tools)-maxDebugEntities)
+			break
+		}
+		log.Debugf("inventory: tool %q [%s] %s:%d", t.Name, t.Kind, t.FilePath, t.Line)
+	}
+	for i, a := range agents {
+		if i == maxDebugEntities {
+			log.Debugf("inventory: ... and %d more agents", len(agents)-maxDebugEntities)
+			break
+		}
+		log.Debugf("inventory: agent %q [%s] %s:%d", a.Name, a.SDK, a.FilePath, a.Line)
+	}
+}
+
+// logFindingsDetail dumps each finding at debug level, capped. The findings are
+// already deterministically sorted by the detector registry. Caller guards with
+// log.Enabled(LevelDebug).
+func logFindingsDetail(log *logx.Logger, findings []models.Finding) {
+	for i, f := range findings {
+		if i == maxDebugEntities {
+			log.Debugf("analysis: ... and %d more findings", len(findings)-maxDebugEntities)
+			break
+		}
+		loc := f.FilePath
+		if f.Line > 0 {
+			loc = fmt.Sprintf("%s:%d", f.FilePath, f.Line)
+		}
+		log.Debugf("analysis: %s [%s] %s — %s", f.RuleID, f.Severity, loc, f.Title)
+	}
+}

--- a/internal/scanner/diagnostics_test.go
+++ b/internal/scanner/diagnostics_test.go
@@ -1,0 +1,91 @@
+package scanner_test
+
+import (
+	"bytes"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/trustabl/trustabl/internal/logx"
+	"github.com/trustabl/trustabl/internal/scanner"
+)
+
+// corpusTarget returns an absolute path to a corpus repo, resolved relative to
+// this test file so it works regardless of the working directory.
+func corpusTarget(name string) string {
+	_, thisFile, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(thisFile), "..", "..", "testdata", "corpus", name)
+}
+
+// A verbose logger attached to a scan emits a stderr diagnostic line for every
+// pipeline phase. This guards the "proper functionality" of -v end to end:
+// every scan, regardless of corpus content, narrates recon/inventory/policy/
+// analysis. The lines are stderr-only and never alter the result.
+func TestRun_VerboseEmitsPhaseDiagnostics(t *testing.T) {
+	var buf bytes.Buffer
+	cfg := scanner.Config{
+		Target:  corpusTarget("google-adk-demo"),
+		RulesFS: rulesFixture(t),
+		Log:     logx.New(&buf, logx.LevelVerbose, false),
+	}
+	if _, err := scanner.Run(cfg); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"recon:", "inventory:", "policy:", "analysis:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("verbose output missing a %q line:\n%s", want, out)
+		}
+	}
+	// Timing is debug-only; verbose must not emit it.
+	if strings.Contains(out, "took ") {
+		t.Errorf("verbose output unexpectedly contains debug timing:\n%s", out)
+	}
+	// Diagnostics carry the verbose tag and no debug tag.
+	if !strings.Contains(out, "[verbose]") || strings.Contains(out, "[debug]") {
+		t.Errorf("verbose output has wrong tags:\n%s", out)
+	}
+}
+
+// A normal-level logger and a nil logger both produce no diagnostics — the
+// scan stays silent on stderr, preserving the byte-stable contract on the
+// normal path.
+func TestRun_NormalAndNilLoggerSilent(t *testing.T) {
+	target := corpusTarget("google-adk-demo")
+
+	var buf bytes.Buffer
+	cfg := scanner.Config{
+		Target:  target,
+		RulesFS: rulesFixture(t),
+		Log:     logx.New(&buf, logx.LevelNormal, false),
+	}
+	if _, err := scanner.Run(cfg); err != nil {
+		t.Fatalf("scan (normal level): %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("normal-level logger emitted output:\n%s", buf.String())
+	}
+
+	// A nil logger must not panic and must still produce a result.
+	if _, err := scanner.Run(scanner.Config{Target: target, RulesFS: rulesFixture(t), Log: nil}); err != nil {
+		t.Fatalf("scan (nil log): %v", err)
+	}
+}
+
+// Debug adds per-phase timing on top of the verbose lines.
+func TestRun_DebugEmitsTiming(t *testing.T) {
+	var buf bytes.Buffer
+	cfg := scanner.Config{
+		Target:  corpusTarget("google-adk-demo"),
+		RulesFS: rulesFixture(t),
+		Log:     logx.New(&buf, logx.LevelDebug, false),
+	}
+	if _, err := scanner.Run(cfg); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "[debug]") || !strings.Contains(out, "took ") {
+		t.Errorf("debug output missing timing lines:\n%s", out)
+	}
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -22,6 +22,7 @@ import (
 	"github.com/trustabl/trustabl/internal/analysis"
 	"github.com/trustabl/trustabl/internal/analysis/astutil"
 	"github.com/trustabl/trustabl/internal/ingestion"
+	"github.com/trustabl/trustabl/internal/logx"
 	"github.com/trustabl/trustabl/internal/models"
 	"github.com/trustabl/trustabl/internal/progress"
 	"github.com/trustabl/trustabl/internal/rules"
@@ -43,6 +44,12 @@ type Config struct {
 	// Progress receives real-time phase events. Nil means no progress output.
 	Progress progress.Reporter
 
+	// Log receives verbose/debug diagnostics on stderr. Nil disables them (a nil
+	// *logx.Logger is a safe no-op). It is independent of Progress: Progress
+	// renders the phase UI, Log narrates detail at -v/--debug. Both are
+	// stderr-only and never feed ScanResult, so neither affects determinism.
+	Log *logx.Logger
+
 	// Ctx, when non-nil, cancels the scan. The CLI ties this to its interrupt
 	// handler so a Ctrl-C aborts the run at the next phase boundary and lets the
 	// deferred temp-dir cleanup fire before the process exits. Nil means an
@@ -61,6 +68,8 @@ func Run(cfg Config) (models.ScanResult, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	log := cfg.Log // a nil *logx.Logger is a safe no-op
+	defer log.Timer("scan total")()
 
 	// Step 0: resolve the target. For a remote target this shallow-clones to a
 	// temp dir — potentially the longest single wait of the whole scan, and the
@@ -87,6 +96,8 @@ func Run(cfg Config) (models.ScanResult, error) {
 	defer src.Cleanup()
 	if remote {
 		rep.EndPhase(cfg.Target)
+		log.Verbosef("clone: %s", cfg.Target)
+		log.Debugf("clone: checked out to %s", src.RootPath)
 	}
 	// Cancellation checkpoint. The expensive phases below (recon walk, per-language
 	// AST, analysis) have no internal cancellation, but checking here — right after
@@ -116,15 +127,27 @@ func Run(cfg Config) (models.ScanResult, error) {
 
 	// Step 1: recon (cheap, no AST)
 	rep.StartPhase("recon", "Recon")
+	reconStop := log.Timer("recon")
 	profile, err := ingestion.Recon(src, func(path string) { rep.Advance(path) })
 	if err != nil {
 		rep.Fatal(err)
 		return models.ScanResult{}, fmt.Errorf("recon: %w", err)
 	}
 	rep.EndPhase(fmt.Sprintf("%d files · %s", len(profile.Manifest.PythonFiles), languagesLabel(profile.Languages)))
+	reconStop()
+	log.Verbosef("recon: languages %s · %d SDK deps declared", languagesLabel(profile.Languages), len(profile.SDKDeps))
+	if log.Enabled(logx.LevelDebug) {
+		m := profile.Manifest
+		log.Debugf("recon: files py=%d ts=%d js=%d yaml=%d json=%d md=%d",
+			len(m.PythonFiles), len(m.TypeScriptFiles), len(m.JavaScriptFiles), len(m.YAMLFiles), len(m.JSONFiles), len(m.MarkdownFiles))
+		for _, d := range profile.SDKDeps {
+			log.Debugf("recon: dep %s (source=%s confidence=%.2f)", d.Name, d.Source, d.Confidence)
+		}
+	}
 
 	// Step 2: inventory (per-language AST; Python only for now)
 	rep.StartPhase("inventory", "Inventory")
+	inventoryStop := log.Timer("inventory")
 	rep.SetTotal(len(profile.Manifest.PythonFiles) + len(profile.Manifest.TypeScriptFiles))
 	tools, parsed, pySkipped, err := analysis.DiscoverTools(profile.Manifest, func(path string) {
 		rep.Advance(path)
@@ -256,6 +279,13 @@ func Run(cfg Config) (models.ScanResult, error) {
 	// Fold them into SDKsDetected so LoadFor loads the claude_sdk pack (CSDK-110).
 	inventory.SDKsDetected = deriveSDKsDetected(tools, agents, inventory.Subagents, inventory.ClaudeSettings, inventory.ClaudeAgentOptions)
 	rep.EndPhase(fmt.Sprintf("%d tools · %d agents", len(tools), len(agents)))
+	inventoryStop()
+	log.Verbosef("inventory: %d tools · %d agents · %d guardrails · %d sessions · %d subagents · %d mcp servers · %d skills",
+		len(tools), len(agents), len(guardrails), len(sessions), len(inventory.Subagents), len(mcpServers), len(inventory.Skills))
+	log.Verbosef("inventory: SDKs detected: %s", sdkListLabel(inventory.SDKsDetected))
+	if log.Enabled(logx.LevelDebug) {
+		logDiscoveredEntities(log, tools, agents)
+	}
 
 	// Step 3: policy selection
 	if cfg.RulesFS == nil {
@@ -265,8 +295,14 @@ func Run(cfg Config) (models.ScanResult, error) {
 	if err != nil {
 		return models.ScanResult{}, fmt.Errorf("load rules: %w", err)
 	}
+	log.Verbosef("policy: loaded %d detectors for SDKs: %s", registry.Count(), sdkListLabel(inventory.SDKsDetected))
+	if un := unauditedSDKs(inventory.SDKsDetected); len(un) > 0 {
+		log.Verbosef("policy: unaudited SDKs (no pack shipped): %s", sdkListLabel(un))
+	}
 	if len(cfg.Categories) > 0 {
 		registry = registry.Subset(cfg.Categories...)
+		log.Verbosef("policy: --detectors filter → %d detectors for categories: %s",
+			registry.Count(), categoryListLabel(cfg.Categories))
 	}
 	metaFindings := SelectAndEmitMETA(profile, inventory)
 	metaFindings = append(metaFindings,
@@ -274,12 +310,19 @@ func Run(cfg Config) (models.ScanResult, error) {
 
 	// Step 4: analysis
 	rep.StartPhase("analysis", "Analysis")
+	analysisStop := log.Timer("analysis")
 	rep.SetTotal(len(inventory.Tools) + len(inventory.Agents))
 	ruleFindings := registry.Run(profile, inventory, allParsed, func(label string) {
 		rep.Advance(label)
 	})
 	findings := append(metaFindings, ruleFindings...)
 	rep.EndPhase(fmt.Sprintf("%d findings", len(findings)))
+	analysisStop()
+	log.Verbosef("analysis: %d findings (%d META + %d rule) · %s",
+		len(findings), len(metaFindings), len(ruleFindings), severitySummary(findings))
+	if log.Enabled(logx.LevelDebug) {
+		logFindingsDetail(log, findings)
+	}
 
 	// Step 5: scoring
 	surfaces, overall := analysis.Score(tools, inventory.Agents, inventory.Subagents, findings)


### PR DESCRIPTION
## Summary

Adds global `--verbose` (`-v`) and `--debug` flags that emit opt-in, **stderr-only** diagnostics across the scan pipeline, without touching the byte-stable report on stdout. Previously the engine had no way to narrate what a scan was doing or why (rule provenance, discovery counts, timing).

Jira: TR-213

## What it does

- **`--verbose` / `-v`** — narrates the scan on stderr: rule provenance (repo, ref, resolved SHA, cache fallback), per-phase discovery counts (languages, tools/agents, detected + unaudited SDKs, loaded detectors), output destinations, and a result summary (scan ID, score, findings by severity, exit code).
- **`--debug`** — everything `--verbose` shows, plus per-phase timing and capped per-entity / per-finding detail (each discovered tool/agent and each finding with `file:line`).
- Both are **global** (work on `scan`, `mcp`, `rules pull`; placeable before or after the subcommand). `--debug` implies `--verbose`.

## Design notes

- New leaf package `internal/logx`: a nil-safe, leveled (Normal/Verbose/Debug) logger. A nil `*Logger` is a valid silent no-op, so `scanner.Config.Log` defaults to nothing. The `Timer` reads no clock unless `--debug` is on, so timing is free on the normal path and **determinism is preserved** — diagnostics never feed `ScanResult`.
- Verbose/debug **downgrade the animated TTY panel to plain `[phase]` lines** (`modeForLogs`): an in-place bubbletea repaint and interleaved log lines on the same stderr would corrupt each other. A verbose run therefore takes the synchronous path.
- Diagnostic color follows the report's contract (off under `--no-color`, `NO_COLOR`, or a non-terminal stderr).
- `--format json --debug` still emits a clean document on stdout; diagnostics go only to stderr.

## Example

```
$ trustabl scan ./repo --debug --format json >out.json
[verbose] scan: target ./repo
[verbose] rules: resolved <sha> from https://github.com/trustabl/trustabl-rules
[debug] recon took 540µs
[verbose] inventory: 1 tools · 1 agents · … · SDKs detected: google_adk
[verbose] policy: loaded 26 detectors for SDKs: google_adk
[verbose] analysis: 7 findings (0 META + 7 rule) · 2 high, 3 medium, 2 low
[verbose] result: scan_id scan_… · overall 65% · 7 findings · exit 1
```

## Testing

- `go test ./...` passes; `go vet` and `gofmt` clean.
- New tests: logx leveling / nil-safety / color / timer; `modeForLogs` downgrade matrix; `severitySummary`; end-to-end scanner diagnostics (verbose emits each phase; **normal/nil logger stays silent** — guards the determinism contract; debug emits timing).
- Smoke-tested the built binary at `-v` and `--debug`.

## Files

`internal/logx/` (new), `internal/scanner/diagnostics.go` (new), `internal/scanner/scanner.go`, `cmd/trustabl/{main,scan,mcp,rules}.go`, `README.md`, `ARCHITECTURE.md`, `CHANGELOG.md`.
