### PR TITLE
docs(cli): show how to save diagnostics via stderr redirection

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,25 @@ Because an animated progress panel and interleaved log lines would corrupt each
 other on the same stderr, `--verbose`/`--debug` automatically render progress as
 plain `[phase]` lines instead of the live spinner.
 
+**Saving diagnostics to a file.** There is no dedicated `--log-file` flag —
+because diagnostics are a separate stream (stderr), redirecting stderr is the
+intended mechanism:
+
+```bash
+# Report and diagnostics to separate files (stdout vs stderr)
+trustabl scan ./repo --debug --format json >report.json 2>diagnostics.log
+
+# Human report on screen, diagnostics to a file
+trustabl scan ./repo --debug 2>diagnostics.log
+
+# Everything (report + diagnostics) in one file
+trustabl scan ./repo --debug &>everything.log
+```
+
+With `--format json`/`sarif` progress is off, so the stderr file is
+diagnostics-only; with `--format human` it also carries the plain `[phase]`
+progress lines.
+
 Exit codes:
 - `0` — no findings ≥ medium severity (or no findings at all).
 - `1` — at least one finding ≥ medium severity, OR `--strict` with any


### PR DESCRIPTION
## Summary

Follow-up docs for the `--verbose` / `--debug` diagnostics flags (the feature itself shipped in #27). Documents that there is intentionally **no `--log-file` flag** and that redirecting **stderr** (`2>`) is the intended way to persist diagnostics, with copy-paste examples for the report-vs-diagnostics split.

## What changed

`README.md` (+19) — a "Saving diagnostics to a file" note under the `--verbose`/`--debug` section:

- report → stdout, diagnostics → stderr file: `… --format json >report.json 2>diagnostics.log`
- human report on screen, diagnostics → file: `… 2>diagnostics.log`
- everything in one file: `… &>everything.log`

It also clarifies that with `--format json`/`sarif` the stderr file is diagnostics-only, while `--format human` additionally carries the plain `[phase]` progress lines.

## Reviewer notes

- Docs-only; no flags or behavior change. The diagnostics feature merged in #27.
- Not adding a `--log-file` flag is deliberate — diagnostics are a separate stream (stderr), so redirection is the mechanism.

Refs: TR-213
