### PR TITLE
docs(cli): expand -h help across all commands + fix --detectors filter

### DIFF
--- a/cmd/trustabl/llm.go
+++ b/cmd/trustabl/llm.go
@@ -17,6 +17,17 @@ func newLLMCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "llm",
 		Short: "Manage LLM provider configuration",
+		Long: `Manage the optional LLM provider configuration (provider, model, and API key)
+used for bring-your-own-key enrichment. Configuration is stored in your user
+config directory with 0600 permissions.
+
+NOTE: LLM enrichment is not wired into the scan yet. These commands only store
+the provider, model, and key for that future path — no scan makes an LLM call
+today, with or without a key configured.`,
+		Example: `  # One-time setup
+  trustabl llm provider set anthropic
+  trustabl llm key set
+  trustabl llm list`,
 	}
 	cmd.AddCommand(newLLMListCommand())
 	cmd.AddCommand(newLLMKeyCommand())
@@ -31,7 +42,10 @@ func newLLMListCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
 		Short: "Show current LLM configuration",
-		Args:  cobra.NoArgs,
+		Long: `Show the configured providers, their models, and masked API keys. The active
+provider is marked with an asterisk (*).`,
+		Example: "  trustabl llm list",
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runLLMList(cmd)
 		},
@@ -72,6 +86,11 @@ func newLLMKeyCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "key",
 		Short: "Manage the API key for the active provider",
+		Long: `Manage the API key for the active provider (set, get, delete). Keys are stored in
+your user config directory with 0600 permissions and are shown masked.`,
+		Example: `  trustabl llm key set
+  trustabl llm key get
+  trustabl llm key delete`,
 	}
 	cmd.AddCommand(newLLMKeySetCommand())
 	cmd.AddCommand(newLLMKeyGetCommand())
@@ -83,7 +102,15 @@ func newLLMKeySetCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "set [key]",
 		Short: "Store the API key for the active provider",
-		Args:  cobra.MaximumNArgs(1),
+		Long: `Store the API key for the active provider. Pass the key as an argument, or omit
+it to be prompted (the key is read from the terminal without echo). The key is
+validated against the active provider's expected format before it is saved.`,
+		Example: `  # Prompt for the key (not echoed)
+  trustabl llm key set
+
+  # Pass the key directly (note: it may be saved in shell history)
+  trustabl llm key set sk-ant-...`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runLLMKeySet(cmd, args)
 		},
@@ -123,9 +150,11 @@ func runLLMKeySet(cmd *cobra.Command, args []string) error {
 
 func newLLMKeyGetCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "get",
-		Short: "Show the stored API key (masked)",
-		Args:  cobra.NoArgs,
+		Use:     "get",
+		Short:   "Show the stored API key (masked)",
+		Long:    "Show the stored API key for the active provider, masked (only a few trailing\ncharacters are revealed).",
+		Example: "  trustabl llm key get",
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runLLMKeyGet(cmd)
 		},
@@ -148,9 +177,11 @@ func runLLMKeyGet(cmd *cobra.Command) error {
 
 func newLLMKeyDeleteCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "delete",
-		Short: "Delete the stored API key for the active provider",
-		Args:  cobra.NoArgs,
+		Use:     "delete",
+		Short:   "Delete the stored API key for the active provider",
+		Long:    "Delete the stored API key for the active provider. You are asked to confirm\nbefore the key is removed.",
+		Example: "  trustabl llm key delete",
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runLLMKeyDelete(cmd)
 		},
@@ -186,8 +217,10 @@ func runLLMKeyDelete(cmd *cobra.Command) error {
 
 func newLLMModelCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "model",
-		Short: "Manage the model for the active provider",
+		Use:     "model",
+		Short:   "Manage the model for the active provider",
+		Long:    "Manage the model used for the active provider.",
+		Example: "  trustabl llm model set claude-sonnet-4",
 	}
 	cmd.AddCommand(newLLMModelSetCommand())
 	return cmd
@@ -195,9 +228,11 @@ func newLLMModelCommand() *cobra.Command {
 
 func newLLMModelSetCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "set <model>",
-		Short: "Set the model for the active provider",
-		Args:  cobra.ExactArgs(1),
+		Use:     "set <model>",
+		Short:   "Set the model for the active provider",
+		Long:    "Set the model identifier for the active provider (e.g. a Claude or GPT model\nname). The value is stored as-is and is not validated against the provider.",
+		Example: "  trustabl llm model set claude-sonnet-4",
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runLLMModelSet(cmd, args[0])
 		},
@@ -223,6 +258,10 @@ func newLLMProviderCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "provider",
 		Short: "Manage LLM providers",
+		Long: `Manage which LLM provider is active and list the providers you have configured.
+Setting a provider that has no key yet prompts you to run "trustabl llm key set".`,
+		Example: `  trustabl llm provider list
+  trustabl llm provider set anthropic`,
 	}
 	cmd.AddCommand(newLLMProviderSetCommand())
 	cmd.AddCommand(newLLMProviderListCommand())
@@ -233,7 +272,11 @@ func newLLMProviderSetCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "set <provider>",
 		Short: "Set the active LLM provider",
-		Args:  cobra.ExactArgs(1),
+		Long: `Set the active LLM provider. The provider must be one Trustabl knows about; an
+unknown name is rejected with the list of known providers. If the chosen provider
+has no API key yet, you are reminded to run "trustabl llm key set".`,
+		Example: "  trustabl llm provider set anthropic",
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runLLMProviderSet(cmd, args[0])
 		},
@@ -264,9 +307,11 @@ func runLLMProviderSet(cmd *cobra.Command, provider string) error {
 
 func newLLMProviderListCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "list",
-		Short: "List configured LLM providers",
-		Args:  cobra.NoArgs,
+		Use:     "list",
+		Short:   "List configured LLM providers",
+		Long:    "List the providers you have configured. The active provider is marked with an\nasterisk (*).",
+		Example: "  trustabl llm provider list",
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runLLMProviderList(cmd)
 		},

--- a/cmd/trustabl/main.go
+++ b/cmd/trustabl/main.go
@@ -4,6 +4,8 @@
 //
 //	trustabl scan <target> [flags]   primary command: scan a repo
 //	trustabl mcp [flags]             run a stdio MCP server exposing the scan
+//	trustabl rules pull [flags]      pre-fetch the detection rule packs
+//	trustabl llm ...                 manage optional LLM provider config (BYOK)
 //	trustabl version                 print version
 //
 // Exit codes:
@@ -48,8 +50,35 @@ func main() {
 	rootCmd := &cobra.Command{
 		Use:   "trustabl",
 		Short: "Static analyzer for agent reliability",
-		Long: "Trustabl scans agent SDK repos (Claude Agent SDK, OpenAI Agents SDK,\n" +
-			"MCP) for reliability and safety weaknesses and reports the findings.",
+		Long: `Trustabl is a static analyzer for AI-agent codebases.
+
+It scans repositories that use agent SDKs — Claude Agent SDK, OpenAI Agents SDK,
+Google ADK, LangChain, CrewAI, Pydantic AI, Vercel AI, and AutoGen — and Model
+Context Protocol (MCP) servers, then reports reliability and safety weaknesses in
+the tools, agents, and subagents it discovers. Python and TypeScript codebases
+are analyzed in depth; JavaScript and Go are recognized during recon but not yet
+AST-parsed.
+
+Detection rules are not built into this binary: they are resolved from the
+trustabl-rules repository at scan time and cached locally, with an offline
+fallback. Run "trustabl rules pull" to pre-fetch them.
+
+Exit codes: 0 = clean (no finding >= medium), 1 = findings >= medium (or >= low
+with --strict), 2 = scanner error or no usable rules.`,
+		Example: `  # Scan the current directory
+  trustabl scan .
+
+  # Scan a public GitHub repository
+  trustabl scan https://github.com/owner/repo
+
+  # Fail CI on any finding (low severity and above)
+  trustabl scan . --strict
+
+  # SARIF output for GitHub code scanning
+  trustabl scan . --format sarif -o trustabl.sarif
+
+  # Pre-download the rule packs for offline use
+  trustabl rules pull`,
 		SilenceUsage:  true,
 		SilenceErrors: true, // we handle error printing ourselves below
 	}

--- a/cmd/trustabl/main_test.go
+++ b/cmd/trustabl/main_test.go
@@ -132,6 +132,19 @@ func TestParseCategories(t *testing.T) {
 			want: []models.DetectorCategory{models.CategoryOpenShell},
 		},
 		{
+			// Regression: every shipped SDK category must be filterable, not just
+			// the original five — parseCategories used to reject langchain, crewai,
+			// pydantic_ai, vercel_ai, and autogen.
+			name: "langchain",
+			in:   "langchain",
+			want: []models.DetectorCategory{models.CategoryLangChain},
+		},
+		{
+			name: "autogen and vercel_ai combined",
+			in:   "autogen,vercel_ai",
+			want: []models.DetectorCategory{models.CategoryAutoGen, models.CategoryVercelAI},
+		},
+		{
 			// Regression: the combined form from README § Use.
 			name: "claude_sdk and openai_sdk combined",
 			in:   "claude_sdk,openai_sdk",

--- a/cmd/trustabl/mcp.go
+++ b/cmd/trustabl/mcp.go
@@ -42,6 +42,16 @@ func newMCPCommand() *cobra.Command {
 			"and returns the structured result as JSON.\n\n" +
 			"The MCP protocol uses stdout for its JSON-RPC stream, so this command\n" +
 			"writes nothing else to stdout; diagnostics go to stderr.",
+		Example: `  # Run the server (an MCP client normally launches this for you)
+  trustabl mcp
+
+  # Pin the rules ref the server resolves
+  trustabl mcp --rules-ref v1.2.0
+
+  # Example Claude Code / Cursor client config entry:
+  #   "mcpServers": {
+  #     "trustabl": { "command": "trustabl", "args": ["mcp"] }
+  #   }`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runMCP(cmd.Context(), f, logLevelFor(cmd))

--- a/cmd/trustabl/rules.go
+++ b/cmd/trustabl/rules.go
@@ -16,13 +16,34 @@ func newRulesCommand() *cobra.Command {
 	rulesCmd := &cobra.Command{
 		Use:   "rules",
 		Short: "Manage Trustabl's detection rules",
+		Long: `Manage Trustabl's detection rules.
+
+Rules live in the external trustabl-rules repository and are resolved
+automatically the first time you scan, then cached under your user cache
+directory (keyed by commit, with an offline fallback). You normally never run
+these commands — a scan fetches what it needs — but "rules pull" lets you
+pre-fetch the packs so a later scan can run offline.`,
+		Example: `  # Pre-download the rule packs into the local cache
+  trustabl rules pull`,
 	}
 
 	var repo, ref string
 	pull := &cobra.Command{
 		Use:   "pull",
 		Short: "Download the detection rule packs into the local cache",
-		Args:  cobra.NoArgs,
+		Long: `Download the detection rule packs into the local cache so later scans can run
+offline. By default this fetches the official trustabl-rules repository's default
+branch; override the source with --rules-repo / --rules-ref, or set the
+TRUSTABL_RULES_REPO environment variable.`,
+		Example: `  # Pull the official rules (default branch)
+  trustabl rules pull
+
+  # Pull a specific tag or branch
+  trustabl rules pull --rules-ref v1.2.0
+
+  # Pull from a fork or mirror
+  trustabl rules pull --rules-repo https://github.com/me/my-rules`,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			log := logx.New(os.Stderr, logLevelFor(cmd), diagColor(false))
 			if repo == "" {

--- a/cmd/trustabl/scan.go
+++ b/cmd/trustabl/scan.go
@@ -42,7 +42,53 @@ func newScanCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "scan <target>",
 		Short: "Scan a local repo or GitHub URL",
-		Args:  cobra.ExactArgs(1),
+		Long: `Scan a repository for agent reliability and safety weaknesses.
+
+<target> is either a local path (a directory or a single file) or a GitHub URL
+(https://github.com/owner/repo, optionally .../tree/<ref>). A remote target is
+cloned into a temporary directory for the scan and removed afterward.
+
+The scan discovers the tools, agents, subagents, and MCP servers in the repo,
+loads the rule packs for the SDKs it actually finds, and reports the findings.
+Detection rules are resolved from the trustabl-rules repository and cached
+locally; pass --no-rules-update to run fully offline from that cache, or
+--rules-ref to pin a branch or tag.
+
+The report is written to stdout in the chosen --format (human, json, or sarif).
+Use --output/-o to write it to a file instead, or --json-out / --sarif-out to
+persist those formats alongside the stdout report. All progress, diagnostics, and
+warnings go to stderr, so stdout stays byte-stable for machine consumers.
+
+Exit codes:
+  0  no findings of medium severity or higher
+  1  one or more findings >= medium (or >= low with --strict; info/META
+     signals never raise the exit code)
+  2  scanner / I/O error, or no usable rules`,
+		Example: `  # Human-readable scan of the current directory
+  trustabl scan .
+
+  # Scan a GitHub repo at a specific branch or tag
+  trustabl scan https://github.com/owner/repo/tree/main
+
+  # JSON to stdout, or to a file
+  trustabl scan . --format json
+  trustabl scan . --format json -o report.json
+
+  # SARIF for a GitHub code-scanning upload
+  trustabl scan . --format sarif -o trustabl.sarif
+
+  # Print the human panel but also save machine artifacts
+  trustabl scan . --json-out report.json --sarif-out trustabl.sarif
+
+  # Strict CI gate: any finding (low and above) fails the run
+  trustabl scan . --strict
+
+  # Limit to specific detector categories
+  trustabl scan . --detectors claude_sdk,mcp
+
+  # Offline: use the cached rules without fetching
+  trustabl scan . --no-rules-update`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runScan(args[0], f, logLevelFor(cmd))
 		},

--- a/cmd/trustabl/scan.go
+++ b/cmd/trustabl/scan.go
@@ -94,7 +94,7 @@ Exit codes:
 		},
 	}
 	cmd.Flags().StringVar(&f.detectors, "detectors", "",
-		"comma-separated detector categories: claude_sdk, openai_sdk, openshell, google_adk, mcp (default: all)")
+		"comma-separated detector categories to run (default: all): "+categoryList())
 	cmd.Flags().StringVar(&f.format, "format", "human",
 		"output format: human|json|sarif")
 	cmd.Flags().StringVarP(&f.output, "output", "o", "",
@@ -591,13 +591,21 @@ func parseCategories(s string) ([]models.DetectorCategory, error) {
 	var out []models.DetectorCategory
 	for _, raw := range strings.Split(s, ",") {
 		c := models.DetectorCategory(strings.TrimSpace(raw))
-		switch c {
-		case models.CategoryClaudeSDK, models.CategoryOpenAISDK,
-			models.CategoryOpenShell, models.CategoryGoogleADK, models.CategoryMCP:
-			out = append(out, c)
-		default:
-			return nil, fmt.Errorf("unknown detector category %q (allowed: claude_sdk, openai_sdk, openshell, google_adk, mcp)", c)
+		if !models.ValidCategory(c) {
+			return nil, fmt.Errorf("unknown detector category %q (allowed: %s)", c, categoryList())
 		}
+		out = append(out, c)
 	}
 	return out, nil
+}
+
+// categoryList renders the recognized detector categories as a comma-separated
+// string, sourced from models.AllCategories so the --detectors help text and the
+// validation error never drift from what the engine actually recognizes.
+func categoryList() string {
+	names := make([]string, len(models.AllCategories))
+	for i, c := range models.AllCategories {
+		names[i] = string(c)
+	}
+	return strings.Join(names, ", ")
 }

--- a/cmd/trustabl/version.go
+++ b/cmd/trustabl/version.go
@@ -9,7 +9,12 @@ import (
 func newVersionCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
-		Short: "Print version",
+		Short: "Print version, commit, and build date",
+		Long: `Print the Trustabl version, the git commit it was built from, and the build
+date. A binary built locally with "go build" reports "dev" / "none" / "unknown";
+released binaries carry real values injected at build time.`,
+		Example: "  trustabl version",
+		Args:    cobra.NoArgs,
 		Run: func(cmd *cobra.Command, _ []string) {
 			fmt.Fprintf(cmd.OutOrStdout(), "Trustabl %s\ncommit: %s\nbuilt:  %s\n",
 				version, commit, date)

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -67,17 +67,27 @@ const (
 	CategoryAutoGen    DetectorCategory = "autogen"
 )
 
-// ValidCategory reports whether c is a category this build recognizes. New SDK
-// categories are added here as coverage lands. The rule loader skips packs with
-// an unrecognized category leniently at runtime (forward-compat: a newer rules
-// release must not block an older binary from scanning the SDKs it knows) and
-// rejects them in strict (authoring/CI) mode so a typo'd category is caught.
+// AllCategories is every detector category this build recognizes, in a stable
+// display order. It is the single source of truth for category membership:
+// ValidCategory checks against it, and the CLI's --detectors flag derives its
+// help text and validation error from it (so neither drifts as coverage lands).
+// New SDK categories are added here as coverage lands.
+var AllCategories = []DetectorCategory{
+	CategoryClaudeSDK, CategoryOpenAISDK, CategoryOpenShell, CategoryGoogleADK,
+	CategoryMCP, CategoryLangChain, CategoryCrewAI, CategoryPydanticAI,
+	CategoryVercelAI, CategoryAutoGen,
+}
+
+// ValidCategory reports whether c is a category this build recognizes. The rule
+// loader skips packs with an unrecognized category leniently at runtime
+// (forward-compat: a newer rules release must not block an older binary from
+// scanning the SDKs it knows) and rejects them in strict (authoring/CI) mode so
+// a typo'd category is caught.
 func ValidCategory(c DetectorCategory) bool {
-	switch c {
-	case CategoryClaudeSDK, CategoryOpenAISDK, CategoryOpenShell, CategoryGoogleADK,
-		CategoryMCP, CategoryLangChain, CategoryCrewAI, CategoryPydanticAI,
-		CategoryVercelAI, CategoryAutoGen:
-		return true
+	for _, k := range AllCategories {
+		if c == k {
+			return true
+		}
 	}
 	return false
 }


### PR DESCRIPTION
Expands the `-h` help for the root command and every subcommand, and fixes a real gap in the `--detectors` filter. Independent of the language-coverage stack (touches `cmd/` + one `models` helper) — mergeable on its own against main.

## Help expansion (no behavior change)
Adds `Long` descriptions and `Example` blocks across the cobra tree so `trustabl -h` and each `<command> -h` is self-explanatory:
- **root** — what Trustabl scans, where rules come from, exit codes, common-invocation examples.
- **scan** — target forms (local path / GitHub URL), the discovery→rules→report pipeline, output routing (stdout vs `--output` / `--json-out` / `--sarif-out`), exit codes, and worked examples.
- **rules / rules pull** — the rule-cache model + pull examples.
- **mcp** — examples block with an MCP client-config snippet.
- **llm** (+ list/key/model/provider leaves) — per-command help, with an explicit note that LLM enrichment is not wired into the scan yet (commands only store config).
- **version** — `Long` + example.
- Refreshes the package-header subcommand list (it omitted `rules` and `llm`).

Language claims in the root help describe **this build's** actual support (Python/TS analyzed in depth; JS/Go recon-only) — accurate to main.

## `--detectors` fix
`parseCategories` accepted only 5 of the engine's categories, so a scan could not be filtered to `langchain`, `crewai`, `pydantic_ai`, `vercel_ai`, or `autogen` even though those packs ship and run by default. Now validates against `models.ValidCategory`, and both the `--detectors` help text and the validation error are derived from a new `models.AllCategories` (single source of truth) so neither drifts. Adds regression test cases for the previously-rejected categories.

## Tests
Full `go test ./...`, `go vet`, and `gofmt -l` pass.