### PR TITLE
feat(vulndb): per-ecosystem progress bar while pulling the OSV database

### DIFF
--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -450,14 +450,15 @@ func Run(cfg Config) (models.ScanResult, error) {
 	var vulnDBVersion string
 	if cfg.VulnScan {
 		rep.StartPhase("vuln-scan", "Vulnerability scan")
-		v, ver, verr := runVulnScan(inventory.Dependencies, cfg.VulnNoUpdate, cfg.VulnCacheDir)
+		rep.SetDetail(fmt.Sprintf("%d dependencies in scope", len(inventory.Dependencies)))
+		v, ver, verr := runVulnScan(inventory.Dependencies, cfg.VulnNoUpdate, cfg.VulnCacheDir, rep)
 		if verr != nil {
 			log.Verbosef("vuln-scan: %v (continuing without vuln findings)", verr)
 		} else {
 			vulns, vulnDBVersion = v, ver
 			findings = append(findings, vulnFindings(vulns)...)
 		}
-		rep.EndPhase(fmt.Sprintf("%d vulnerable", len(vulns)))
+		rep.EndPhase(fmt.Sprintf("%d vulnerabilities across %d dependencies", len(vulns), len(inventory.Dependencies)))
 		log.Verbosef("vuln-scan: OSV snapshot %s · %d dependency vulnerabilities", vulnDBVersion, len(vulns))
 	}
 

--- a/internal/scanner/vuln.go
+++ b/internal/scanner/vuln.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 
 	"github.com/trustabl/trustabl/internal/models"
+	"github.com/trustabl/trustabl/internal/progress"
 	"github.com/trustabl/trustabl/internal/vulndb"
 )
 
@@ -14,16 +15,58 @@ import (
 // into ScanID (keeping the ID honest about which vuln data produced the result).
 // The scan never queries the OSV API per dependency — matching is against the
 // cached snapshot only.
-func runVulnScan(deps []models.DepRef, noUpdate bool, cacheDir string) (vulns []models.DepVuln, version string, err error) {
+//
+// rep drives the live progress display: a step bar over the ecosystems being
+// pulled, with a status line showing the current download (and its byte count)
+// or the cache hit. Progress is stderr-only and never affects the result.
+func runVulnScan(deps []models.DepRef, noUpdate bool, cacheDir string, rep progress.Reporter) (vulns []models.DepVuln, version string, err error) {
+	sized := false
 	res, err := vulndb.Resolve(vulndb.ResolveConfig{
 		Ecosystems: depEcosystems(deps),
 		NoUpdate:   noUpdate,
 		CacheDir:   cacheDir,
+		OnProgress: func(p vulndb.ResolveProgress) {
+			if !sized {
+				rep.SetTotal(p.Total) // size the bar to the ecosystem count on the first event
+				sized = true
+			}
+			switch {
+			case p.Finished:
+				rep.Advance(finishedVulnDetail(p))
+			case p.BytesRead > 0:
+				rep.SetDetail(fmt.Sprintf("downloading %s database — %s", p.OSVEcosystem, humanizeBytes(p.BytesRead)))
+			default:
+				rep.SetDetail("resolving " + p.OSVEcosystem + " database…")
+			}
+		},
 	})
 	if err != nil {
 		return nil, "", err
 	}
+	rep.SetDetail(fmt.Sprintf("matching %d dependencies against the OSV snapshot", len(deps)))
 	return vulndb.Match(deps, res.DB), res.Version, nil
+}
+
+// finishedVulnDetail renders the persistent detail for a resolved ecosystem,
+// e.g. "PyPI — 4821 advisories (cached)".
+func finishedVulnDetail(p vulndb.ResolveProgress) string {
+	src := "fetched"
+	if p.FromCache {
+		src = "cached"
+	}
+	return fmt.Sprintf("%s — %d advisories (%s)", p.OSVEcosystem, p.Records, src)
+}
+
+// humanizeBytes formats a byte count for the download status line.
+func humanizeBytes(n int64) string {
+	switch {
+	case n >= 1<<20:
+		return fmt.Sprintf("%.1f MB", float64(n)/float64(1<<20))
+	case n >= 1<<10:
+		return fmt.Sprintf("%.0f KB", float64(n)/float64(1<<10))
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
 }
 
 // depEcosystems returns the distinct ecosystems present in the BOM, so the vulndb

--- a/internal/vulndb/resolve.go
+++ b/internal/vulndb/resolve.go
@@ -31,6 +31,24 @@ type ResolveConfig struct {
 	CacheDir   string // empty => os.UserCacheDir()/trustabl/vulndb
 	NoUpdate   bool   // offline: use the cache only, never fetch
 	HTTPClient *http.Client
+	// OnProgress, if set, receives per-ecosystem resolution events for a UI
+	// (progress bar / status line). It is advisory only — it never affects the
+	// resolved snapshot or its Version, so determinism is preserved.
+	OnProgress func(ResolveProgress)
+}
+
+// ResolveProgress reports per-ecosystem resolution progress to the optional
+// ResolveConfig.OnProgress hook. It fires once when an ecosystem starts, again
+// for roughly every 1 MiB downloaded, and once when the ecosystem finishes
+// (loaded from the network or the cache, or skipped when neither is available).
+type ResolveProgress struct {
+	OSVEcosystem string // OSV export name being resolved, e.g. "PyPI", "npm"
+	Index        int    // 1-based position in the resolve order
+	Total        int    // total ecosystems being resolved
+	BytesRead    int64  // cumulative bytes downloaded so far (0 if cached / just started)
+	Finished     bool   // the ecosystem is done (data loaded or skipped)
+	FromCache    bool   // Finished: loaded from cache, no successful fetch
+	Records      int    // Finished: number of advisory records loaded
 }
 
 // Resolved is a loaded, indexed OSV snapshot plus its provenance.
@@ -67,34 +85,47 @@ func Resolve(cfg ResolveConfig) (*Resolved, error) {
 	fromCache := true
 	var records []Record
 	hasher := sha256.New()
-	for _, osvEco := range ecos {
+	for i, osvEco := range ecos {
+		report := func(p ResolveProgress) {
+			if cfg.OnProgress != nil {
+				p.OSVEcosystem, p.Index, p.Total = osvEco, i+1, len(ecos)
+				cfg.OnProgress(p)
+			}
+		}
+		report(ResolveProgress{}) // ecosystem started
+
 		dest := filepath.Join(cacheDir, sanitizeEco(osvEco)+".zip")
 		var data []byte
+		thisFromCache := true
 		if !cfg.NoUpdate {
-			if fetched, ferr := fetchExport(client, osvEco); ferr == nil {
-				if werr := atomicWrite(dest, fetched); werr == nil {
-					data, fromCache = fetched, false
-				} else {
-					data = fetched // use it even if we couldn't cache
-					fromCache = false
-				}
+			onBytes := func(n int64) { report(ResolveProgress{BytesRead: n}) }
+			if fetched, ferr := fetchExport(client, osvEco, onBytes); ferr == nil {
+				thisFromCache = false
+				_ = atomicWrite(dest, fetched) // cache best-effort; use the bytes regardless
+				data = fetched
 			}
 		}
 		if data == nil {
 			cached, cerr := os.ReadFile(dest)
 			if cerr != nil {
-				continue // no fetch and no cache for this ecosystem — skip it
+				report(ResolveProgress{Finished: true, FromCache: true}) // no fetch, no cache — skipped
+				continue
 			}
 			data = cached
 		}
 		recs, lerr := loadRecordsFromZip(data)
 		if lerr != nil {
+			report(ResolveProgress{Finished: true, FromCache: thisFromCache})
 			continue
+		}
+		if !thisFromCache {
+			fromCache = false
 		}
 		records = append(records, recs...)
 		hasher.Write([]byte(osvEco))
 		hasher.Write([]byte{0})
 		hasher.Write(data)
+		report(ResolveProgress{Finished: true, FromCache: thisFromCache, Records: len(recs)})
 	}
 
 	return &Resolved{
@@ -104,8 +135,9 @@ func Resolve(cfg ResolveConfig) (*Resolved, error) {
 	}, nil
 }
 
-// fetchExport downloads {base}/{osvEcosystem}/all.zip.
-func fetchExport(client *http.Client, osvEco string) ([]byte, error) {
+// fetchExport downloads {base}/{osvEcosystem}/all.zip, streaming byte progress
+// to onBytes (which may be nil) so a UI can show download status.
+func fetchExport(client *http.Client, osvEco string, onBytes func(int64)) ([]byte, error) {
 	url := fmt.Sprintf("%s/%s/all.zip", osvExportBaseURL, osvEco)
 	resp, err := client.Get(url)
 	if err != nil {
@@ -115,7 +147,39 @@ func fetchExport(client *http.Client, osvEco string) ([]byte, error) {
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("vulndb: GET %s: %s", url, resp.Status)
 	}
-	return io.ReadAll(resp.Body)
+	return readAllProgress(resp.Body, onBytes)
+}
+
+// readAllProgress reads r to completion, invoking onBytes with the cumulative
+// byte count at ~1 MiB granularity (and once more with the exact final total) so
+// a UI can show download progress without being flooded. onBytes may be nil. The
+// returned bytes are identical to io.ReadAll(r) — progress never alters the data,
+// so the snapshot hash (and thus ScanID) is unaffected.
+func readAllProgress(r io.Reader, onBytes func(int64)) ([]byte, error) {
+	var buf bytes.Buffer
+	chunk := make([]byte, 64*1024)
+	var total, reported int64
+	for {
+		n, rerr := r.Read(chunk)
+		if n > 0 {
+			buf.Write(chunk[:n])
+			total += int64(n)
+			if onBytes != nil && total-reported >= 1<<20 {
+				onBytes(total)
+				reported = total
+			}
+		}
+		if rerr == io.EOF {
+			break
+		}
+		if rerr != nil {
+			return nil, rerr
+		}
+	}
+	if onBytes != nil && total != reported {
+		onBytes(total)
+	}
+	return buf.Bytes(), nil
 }
 
 // loadRecordsFromZip parses every *.json entry of an OSV all.zip into a Record.

--- a/internal/vulndb/resolve_test.go
+++ b/internal/vulndb/resolve_test.go
@@ -3,6 +3,8 @@ package vulndb
 import (
 	"archive/zip"
 	"bytes"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -44,5 +46,82 @@ func TestResolve_OfflineNoCacheIsEmpty(t *testing.T) {
 	}
 	if !r.FromCache {
 		t.Error("offline resolve should report FromCache=true")
+	}
+}
+
+// TestReadAllProgress_ReportsCumulativeBytes proves the download status hook
+// reports a monotonic byte count ending at the exact total, and returns the full
+// data unchanged (so the snapshot hash is unaffected).
+func TestReadAllProgress_ReportsCumulativeBytes(t *testing.T) {
+	data := bytes.Repeat([]byte("x"), 3<<20) // 3 MiB → reports near 1/2/3 MiB
+	var reports []int64
+	out, err := readAllProgress(bytes.NewReader(data), func(n int64) { reports = append(reports, n) })
+	if err != nil {
+		t.Fatalf("readAllProgress: %v", err)
+	}
+	if len(out) != len(data) {
+		t.Fatalf("returned %d bytes, want %d", len(out), len(data))
+	}
+	if len(reports) == 0 {
+		t.Fatal("expected at least one progress report")
+	}
+	for i := 1; i < len(reports); i++ {
+		if reports[i] < reports[i-1] {
+			t.Errorf("reports not monotonic: %v", reports)
+		}
+	}
+	if last := reports[len(reports)-1]; last != int64(len(data)) {
+		t.Errorf("final report %d != total %d", last, len(data))
+	}
+}
+
+// TestReadAllProgress_NilCallback proves a nil hook is safe (the vulndb-pull /
+// no-UI path).
+func TestReadAllProgress_NilCallback(t *testing.T) {
+	out, err := readAllProgress(bytes.NewReader([]byte("hello")), nil)
+	if err != nil || string(out) != "hello" {
+		t.Fatalf("readAllProgress(nil) = %q, %v", out, err)
+	}
+}
+
+// TestResolve_OnProgressReportsEachEcosystem proves Resolve fires the UI hook
+// with a start event and a finished event (carrying the cache source + record
+// count) for each ecosystem it resolves.
+func TestResolve_OnProgressReportsEachEcosystem(t *testing.T) {
+	dir := t.TempDir()
+	// Stage a cached PyPI snapshot so the offline path loads a real record.
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, _ := zw.Create("PYSEC-1.json")
+	_, _ = w.Write([]byte(`{"id":"PYSEC-1","affected":[{"package":{"ecosystem":"PyPI","name":"requests"}}]}`))
+	_ = zw.Close()
+	if err := os.WriteFile(filepath.Join(dir, "PyPI.zip"), buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var starts, finishes int
+	var last ResolveProgress
+	if _, err := Resolve(ResolveConfig{
+		Ecosystems: []string{"pypi"},
+		CacheDir:   dir,
+		NoUpdate:   true, // offline: load from the staged cache, no fetch
+		OnProgress: func(p ResolveProgress) {
+			switch {
+			case p.Finished:
+				finishes++
+				last = p
+			case p.BytesRead == 0:
+				starts++
+			}
+		},
+	}); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	if starts != 1 || finishes != 1 {
+		t.Fatalf("want 1 start + 1 finish event, got %d/%d", starts, finishes)
+	}
+	if !last.FromCache || last.Records != 1 || last.OSVEcosystem != "PyPI" || last.Index != 1 || last.Total != 1 {
+		t.Errorf("unexpected finish event: %+v", last)
 	}
 }


### PR DESCRIPTION
## Summary

`--vuln-scan` could sit on a **frozen spinner for the entire OSV download** — the PyPI export alone is ~23 MB / 20,359 advisories, and npm is far larger. This adds live, per-ecosystem progress so the user sees exactly what's happening during the pull.

The progress display (TTY) now shows a step bar over the ecosystems being resolved plus a live status line:

```
⠙ Vulnerability scan  ━━━━━━──  0/1  downloading PyPI database — 14.2 MB
✔ Vulnerability scan  1 vulnerabilities across 4 dependencies
```

Verified against **live osv.dev** (the exact OnProgress event stream the bar consumes):

```
--- COLD cache (live download) ---
  resolving PyPI database…
  downloading PyPI database — 1.0 MB → 2.0 MB → … → 23.3 MB   (throttled ~1 MiB)
  ✔ PyPI — 20359 advisories (fetched)
--- WARM cache (offline) ---
  resolving PyPI database…
  ✔ PyPI — 20359 advisories (cached)
```

## What changed

- **`vulndb.ResolveConfig` gains `OnProgress func(ResolveProgress)`** — an optional UI hook. The resolve loop fires a *start*, periodic *byte*, and *finished* event per ecosystem, tracking a **per-ecosystem** cache flag (previously only a single aggregate `FromCache`).
- **`fetchExport` streams through a new `readAllProgress`** that reports cumulative bytes at ~1 MiB granularity. Its output is byte-identical to `io.ReadAll`, so the snapshot hash — and therefore `ScanID` — is unaffected.
- **`runVulnScan` translates the events** into `SetTotal` (bar sized to the ecosystem count) / `SetDetail` (download + matching status) / `Advance` (per-ecosystem completion), and the phase now ends `"N vulnerabilities across M dependencies"`.

## Determinism / contract

Progress is **stderr-only** and never touches `ScanResult` (per the repo contract). `readAllProgress` returns the same bytes as before, the snapshot `Version` is unchanged, and the byte-throttled events ride the reporter's existing 1024-buffered channel (no backpressure). A non-TTY / `--no-progress` / JSON run is unaffected.

## Tests

- `TestReadAllProgress_ReportsCumulativeBytes` (monotonic, exact final total, data unchanged) + `_NilCallback` (the no-UI / `vulndb pull` path).
- `TestResolve_OnProgressReportsEachEcosystem` (start + finished events with cache source and record count).
- Full suite green (19 packages), gofmt + vet clean.

Refs: TR-271