### PR TITLE
feat(rules): surface stale cached rules as a warning (TR-272 D)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -156,7 +156,9 @@ it. Verification is fail-closed —
 a bad signature, an untrusted/expired key, channel confusion, an expired or
 rolled-back statement, or a digest mismatch each refuse the scan (exit 2)
 rather than running unverified rules; only a remote-contact failure degrades to
-the last verified bundle (marked stale past its statement's expiry). The
+the last verified bundle (marked stale past its statement's expiry — surfaced
+on `ScanResult.RulesStale` and as a louder "rules may be out of date" stderr
+warning). The
 provenance of the rules (`models.RulesOrigin`: signed channel / unsigned
 custom / unsigned default) is surfaced as a report watermark and folded into
 `ScanID`. The default scan is unchanged — `gitSource` stays the default until

--- a/cmd/trustabl/scan.go
+++ b/cmd/trustabl/scan.go
@@ -330,12 +330,16 @@ func resolveAndScan(cfg *scanner.Config, f scanFlags, rep progress.Reporter) (mo
 	if res.SchemaNewer {
 		summary += " (newer schema)"
 	}
+	if res.Stale {
+		summary += " (stale)"
+	}
 	rep.EndPhase(summary)
 
 	cfg.RulesFS = res.FS
 	cfg.RulesSource = res.RepoURL
 	cfg.RulesVersion = res.SHA
 	cfg.RulesFromCache = res.FromCache
+	cfg.RulesStale = res.Stale
 	cfg.RulesSchemaVersion = res.SchemaVersion
 	cfg.RulesSchemaNewer = res.SchemaNewer
 	cfg.RulesOrigin = rulesOriginFromScan(f)
@@ -418,10 +422,17 @@ func finishScan(result models.ScanResult, jobErr error, f scanFlags, log *logx.L
 		return jobErr
 	}
 
-	// In silent mode (JSON or --no-progress) the "(cached, offline)" rules
-	// phase line is suppressed, so surface the cache-fallback as a stderr
-	// warning — stale rules should never be used without a human-visible signal.
-	if result.RulesFromCache && pickScanMode(f, log) == progress.ModeOff {
+	// In silent mode (JSON or --no-progress) the "(cached, offline)" rules phase
+	// line is suppressed, so surface a cache fallback as a stderr warning — stale
+	// rules should never be used without a human-visible signal. A stale bundle
+	// (its signed-channel statement has expired) gets a louder, distinct message
+	// and takes precedence over the plain cache-fallback warning.
+	switch {
+	case result.RulesStale && pickScanMode(f, log) == progress.ModeOff:
+		fmt.Fprintf(os.Stderr,
+			"warning: using cached rules %s whose signed channel statement has expired; the rules may be out of date. Run 'trustabl rules pull' when back online.\n",
+			result.RulesVersion)
+	case result.RulesFromCache && pickScanMode(f, log) == progress.ModeOff:
 		fmt.Fprintf(os.Stderr,
 			"warning: using cached rules %s; could not fetch or use newer rules\n",
 			result.RulesVersion)

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -463,6 +463,7 @@ type ScanResult struct {
 	RulesSource         string             `json:"rules_source"`                   // repo the rule pack came from
 	RulesVersion        string             `json:"rules_version"`                  // resolved rules commit SHA
 	RulesFromCache      bool               `json:"rules_from_cache"`               // true if rules came from cache (network skipped/unreachable)
+	RulesStale          bool               `json:"rules_stale,omitempty"`          // true if the cached signed bundle's channel statement has expired
 	RulesSchemaVersion  int                `json:"rules_schema_version,omitempty"` // pack manifest's declared schema_version
 	RulesSchemaNewer    bool               `json:"rules_schema_newer,omitempty"`   // pack targets a schema newer than this build supports
 	RulesSkipped        []string           `json:"rules_skipped,omitempty"`        // rule IDs dropped as forward-incompatible (sorted, deduped)

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -40,6 +40,10 @@ type Config struct {
 	RulesSource    string
 	RulesVersion   string
 	RulesFromCache bool
+	// RulesStale is true when an offline fallback served a cached signed bundle
+	// whose channel statement has expired (rulesource.Resolved.Stale). Surfaced on
+	// ScanResult and used by the CLI's louder "rules may be out of date" warning.
+	RulesStale bool
 	// RulesSchemaVersion is the resolved pack manifest's schema_version, and
 	// RulesSchemaNewer is true when it exceeds this build's support. Surfaced on
 	// ScanResult and used by the CLI's "rules newer than this build" warning.
@@ -481,6 +485,7 @@ func Run(cfg Config) (models.ScanResult, error) {
 		RulesSource:         cfg.RulesSource,
 		RulesVersion:        cfg.RulesVersion,
 		RulesFromCache:      cfg.RulesFromCache,
+		RulesStale:          cfg.RulesStale,
 		RulesSchemaVersion:  cfg.RulesSchemaVersion,
 		RulesSchemaNewer:    cfg.RulesSchemaNewer,
 		RulesSkipped:        sortedUnique(rulesSkipped),

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -199,6 +199,21 @@ func TestScan_PopulatesSkillDependencyBOM(t *testing.T) {
 	}
 }
 
+// TestScanRun_ThreadsRulesStale proves the Batch-D wiring: Config.RulesStale
+// (set by the CLI from rulesource.Resolved.Stale) surfaces on
+// ScanResult.RulesStale, which the CLI turns into the louder "rules may be out
+// of date" warning.
+func TestScanRun_ThreadsRulesStale(t *testing.T) {
+	dir := t.TempDir()
+	res, err := scanner.Run(scanner.Config{Target: dir, RulesFS: rulesFixture(t), RulesStale: true})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !res.RulesStale {
+		t.Error("Config.RulesStale=true should surface as ScanResult.RulesStale=true")
+	}
+}
+
 // rulesFixture returns the Phase-1 interim rule packs for tests.
 func rulesFixture(t *testing.T) fs.FS {
 	t.Helper()


### PR DESCRIPTION
## Summary
Audit remediation **Batch D** (TR-274) — close a half-wired feature.

`rulesource.Resolved.Stale` is set when an offline fallback serves a cached *signed* bundle whose channel statement has expired, but **nothing consumed it** — so ARCHITECTURE's "rules may be out of date" promise (and the field's own doc) had no implementation.

This threads it through the same path as `RulesFromCache`:
`Resolved.Stale` → `Config.RulesStale` → `ScanResult.RulesStale` → a louder, distinct stderr warning that takes precedence over the plain cache-fallback one (plus a `(stale)` marker on the rules phase line in TTY mode).

## Safety
- `json:"rules_stale,omitempty"` → non-stale scans' JSON is byte-identical to before.
- `ScanID` unchanged — `Stale` is provenance, not folded into the ID (same as `RulesFromCache`).
- Latent path (signed channels are inert until keys are published), so zero behavior change on the default `gitSource` path today.

## Tests
`TestScanRun_ThreadsRulesStale` asserts the Config→ScanResult threading; `go test ./...`, gofmt, vet all green.

Refs: TR-274
