### PR TITLE
fix(discovery): tighten MCP/Claude false-positive & false-negative matches (TR-272 B)

### DIFF
--- a/internal/analysis/discovery.go
+++ b/internal/analysis/discovery.go
@@ -214,7 +214,7 @@ func kindFromDecorators(decs []*sitter.Node, src []byte, toolImports map[string]
 			return models.KindClaudeSDKTool
 		case callee == "claude_tool" || last == "claude_tool",
 			callee == "agent.tool",
-			strings.Contains(callee, "claude_agent_sdk"):
+			strings.HasPrefix(callee, "claude_agent_sdk."):
 			return models.KindClaudeSDKTool
 		// MCP registrations.
 		case callee == "server.tool" || callee == "mcp.tool",

--- a/internal/analysis/go_mcp.go
+++ b/internal/analysis/go_mcp.go
@@ -166,7 +166,11 @@ func goToolStructFields(lit *sitter.Node, src []byte) (name, desc string, ok boo
 		return "", "", false
 	}
 	typeText := astutil.NodeText(typeNode, src)
-	if !strings.HasSuffix(typeText, "Tool") {
+	// Match the official SDK's tool type exactly (mcp.Tool, or bare Tool under a
+	// dot-import / in-package use) rather than any struct whose name ends in
+	// "Tool", so a custom argument like &MyCustomTool{...} passed to mcp.AddTool
+	// is not mistaken for a tool definition.
+	if typeText != "mcp.Tool" && typeText != "Tool" {
 		return "", "", false
 	}
 	body := lit.ChildByFieldName("body")
@@ -197,7 +201,10 @@ func goToolStructFields(lit *sitter.Node, src []byte) (name, desc string, ok boo
 			}
 		}
 	}
-	return name, desc, name != "" || desc != ""
+	// A tool must have a Name; a literal carrying only a Description is not a
+	// usable tool definition (and an empty-name ToolDef would be a phantom that
+	// could fire a "missing name" rule).
+	return name, desc, name != ""
 }
 
 // goUnwrapLiteralElement returns the inner expression of a literal_element

--- a/internal/analysis/go_mcp_test.go
+++ b/internal/analysis/go_mcp_test.go
@@ -118,3 +118,28 @@ func run() {
 		t.Errorf("non-mcp-go import must gate out; got %d: %+v", len(tools), tools)
 	}
 }
+
+// TestDiscoverGoMCPTools_RejectsCustomToolAndEmptyName guards the official-SDK
+// extractor: only a real &mcp.Tool{Name: ...} is a tool. A custom struct whose
+// type merely ends in "Tool", and an mcp.Tool literal with no Name, must not
+// produce phantom ToolDefs.
+func TestDiscoverGoMCPTools_RejectsCustomToolAndEmptyName(t *testing.T) {
+	src := `package main
+
+import "github.com/modelcontextprotocol/go-sdk/mcp"
+
+func run() {
+	server := mcp.NewServer(&mcp.Implementation{Name: "g"}, nil)
+	mcp.AddTool(server, &mcp.Tool{Name: "real", Description: "d"}, nil)
+	mcp.AddTool(server, &MyCustomTool{Name: "phantom"}, nil)
+	mcp.AddTool(server, &mcp.Tool{Description: "no name"}, nil)
+}
+`
+	tools := analysis.DiscoverGoMCPTools([]analysis.ParsedFile{parseGoForTest(t, src)}, nil)
+	if len(tools) != 1 {
+		t.Fatalf("only the named &mcp.Tool should be discovered; got %d: %+v", len(tools), tools)
+	}
+	if tools[0].Name != "real" {
+		t.Errorf("name = %q, want real", tools[0].Name)
+	}
+}

--- a/internal/analysis/php_mcp.go
+++ b/internal/analysis/php_mcp.go
@@ -18,6 +18,10 @@ import (
 var (
 	phpAttrNameRe = regexp.MustCompile(`\bname\s*:\s*['"]([^'"]*)['"]`)
 	phpAttrDescRe = regexp.MustCompile(`\bdescription\s*:\s*['"]([^'"]*)['"]`)
+	// phpMcpToolNameRe matches the McpTool attribute name as a whole word, so a
+	// different attribute such as #[McpToolbox] or #[McpToolFactory] is not
+	// mistaken for #[McpTool].
+	phpMcpToolNameRe = regexp.MustCompile(`\bMcpTool\b`)
 )
 
 // DiscoverPHPMCPTools walks each parsed PHP file and emits a ToolDef per
@@ -106,7 +110,7 @@ func discoverPHPMCPToolsInFile(pf ParsedFile) []models.ToolDef {
 func phpMcpToolAttrComment(method *sitter.Node, src []byte) (string, bool) {
 	for cur := method.PrevNamedSibling(); cur != nil && cur.Type() == "comment"; cur = cur.PrevNamedSibling() {
 		text := strings.TrimSpace(astutil.NodeText(cur, src))
-		if strings.HasPrefix(text, "#[") && strings.Contains(text, "McpTool") {
+		if strings.HasPrefix(text, "#[") && phpMcpToolNameRe.MatchString(text) {
 			return text, true
 		}
 	}
@@ -121,7 +125,7 @@ func phpUsesMCP(root *sitter.Node, src []byte) bool {
 		if found {
 			return false
 		}
-		if n.Type() == "namespace_use_declaration" && strings.Contains(astutil.NodeText(n, src), "Mcp") {
+		if n.Type() == "namespace_use_declaration" && strings.Contains(astutil.NodeText(n, src), "Mcp\\") {
 			found = true
 			return false
 		}

--- a/internal/analysis/php_mcp_test.go
+++ b/internal/analysis/php_mcp_test.go
@@ -78,3 +78,45 @@ class Tools {
 		t.Errorf("file without a `use ...Mcp...` must gate out; got %d: %+v", len(tools), tools)
 	}
 }
+
+// TestDiscoverPHPMCPTools_McpToolboxNotMatched guards against the substring
+// match: #[McpToolbox] / #[McpToolFactory] are different attributes and must not
+// be read as #[McpTool].
+func TestDiscoverPHPMCPTools_McpToolboxNotMatched(t *testing.T) {
+	src := `<?php
+use PhpMcp\Server\Attributes\McpTool;
+
+class Tools {
+    #[McpToolbox(name: 'notatool')]
+    public function box(): void {}
+
+    #[McpTool(name: 'real')]
+    public function real(int $a): int { return $a; }
+}
+`
+	tools := analysis.DiscoverPHPMCPTools([]analysis.ParsedFile{parsePHPForTest(t, src)}, nil)
+	if len(tools) != 1 {
+		t.Fatalf("only #[McpTool] should match, not #[McpToolbox]; got %d: %+v", len(tools), tools)
+	}
+	if tools[0].Name != "real" {
+		t.Errorf("name = %q, want real", tools[0].Name)
+	}
+}
+
+// TestDiscoverPHPMCPTools_McpenzieNamespaceNotGate guards the file gate: an
+// unrelated `use App\Mcpenzie\...` (which merely contains "Mcp") must not open
+// the MCP gate.
+func TestDiscoverPHPMCPTools_McpenzieNamespaceNotGate(t *testing.T) {
+	src := `<?php
+use App\Mcpenzie\Client;
+
+class Tools {
+    #[McpTool(name: 'add')]
+    public function add(int $a): int { return $a; }
+}
+`
+	tools := analysis.DiscoverPHPMCPTools([]analysis.ParsedFile{parsePHPForTest(t, src)}, nil)
+	if len(tools) != 0 {
+		t.Errorf("a non-MCP `use App\\Mcpenzie\\...` must not open the gate; got %d: %+v", len(tools), tools)
+	}
+}

--- a/internal/analysis/rust_mcp.go
+++ b/internal/analysis/rust_mcp.go
@@ -174,7 +174,7 @@ func rustUsesMCP(root *sitter.Node, src []byte) bool {
 		if found {
 			return false
 		}
-		if n.Type() == "use_declaration" && strings.Contains(astutil.NodeText(n, src), "rmcp") {
+		if n.Type() == "use_declaration" && strings.Contains(astutil.NodeText(n, src), "rmcp::") {
 			found = true
 			return false
 		}

--- a/internal/analysis/rust_mcp_test.go
+++ b/internal/analysis/rust_mcp_test.go
@@ -94,3 +94,20 @@ impl Calculator {
 		t.Errorf("file without a `use rmcp` must gate out; got %d: %+v", len(tools), tools)
 	}
 }
+
+// TestDiscoverRustMCPTools_WarmcpNotGate guards the file gate: a `use
+// warmcp_utils::...` (which merely contains the substring "rmcp") is not the
+// rmcp crate and must not open the gate.
+func TestDiscoverRustMCPTools_WarmcpNotGate(t *testing.T) {
+	src := `use warmcp_utils::Helper;
+
+impl Calculator {
+    #[tool(description = "Add")]
+    fn add(&self) -> String { String::new() }
+}
+`
+	tools := analysis.DiscoverRustMCPTools([]analysis.ParsedFile{parseRustForTest(t, src)}, nil)
+	if len(tools) != 0 {
+		t.Errorf("a `use warmcp_utils` (not the rmcp crate) must gate out; got %d: %+v", len(tools), tools)
+	}
+}

--- a/internal/analysis/skills.go
+++ b/internal/analysis/skills.go
@@ -197,6 +197,11 @@ func dedupeStrings(in []string) []string {
 const maxBundledScriptScanBytes = 1 << 20 // 1 MiB
 
 var (
+	// bundledCommentRe matches a shell/python `#` line comment (from the first
+	// `#` to end of line). The "script does X" facts (egress / secret read) are
+	// matched against comment-stripped content so a word like `curl` or
+	// `credentials` mentioned only in a comment is not read as a real call.
+	bundledCommentRe = regexp.MustCompile(`(?m)#.*$`)
 	// bundledEgressRe matches a network-egress invocation in a bundled script
 	// (curl / wget / nc / ...). Mirrors the dynamic-exec egress check.
 	bundledEgressRe = regexp.MustCompile(`(?i)\b(?:curl|wget|nc|ncat|telnet|scp|sftp|rsync)\b`)
@@ -255,10 +260,14 @@ func bundledFiles(repoRoot, skillPath string) []models.BundledFile {
 		// literal — both surfaces that scanning SKILL.md alone misses.
 		if bf.Kind != "binary" {
 			if content, rerr := readCapped(abs, maxBundledScriptScanBytes); rerr == nil {
+				// A committed secret literal counts even inside a comment, so scan raw.
 				bf.HasHardcodedSecret = bundledSecretLiteralRe.Match(content)
 				if bf.Kind == "script" {
-					bf.HasNetworkEgress = bundledEgressRe.Match(content)
-					bf.ReadsSecrets = bundledSecretRe.Match(content)
+					// Egress / secret-read describe executed behavior, so strip `#`
+					// line comments first: `# never curl secrets` is not a real call.
+					code := bundledCommentRe.ReplaceAll(content, nil)
+					bf.HasNetworkEgress = bundledEgressRe.Match(code)
+					bf.ReadsSecrets = bundledSecretRe.Match(code)
 				}
 			}
 		}

--- a/internal/analysis/skills_test.go
+++ b/internal/analysis/skills_test.go
@@ -100,6 +100,34 @@ func TestSkills_BodyFacts_DynamicExec(t *testing.T) {
 	}
 }
 
+// TestSkills_BundledScript_CommentStrippedFromEgressSecretScan proves the
+// executed-behavior facts (egress / secret read) ignore `#` line comments: a
+// `curl` or `credentials` word that appears only in a comment must not flag,
+// while a real call still does.
+func TestSkills_BundledScript_CommentStrippedFromEgressSecretScan(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, ".claude/skills/s/SKILL.md", "---\nname: s\ndescription: d\n---\n# S\n")
+	// notes.sh: curl/credentials appear ONLY in a comment → must not flag.
+	writeFixture(t, dir, ".claude/skills/s/notes.sh", "#!/bin/sh\n# never curl secrets or read credentials here\necho ok\n")
+	// run.sh: a real egress call → must still flag.
+	writeFixture(t, dir, ".claude/skills/s/run.sh", "#!/bin/sh\ncurl -s https://example.com/x\n")
+	manifest := models.ScanManifest{RepoRoot: dir, MarkdownFiles: []string{".claude/skills/s/SKILL.md"}}
+	got := analysis.DiscoverSkills(manifest)
+	if len(got) != 1 {
+		t.Fatalf("got %d skills, want 1", len(got))
+	}
+	facts := map[string]models.BundledFile{}
+	for _, b := range got[0].BundledFiles {
+		facts[b.Path] = b
+	}
+	if b := facts[".claude/skills/s/notes.sh"]; b.HasNetworkEgress || b.ReadsSecrets {
+		t.Errorf("curl/credentials in a comment must not flag egress/secret: %+v", b)
+	}
+	if b := facts[".claude/skills/s/run.sh"]; !b.HasNetworkEgress {
+		t.Errorf("a real `curl https://...` must still set HasNetworkEgress: %+v", b)
+	}
+}
+
 func TestSkills_BodyFacts_URLsAndInjectionMarkers(t *testing.T) {
 	dir := t.TempDir()
 	// Instruction-override phrasing, a zero-width space (U+200B), and an external


### PR DESCRIPTION
## Summary
Audit remediation **Batch B** (TR-275) — tighten the discovery layer's false-positive and false-negative matches. Several gates relied on loose substring/suffix matching.

| Site | Was | Now |
|---|---|---|
| `go_mcp.go` | `HasSuffix(type, "Tool")` → `&MyCustomTool{}` phantom; empty Name accepted | exact `mcp.Tool`/`Tool`; require `Name` |
| `php_mcp.go` | `Contains("McpTool")` matches `#[McpToolbox]`; gate `Contains("Mcp")` matches `App\Mcpenzie` | `\bMcpTool\b`; gate requires `Mcp\` segment |
| `rust_mcp.go` | gate `Contains("rmcp")` matches `warmcp_utils` | requires `rmcp::` |
| `discovery.go` | `Contains(callee, "claude_agent_sdk")` matches `claude_agent_sdk_compat.tool` | exact module prefix `claude_agent_sdk.` |
| `skills.go` | egress/secret regex matches `curl`/`credentials` **inside `#` comments** | scan comment-stripped content (the secret-literal scan still reads raw) |

Each is a strictly-tighter match: a phantom/false-positive removed, or (discovery) a rare mis-tag removed, with no loss of a real detection — proven by the new fire/silent tests and the unchanged existing suite.

## Tests
New cases: `RejectsCustomToolAndEmptyName` (go), `McpToolboxNotMatched` + `McpenzieNamespaceNotGate` (php), `WarmcpNotGate` (rust), `CommentStrippedFromEgressSecretScan` (skills). `go test ./...`, gofmt, vet all green.

## Deferred (own follow-up ticket)
Two lower-frequency items from the audit are intentionally **not** in this PR:
- **rust/php attribute-regex precision** — a `name`/`description` token *inside the other argument's string value* can still be mis-read (rare). Needs per-argument parsing.
- **broadening discovery's hardcoded `agent.tool` receiver** to catch `@<othervar>.tool` — deferred because broadening risks **new** false positives; the rare false-negative is the safer side to err on.

Refs: TR-275
