### PR TITLE
docs(readme): add status badges to README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
   <img src="assets/github_banner.jpg" alt="Trustabl" width="100%">
 </p>
 
+<p align="center">
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue" alt="License: Apache-2.0"></a>
+  <a href="https://github.com/trustabl/trustabl/releases"><img src="https://img.shields.io/github/v/release/trustabl/trustabl" alt="Latest release"></a>
+  <a href="https://github.com/trustabl/trustabl/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/trustabl/trustabl/test.yml?branch=main&amp;label=tests" alt="Tests"></a>
+  <a href="go.mod"><img src="https://img.shields.io/github/go-mod/go-version/trustabl/trustabl" alt="Go version"></a>
+  <br>
+  <a href="https://github.com/trustabl/trustabl-rules"><img src="https://img.shields.io/badge/rules-183-brightgreen" alt="183 detection rules"></a>
+  <a href="COVERAGE.md"><img src="https://img.shields.io/badge/SDKs-9-blue" alt="9 SDKs supported"></a>
+  <a href="COVERAGE.md"><img src="https://img.shields.io/badge/languages-7-blue" alt="7 languages supported"></a>
+  <a href="COVERAGE.md"><img src="https://img.shields.io/badge/scopes-5-blue" alt="5 detection scopes"></a>
+  <a href="COVERAGE.md"><img src="https://img.shields.io/badge/surfaces-tools%20%C2%B7%20agents%20%C2%B7%20subagents%20%C2%B7%20skills%20%C2%B7%20plugins-blue" alt="Analyzed surfaces"></a>
+  <a href="README.md#output-modes"><img src="https://img.shields.io/badge/output-human%20%7C%20JSON%20%7C%20SARIF-blue" alt="Output formats"></a>
+</p>
+
 Trustabl is a static analyzer for agent reliability. It parses an agent-SDK
 repository (Claude Agent SDK, OpenAI Agents SDK, Google ADK, MCP, LangChain /
 LangGraph, CrewAI, AutoGen / AG2, Pydantic AI, and the Vercel AI SDK), models the


### PR DESCRIPTION
## Summary

Adds a badge block under the banner image in the README header.

**Self-maintaining** (read live from GitHub, never drift): license, latest release, CI status, Go version.

**Static counts** (link to COVERAGE.md): `rules-183`, `SDKs-9`, `languages-7`, `scopes-5`, `surfaces` (tools · agents · subagents · skills · plugins), `output` (human | JSON | SARIF).

All numbers verified against source of truth: rule count from the `testdata/rules-fixture/` packs (10 packs), SDK/language/scope counts from the consts in `internal/models/models.go`. All badges confirmed to render real values.

## Notes

- Docs-only change; no code touched.
- The static count badges can drift as the project grows — `rules-183` most of all, since the rules live in the separate `trustabl-rules` repo. A drift guard (Go test asserting README numbers match the `models.go` consts) is a possible follow-up.