### PR TITLE
fix(rules): forward-compatible unknown rule language (don't hard-fail)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,8 @@ resolution path fetches the configured ref, caches the clone under
 the network is unreachable. Rule loading is **forward-compatible**: a pack
 whose `manifest.yaml` `schema_version` exceeds the engine's
 `rules.SupportedSchemaVersion` is loaded leniently rather than refused — a rule
-referencing a `scope`, an `applies_to` value, or a predicate this build lacks is
+referencing a `scope`, an `applies_to` value, a `language`, or a predicate this
+build lacks is
 skipped (recorded on `ScanResult.RulesSkipped`, warned on stderr, and summarized
 in a `META-005` info finding) and the scan runs the rest. A malformed *known*
 rule — empty/missing required field, out-of-range confidence, duplicate ID — is

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -117,6 +117,29 @@ const (
 	LanguageGo         Language = "go"
 )
 
+// AllLanguages is every source language this build recognizes, in a stable
+// order. It is the single source of truth for language membership: ValidLanguage
+// checks against it, the strict rule loader builds its allow-list error from it,
+// and the lenient (runtime) loader uses it to decide whether a rule targets a
+// language this build does not understand — a forward-incompatible rule it skips
+// rather than hard-failing. New languages are added here as discovery lands.
+var AllLanguages = []Language{
+	LanguagePython, LanguageTypeScript, LanguageJavaScript, LanguageGo,
+}
+
+// ValidLanguage reports whether l is a source language this build recognizes.
+// Empty is NOT valid here: the loader treats an empty rule language as the
+// python default separately, so this answers only "is this an explicit, known
+// language". Mirrors ValidScope / ValidCategory.
+func ValidLanguage(l Language) bool {
+	for _, k := range AllLanguages {
+		if l == k {
+			return true
+		}
+	}
+	return false
+}
+
 // ToolDef is one discovered surface that an agent can invoke at runtime.
 // Mirrors the Tool Discovery node in architecture §2.
 type ToolDef struct {

--- a/internal/rules/loader.go
+++ b/internal/rules/loader.go
@@ -197,14 +197,14 @@ func loadPolicies(fsys fs.FS, lenient bool) ([]PolicyFile, []string, error) {
 					seenIDs[rule.ID] = name
 				}
 			}
-			if rule.Language != "" {
-				switch rule.Language {
-				case models.LanguagePython, models.LanguageTypeScript,
-					models.LanguageJavaScript, models.LanguageGo:
-					// valid
-				default:
-					errs = append(errs, fmt.Errorf("%s: unknown language %q (allowed: python, typescript, javascript, go)", tag, rule.Language))
-				}
+			// An explicit, unrecognized language is rejected in strict (authoring)
+			// mode so a typo is caught in CI. The lenient runtime path never reaches
+			// here for such a rule — decodePolicyFileLenient drops it as
+			// forward-incompatible (see ruleNeedsNewerEngine) — so a newer rules
+			// release does not break an older binary. Empty is fine (defaults to
+			// python). models.AllLanguages is the single source of truth.
+			if rule.Language != "" && !models.ValidLanguage(rule.Language) {
+				errs = append(errs, fmt.Errorf("%s: unknown language %q (allowed: %s)", tag, rule.Language, languageAllowList()))
 			}
 			if rule.Scope == "" {
 				errs = append(errs, fmt.Errorf("%s: scope is required (tool|agent|repo|subagent)", tag))
@@ -284,6 +284,17 @@ func loadPolicies(fsys fs.FS, lenient bool) ([]PolicyFile, []string, error) {
 		return nil, nil, errors.Join(errs...)
 	}
 	return policies, skipped, nil
+}
+
+// languageAllowList renders the recognized rule languages for the strict
+// validation error, sourced from models.AllLanguages so it never drifts from
+// what the loader actually accepts.
+func languageAllowList() string {
+	names := make([]string, len(models.AllLanguages))
+	for i, l := range models.AllLanguages {
+		names[i] = string(l)
+	}
+	return strings.Join(names, ", ")
 }
 
 // validRepoHasSDKInCode reports whether tok is a value RepoInventory.SDKsDetected
@@ -480,6 +491,16 @@ func ruleNeedsNewerEngine(ruleNode *yaml.Node, known map[string]bool) bool {
 				return true
 			}
 		}
+	}
+	// Unknown language: a source language (e.g. a future `ruby`) whose discovery
+	// this build lacks, so a rule targeting it can never match and was authored
+	// against a newer engine. Empty is NOT incompatible — it defaults to python (a
+	// known language), mirroring the empty-scope / empty-applies_to carve-out: an
+	// absent field is a default, only a present-but-unrecognized value is a
+	// newer-engine signal.
+	lang := models.Language(scalarValue(ruleNode, "language"))
+	if lang != "" && !models.ValidLanguage(lang) {
+		return true
 	}
 	// Unknown predicate key anywhere in the match tree: a predicate from a newer
 	// schema. A known predicate's nested struct keys are NOT match-level keys, so

--- a/internal/rules/loader_lenient_test.go
+++ b/internal/rules/loader_lenient_test.go
@@ -349,3 +349,65 @@ rules:
 		})
 	}
 }
+
+// TestLoadLenient_SkipsUnknownLanguage is the forward-compat contract for a NEW
+// language, and the regression guard for the v0.1.3 break: when csharp/php/rust
+// rules were merged, an older binary whose loader did not know those languages
+// hard-failed the ENTIRE rule load right after inventory — because the language
+// check rejected unknown values on the lenient runtime path too, unlike scope /
+// applies_to / predicates. Now a rule whose `language:` this build cannot produce
+// is dropped whole (its ID returned in skipped) while its known-language sibling
+// loads. Strict Load still rejects it so an authoring typo is caught in CI.
+func TestLoadLenient_SkipsUnknownLanguage(t *testing.T) {
+	const pack = `
+policy:
+  id: len
+  name: Lenient
+  category: claude_sdk
+  description: t
+rules:
+  - id: LEN-200
+    title: Known language rule
+    scope: tool
+    severity: low
+    confidence: 0.8
+    language: go
+    applies_to: [claude_sdk_tool]
+    match:
+      has_docstring: true
+    explanation: x
+    fix: y
+  - id: LEN-201
+    title: Future language rule
+    scope: tool
+    severity: high
+    confidence: 0.9
+    language: ruby
+    applies_to: [claude_sdk_tool]
+    match:
+      has_docstring: true
+    explanation: x
+    fix: y
+`
+	fsys := makeFS(map[string]string{"len.yaml": pack})
+	policies, skipped, err := rules.LoadLenient(fsys)
+	if err != nil {
+		t.Fatalf("LoadLenient unexpected error: %v", err)
+	}
+	ids := ruleIDs(policies)
+	if !ids["LEN-200"] {
+		t.Error("LEN-200 (known language go) should have loaded")
+	}
+	if ids["LEN-201"] {
+		t.Error("LEN-201 (unknown language `ruby`) should have been skipped, not loaded")
+	}
+	if len(skipped) != 1 || skipped[0] != "LEN-201" {
+		t.Errorf("skipped = %v, want [LEN-201]", skipped)
+	}
+
+	if _, err := rules.Load(fsys); err == nil {
+		t.Error("strict Load must error on an unknown language")
+	} else if !strings.Contains(err.Error(), "language") {
+		t.Errorf("strict Load error should name the language problem, got: %v", err)
+	}
+}

--- a/internal/rules/schema_version.go
+++ b/internal/rules/schema_version.go
@@ -7,9 +7,9 @@ package rules
 // Forward-compatible loading (see rules.LoadLenient): the engine NO LONGER
 // rejects a pack just because its schema_version exceeds this constant. It
 // loads the pack leniently — a rule that references a scope, applies_to value,
-// or predicate this build lacks is skipped (surfaced as a stderr warning, the
-// META-005 info finding, and ScanResult.RulesSkipped), and the scan proceeds
-// with the rules it does understand. A pack is refused only when it has no usable manifest
+// language, or predicate this build lacks is skipped (surfaced as a stderr
+// warning, the META-005 info finding, and ScanResult.RulesSkipped), and the scan
+// proceeds with the rules it does understand. A pack is refused only when it has no usable manifest
 // (ErrNoCompatibleRules) or when NO rule is evaluable at all
 // (ErrAllRulesIncompatible). This decouples additive rule updates from binary
 // upgrades: shipping a new predicate no longer locks every older binary out of


### PR DESCRIPTION
## The incident
Merging the language-rule PRs into `trustabl-rules` broke the released **v0.1.3** binary: scans exited immediately after the inventory phase.

**Root cause:** forward-compatible loading (`LoadLenient`) skips rules with an unknown `scope`, `applies_to` value, or match predicate — but the `language` check appended a **hard error** for any unrecognized value on **both** the strict and lenient paths. v0.1.3 recognizes only `python/typescript/javascript/go`, so the merged `language: csharp/php/rust` rules made it fail the *entire* rule load. Rule loading happens at the start of analysis (right after inventory), so the scan died there.

This is exactly the lockstep-upgrade failure mode forward-compat loading is supposed to prevent — `language` was simply missing from the forward-compat vocabulary.

## The fix
- `models.AllLanguages` is now the single source of truth for recognized languages; `models.ValidLanguage` checks against it (mirrors `ValidScope` / `ValidCategory`).
- `ruleNeedsNewerEngine` (the lenient detector) now treats a present-but-unrecognized `language:` as forward-incompatible — the rule is **dropped and recorded in `skipped`**, not hard-failed. Empty language stays the python default (not incompatible).
- Strict `Load` still hard-fails an unknown language (typo-catch in CI); its allow-list is rendered from `models.AllLanguages` so it can't drift.

## Test
`TestLoadLenient_SkipsUnknownLanguage`: `LoadLenient` skips a `language: ruby` rule while its sibling loads; strict `Load` still errors. Full `go test ./...`, `go vet`, `gofmt` pass.

## Rollout / ordering
1. **Now:** merge the rules hotfix (`trustabl-rules` #20) to restore v0.1.3.
2. **This PR → cut v0.1.4** so a forward-compatible build exists.
3. **After v0.1.4 is the floor:** re-merge the csharp/php/rust rules. v0.1.4+ skip what they can't evaluate; only pre-v0.1.4 binaries are affected (unavoidable — they predate the fix — but it never recurs after).

Note: this is the loader's forward-compat fix only; it's independent of the C#/PHP/Rust **discovery** PRs (#31/#32/#33).