### PR TITLE
feat(cyclonedx): emit --vuln-scan matches as CycloneDX VEX vulnerabilities

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -462,7 +462,11 @@ For each language recon cleared, do the AST work and produce a `RepoInventory`:
   Trustabl's own opt-in pinned-OSV `--vuln-scan` layer (TR-271, below). The BOM
   itself is deliberately **not** folded into `ScanID`. The optional `--bom-out`
   flag renders it as a byte-stable CycloneDX 1.5 document via
-  [`internal/cyclonedx`](internal/cyclonedx/render.go).
+  [`internal/cyclonedx`](internal/cyclonedx/render.go); each component carries a
+  `bom-ref`, and when `--vuln-scan` also ran the matched advisories ride along as
+  a CycloneDX **VEX** `vulnerabilities[]` array (advisory id, OSV source,
+  severity rating, upgrade recommendation) linked to the affected component by
+  `affects[].ref` → `bom-ref`.
 - **Vulnerability matching** ([`internal/vulndb`](internal/vulndb), opt-in via
   `--vuln-scan`) — the CVE layer on top of the BOM (TR-271). After analysis the
   scanner resolves a **pinned** OSV snapshot — each ecosystem's published OSV

--- a/README.md
+++ b/README.md
@@ -345,6 +345,15 @@ folded into the `ScanID` only when `--vuln-scan` is on, so the result is honest
 about which vulnerability data produced it while a default scan stays
 byte-identical to before.
 
+Combining `--vuln-scan` with `--bom-out` upgrades the CycloneDX document from a
+plain inventory into a BOM **plus VEX**: the matched advisories are emitted as a
+CycloneDX 1.5 `vulnerabilities[]` array — each with the advisory ID, an OSV
+`source`, a severity `rating`, an upgrade `recommendation`, and an `affects[]`
+reference linking it to the affected component's `bom-ref` — so a single
+`trustabl scan ./repo --vuln-scan --bom-out bom.json` produces a standards-based
+artifact that any CycloneDX-aware tool can ingest. Without `--vuln-scan` the
+`vulnerabilities[]` array is omitted and the BOM stays pure inventory.
+
 `--format json` and `--format sarif` are progress-silent and byte-stable
 across identical-input runs (pure functions of the `ScanResult`). The human
 format is not byte-stable by design: its ANSI color is auto-detected from the
@@ -501,6 +510,7 @@ trustabl scan ./repo --bom-out sbom.json
 # OSV database and FAIL on known CVEs — advisory id, CVSS severity, fixed version.
 trustabl vulndb pull                              # pre-download OSV (optional; --vuln-scan auto-fetches)
 trustabl scan ./repo --vuln-scan                  # BOM inventory + CVE verdict in one pass
+trustabl scan ./repo --vuln-scan --bom-out bom.json  # CycloneDX BOM + VEX (vulnerabilities[]) in one file
 
 # JSON output for CI piping
 trustabl scan ./repo --format json

--- a/cmd/trustabl/scan.go
+++ b/cmd/trustabl/scan.go
@@ -606,7 +606,10 @@ func writeSideOutputs(result models.ScanResult, f scanFlags) error {
 		}
 	}
 	if f.bomOut != "" {
-		if err := os.WriteFile(f.bomOut, cyclonedx.Render(result.Dependencies, version), 0o644); err != nil {
+		// result.Vulnerabilities is populated only under --vuln-scan; otherwise nil,
+		// so the BOM stays a pure inventory. When present, they ride along as a
+		// CycloneDX VEX vulnerabilities[] array linked to the affected components.
+		if err := os.WriteFile(f.bomOut, cyclonedx.Render(result.Dependencies, result.Vulnerabilities, version), 0o644); err != nil {
 			return fmt.Errorf("write --bom-out: %w", err)
 		}
 	}

--- a/internal/cyclonedx/render.go
+++ b/internal/cyclonedx/render.go
@@ -1,17 +1,24 @@
-// Package cyclonedx renders a Trustabl skill dependency BOM (Story D / TR-221)
-// as a CycloneDX 1.5 JSON document.
+// Package cyclonedx renders a Trustabl repo dependency BOM (TR-278, evolving
+// Story D / TR-221) as a CycloneDX 1.5 JSON document.
 //
-// Output is byte-stable, per the engine's determinism contract: components are
-// sorted by a total key, and the document carries no timestamp and no random
-// serial number, so identical inputs yield identical bytes. The BOM is pure
-// inventory — it states what a skill declares as dependencies and hands off to a
-// real SCA tool (OSV-Scanner, Dependabot) for CVE matching. It never asserts a
-// vulnerability verdict.
+// Output is byte-stable, per the engine's determinism contract: components and
+// vulnerabilities are sorted by a total key, and the document carries no
+// timestamp and no random serial number, so identical inputs yield identical
+// bytes.
+//
+// By default the BOM is pure inventory — it states what the repo declares as
+// dependencies and hands off to a real SCA tool (OSV-Scanner, Dependabot) for
+// CVE matching. When the caller ran --vuln-scan, it also passes the matched
+// vulnerabilities, which are emitted as a CycloneDX vulnerabilities[] array
+// (VEX), each rating-tagged and linked to the component it affects by bom-ref.
+// With no vulnerabilities the vulnerabilities[] array is omitted entirely, so an
+// inventory-only BOM is unchanged.
 package cyclonedx
 
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"regexp"
 	"sort"
 
@@ -19,11 +26,12 @@ import (
 )
 
 type doc struct {
-	BOMFormat   string      `json:"bomFormat"`
-	SpecVersion string      `json:"specVersion"`
-	Version     int         `json:"version"`
-	Metadata    metadata    `json:"metadata"`
-	Components  []component `json:"components"`
+	BOMFormat       string          `json:"bomFormat"`
+	SpecVersion     string          `json:"specVersion"`
+	Version         int             `json:"version"`
+	Metadata        metadata        `json:"metadata"`
+	Components      []component     `json:"components"`
+	Vulnerabilities []vulnerability `json:"vulnerabilities,omitempty"`
 }
 
 type metadata struct {
@@ -37,6 +45,7 @@ type tool struct {
 }
 
 type component struct {
+	BOMRef     string     `json:"bom-ref"`
 	Type       string     `json:"type"`
 	Name       string     `json:"name"`
 	Version    string     `json:"version,omitempty"`
@@ -49,6 +58,31 @@ type property struct {
 	Value string `json:"value"`
 }
 
+// vulnerability is a CycloneDX 1.5 vulnerability object (the VEX surface). Each
+// is linked to the component it affects via affects[].ref → component.bom-ref.
+type vulnerability struct {
+	ID             string      `json:"id"`
+	Source         *vulnSource `json:"source,omitempty"`
+	Ratings        []rating    `json:"ratings,omitempty"`
+	Description    string      `json:"description,omitempty"`
+	Recommendation string      `json:"recommendation,omitempty"`
+	Affects        []affect    `json:"affects,omitempty"`
+}
+
+type vulnSource struct {
+	Name string `json:"name"`
+	URL  string `json:"url,omitempty"`
+}
+
+type rating struct {
+	Severity string `json:"severity"`
+	Method   string `json:"method,omitempty"`
+}
+
+type affect struct {
+	Ref string `json:"ref"`
+}
+
 // concreteVersionRe matches a declared version that is a single concrete release
 // — digit-led, or Go's "v"-prefixed module form (v1.2.3, v0.0.0-<ts>-<sha>); no
 // operators or spaces. This is the only form that makes a meaningful purl
@@ -57,10 +91,12 @@ type property struct {
 // component.version.
 var concreteVersionRe = regexp.MustCompile(`^v?[0-9][A-Za-z0-9.+_-]*$`)
 
-// Render returns a CycloneDX 1.5 JSON BOM for deps. toolVersion is stamped as
-// the generating tool's version. The result is deterministic and byte-stable for
-// a given (deps, toolVersion); deps need not be pre-sorted.
-func Render(deps []models.DepRef, toolVersion string) []byte {
+// Render returns a CycloneDX 1.5 JSON BOM for deps, optionally carrying vulns
+// (the --vuln-scan OSV matches) as a vulnerabilities[] VEX array linked to the
+// affected components. toolVersion is stamped as the generating tool's version.
+// The result is deterministic and byte-stable for a given (deps, vulns,
+// toolVersion); neither slice need be pre-sorted.
+func Render(deps []models.DepRef, vulns []models.DepVuln, toolVersion string) []byte {
 	sorted := make([]models.DepRef, len(deps))
 	copy(sorted, deps)
 	sort.Slice(sorted, func(i, j int) bool {
@@ -77,13 +113,28 @@ func Render(deps []models.DepRef, toolVersion string) []byte {
 		}
 	})
 
+	// bom-ref per component. The purl is the natural ref, but dedupeDeps keeps
+	// the same package from two manifests (same purl, different source), so a
+	// repeated purl is disambiguated with a deterministic "#n" suffix. refByDep
+	// lets each vulnerability link back to the exact component it affects.
 	comps := make([]component, 0, len(sorted))
+	refByDep := make(map[models.DepRef]string, len(sorted))
+	seen := map[string]int{}
 	for _, d := range sorted {
+		base := purl(d)
+		ref := base
+		if n := seen[base]; n > 0 {
+			ref = fmt.Sprintf("%s#%d", base, n)
+		}
+		seen[base]++
+		refByDep[d] = ref
+
 		c := component{
+			BOMRef:  ref,
 			Type:    "library",
 			Name:    d.Name,
 			Version: d.Version,
-			PURL:    purl(d),
+			PURL:    base,
 		}
 		if d.Source != "" {
 			c.Properties = []property{{Name: "trustabl:source", Value: d.Source}}
@@ -100,7 +151,8 @@ func Render(deps []models.DepRef, toolVersion string) []byte {
 			Name:    "trustabl",
 			Version: toolVersion,
 		}}},
-		Components: comps,
+		Components:      comps,
+		Vulnerabilities: renderVulns(vulns, refByDep),
 	}
 
 	var buf bytes.Buffer
@@ -109,6 +161,62 @@ func Render(deps []models.DepRef, toolVersion string) []byte {
 	enc.SetIndent("", "  ")
 	_ = enc.Encode(&bom) // encoding a fixed struct never errors
 	return buf.Bytes()
+}
+
+// renderVulns maps the OSV matches to CycloneDX vulnerability objects, sorted for
+// byte-stability and linked to their component by bom-ref. Returns nil (omitted
+// array) when there are no vulnerabilities, keeping the inventory-only BOM
+// unchanged.
+func renderVulns(vulns []models.DepVuln, refByDep map[models.DepRef]string) []vulnerability {
+	if len(vulns) == 0 {
+		return nil
+	}
+	sorted := make([]models.DepVuln, len(vulns))
+	copy(sorted, vulns)
+	sort.Slice(sorted, func(i, j int) bool {
+		a, b := sorted[i], sorted[j]
+		switch {
+		case vulnID(a) != vulnID(b):
+			return vulnID(a) < vulnID(b)
+		case a.Dep.Ecosystem != b.Dep.Ecosystem:
+			return a.Dep.Ecosystem < b.Dep.Ecosystem
+		case a.Dep.Name != b.Dep.Name:
+			return a.Dep.Name < b.Dep.Name
+		case a.Dep.Version != b.Dep.Version:
+			return a.Dep.Version < b.Dep.Version
+		default:
+			return a.Dep.Source < b.Dep.Source
+		}
+	})
+
+	out := make([]vulnerability, 0, len(sorted))
+	for _, v := range sorted {
+		rec := "No fixed version is published; review the advisory and consider an alternative or mitigation."
+		if v.FixedIn != "" {
+			rec = fmt.Sprintf("Upgrade %s to %s or later.", v.Dep.Name, v.FixedIn)
+		}
+		vu := vulnerability{
+			ID:             vulnID(v),
+			Source:         &vulnSource{Name: "OSV", URL: "https://osv.dev/vulnerability/" + v.ID},
+			Ratings:        []rating{{Severity: string(v.Severity), Method: "other"}},
+			Description:    v.Summary,
+			Recommendation: rec,
+		}
+		if ref := refByDep[v.Dep]; ref != "" {
+			vu.Affects = []affect{{Ref: ref}}
+		}
+		out = append(out, vu)
+	}
+	return out
+}
+
+// vulnID prefers the CVE alias (matching the synthesized finding's RuleID, so the
+// report and the BOM cross-reference cleanly) and falls back to the OSV id.
+func vulnID(v models.DepVuln) string {
+	if len(v.Aliases) > 0 {
+		return v.Aliases[0]
+	}
+	return v.ID
 }
 
 // purl builds a Package URL for a dependency. Scoped npm names (@scope/pkg) get

--- a/internal/cyclonedx/render_test.go
+++ b/internal/cyclonedx/render_test.go
@@ -21,9 +21,9 @@ func sampleDeps() []models.DepRef {
 // order — the determinism contract.
 func TestRender_OrderIndependent(t *testing.T) {
 	deps := sampleDeps()
-	a := Render(deps, "1.2.3")
+	a := Render(deps, nil, "1.2.3")
 	shuffled := []models.DepRef{deps[2], deps[0], deps[1]}
-	b := Render(shuffled, "1.2.3")
+	b := Render(shuffled, nil, "1.2.3")
 	if !bytes.Equal(a, b) {
 		t.Fatalf("Render not order-independent:\n--- a ---\n%s\n--- b ---\n%s", a, b)
 	}
@@ -32,7 +32,7 @@ func TestRender_OrderIndependent(t *testing.T) {
 // TestRender_NoNondeterministicFields guards against a timestamp or random
 // serial number leaking into the byte-stable output.
 func TestRender_NoNondeterministicFields(t *testing.T) {
-	out := string(Render(sampleDeps(), "1.2.3"))
+	out := string(Render(sampleDeps(), nil, "1.2.3"))
 	for _, banned := range []string{"timestamp", "serialNumber"} {
 		if strings.Contains(out, banned) {
 			t.Errorf("BOM contains nondeterministic field %q:\n%s", banned, out)
@@ -41,7 +41,7 @@ func TestRender_NoNondeterministicFields(t *testing.T) {
 }
 
 func TestRender_Structure(t *testing.T) {
-	out := Render(sampleDeps(), "9.9.9")
+	out := Render(sampleDeps(), nil, "9.9.9")
 
 	var doc struct {
 		BOMFormat   string `json:"bomFormat"`
@@ -103,7 +103,7 @@ func TestRender_Structure(t *testing.T) {
 }
 
 func TestRender_EmptyIsEmptyArray(t *testing.T) {
-	out := string(Render(nil, "1.0.0"))
+	out := string(Render(nil, nil, "1.0.0"))
 	if !strings.Contains(out, `"components": []`) {
 		t.Errorf("empty BOM should render an empty components array, got:\n%s", out)
 	}
@@ -119,7 +119,7 @@ func TestRender_AllEcosystemPurls(t *testing.T) {
 		{Name: "serde", Version: "1.0.190", Ecosystem: "cargo", Source: "Cargo.toml"},
 		{Name: "monolog/monolog", Version: "^2.0", Ecosystem: "composer", Source: "composer.json"},
 	}
-	out := string(Render(deps, "1.0.0"))
+	out := string(Render(deps, nil, "1.0.0"))
 	for _, want := range []string{
 		`"purl": "pkg:golang/github.com/foo/bar@v1.2.3"`, // Go v-prefix kept
 		`"purl": "pkg:nuget/Newtonsoft.Json@13.0.1"`,
@@ -129,5 +129,95 @@ func TestRender_AllEcosystemPurls(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("missing %s in:\n%s", want, out)
 		}
+	}
+}
+
+// TestRender_Vulnerabilities proves --vuln-scan matches are emitted as a
+// CycloneDX VEX vulnerabilities[] array: CVE-preferred id, OSV source, severity
+// rating, fix recommendation, and an affects[] ref that links to the affected
+// component's bom-ref.
+func TestRender_Vulnerabilities(t *testing.T) {
+	deps := []models.DepRef{
+		{Name: "requests", Version: "2.19.0", Ecosystem: "pypi", Source: "requirements.txt"},
+	}
+	vulns := []models.DepVuln{{
+		Dep:      deps[0],
+		ID:       "GHSA-x84v-xcm2-53pg",
+		Aliases:  []string{"CVE-2018-18074"},
+		Summary:  "Requests leaks Authorization on redirect",
+		Severity: models.SeverityHigh,
+		FixedIn:  "2.20.0",
+	}}
+	out := Render(deps, vulns, "1.0.0")
+
+	var doc struct {
+		Components []struct {
+			BOMRef string `json:"bom-ref"`
+			PURL   string `json:"purl"`
+		} `json:"components"`
+		Vulnerabilities []struct {
+			ID     string `json:"id"`
+			Source struct {
+				Name string `json:"name"`
+				URL  string `json:"url"`
+			} `json:"source"`
+			Ratings []struct {
+				Severity string `json:"severity"`
+				Method   string `json:"method"`
+			} `json:"ratings"`
+			Recommendation string `json:"recommendation"`
+			Affects        []struct {
+				Ref string `json:"ref"`
+			} `json:"affects"`
+		} `json:"vulnerabilities"`
+	}
+	if err := json.Unmarshal(out, &doc); err != nil {
+		t.Fatalf("invalid CycloneDX JSON: %v\n%s", err, out)
+	}
+	if len(doc.Components) != 1 || doc.Components[0].BOMRef == "" {
+		t.Fatalf("component/bom-ref missing: %+v", doc.Components)
+	}
+	if len(doc.Vulnerabilities) != 1 {
+		t.Fatalf("want 1 vulnerability, got %d:\n%s", len(doc.Vulnerabilities), out)
+	}
+	v := doc.Vulnerabilities[0]
+	if v.ID != "CVE-2018-18074" {
+		t.Errorf("id = %q, want CVE alias preferred", v.ID)
+	}
+	if v.Source.Name != "OSV" || !strings.Contains(v.Source.URL, "GHSA-x84v-xcm2-53pg") {
+		t.Errorf("source = %+v, want OSV + osv.dev URL keyed by OSV id", v.Source)
+	}
+	if len(v.Ratings) != 1 || v.Ratings[0].Severity != "high" {
+		t.Errorf("ratings = %+v, want one 'high' rating", v.Ratings)
+	}
+	if !strings.Contains(v.Recommendation, "2.20.0") {
+		t.Errorf("recommendation = %q, want the fixed version", v.Recommendation)
+	}
+	if len(v.Affects) != 1 || v.Affects[0].Ref != doc.Components[0].BOMRef {
+		t.Errorf("affects %+v must link the component bom-ref %q", v.Affects, doc.Components[0].BOMRef)
+	}
+}
+
+// TestRender_VulnsOrderIndependent extends the determinism contract to the
+// vulnerabilities[] array.
+func TestRender_VulnsOrderIndependent(t *testing.T) {
+	deps := sampleDeps()
+	vulns := []models.DepVuln{
+		{Dep: deps[0], ID: "GHSA-2", Severity: models.SeverityLow},
+		{Dep: deps[0], ID: "GHSA-1", Aliases: []string{"CVE-1"}, Severity: models.SeverityHigh, FixedIn: "9.0.0"},
+	}
+	a := Render(deps, vulns, "1")
+	b := Render(deps, []models.DepVuln{vulns[1], vulns[0]}, "1")
+	if !bytes.Equal(a, b) {
+		t.Fatalf("vulnerabilities render not order-independent:\n--- a ---\n%s\n--- b ---\n%s", a, b)
+	}
+}
+
+// TestRender_NoVulnsOmitsArray proves an inventory-only BOM (no --vuln-scan)
+// omits the vulnerabilities array entirely, so it stays unchanged.
+func TestRender_NoVulnsOmitsArray(t *testing.T) {
+	out := string(Render(sampleDeps(), nil, "1.0.0"))
+	if strings.Contains(out, "vulnerabilities") {
+		t.Errorf("inventory-only BOM must not contain a vulnerabilities array:\n%s", out)
 	}
 }

--- a/internal/vulndb/match.go
+++ b/internal/vulndb/match.go
@@ -227,6 +227,13 @@ func inRange(ecosystem, version string, r Range) bool {
 
 func firstFixed(ecosystem string, aff Affected) string {
 	for _, r := range aff.Ranges {
+		// Skip GIT ranges: their "fixed" event is a commit SHA, not a release
+		// version, so it would produce nonsense advice ("upgrade to <40-hex>").
+		// recordAffects skips GIT ranges for the same reason; only a
+		// SEMVER/ECOSYSTEM range yields a usable fixed version.
+		if r.Type == "GIT" {
+			continue
+		}
 		for _, e := range r.Events {
 			if e.Fixed != "" {
 				return e.Fixed

--- a/internal/vulndb/match_test.go
+++ b/internal/vulndb/match_test.go
@@ -88,3 +88,30 @@ func TestMatch_RealRecords(t *testing.T) {
 		}
 	}
 }
+
+// TestMatch_GitRangeFixedSkipped proves firstFixed ignores a GIT range's commit
+// SHA and reports the SEMVER/ECOSYSTEM range's real version. Real OSV records
+// (e.g. PYSEC-2018-28 for requests) carry both, and "upgrade to <40-hex-sha>" is
+// nonsense advice in a finding or a CycloneDX recommendation.
+func TestMatch_GitRangeFixedSkipped(t *testing.T) {
+	rec := Record{
+		ID: "PYSEC-XXXX", Aliases: []string{"CVE-XXXX"},
+		Severity: []Severity{{Type: "CVSS_V3", Score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"}},
+		Affected: []Affected{{
+			Package: AffectedPackage{Ecosystem: "PyPI", Name: "requests"},
+			Ranges: []Range{
+				// GIT range first (commit SHA) — must be skipped …
+				{Type: "GIT", Events: []Event{{Introduced: "0"}, {Fixed: "c45d7c49ea75133e52ab22a8e9e13173938e36ff"}}},
+				// … in favor of the ECOSYSTEM range's real version.
+				{Type: "ECOSYSTEM", Events: []Event{{Introduced: "0"}, {Fixed: "2.20.0"}}},
+			},
+		}},
+	}
+	got := Match([]models.DepRef{{Name: "requests", Version: "2.19.0", Ecosystem: "pypi", Source: "requirements.txt"}}, NewDB([]Record{rec}))
+	if len(got) != 1 {
+		t.Fatalf("want 1 vuln, got %d: %+v", len(got), got)
+	}
+	if got[0].FixedIn != "2.20.0" {
+		t.Errorf("FixedIn = %q, want 2.20.0 (the GIT commit SHA must be skipped)", got[0].FixedIn)
+	}
+}


### PR DESCRIPTION
## Summary

`--bom-out` rendered **components only**, so the vulnerabilities found by `--vuln-scan` never appeared in the CycloneDX file. CycloneDX 1.5 is a BOM **+ VEX** format, so when both flags are used the matched advisories now ride along as a `vulnerabilities[]` array — `trustabl scan ./repo --vuln-scan --bom-out bom.json` yields one standards-based artifact any CycloneDX-aware tool can ingest.

Verified end-to-end against **live osv.dev** (the `/tmp/vulndemo` repo with `requests==2.19.0`, `jinja2==2.10`, `pyyaml==5.1`, `flask==2.3.3`):

```
BOM keys: [bomFormat, specVersion, version, metadata, components, vulnerabilities]
components: 4   (each with a bom-ref)
vulnerabilities: 22
all affects[].ref resolve to a component bom-ref: True
```

One emitted vulnerability:
```json
{
  "id": "CVE-2019-10906",
  "source": { "name": "OSV", "url": "https://osv.dev/vulnerability/PYSEC-2019-217" },
  "ratings": [ { "severity": "high", "method": "other" } ],
  "recommendation": "Upgrade jinja2 to 2.10.1 or later.",
  "affects": [ { "ref": "pkg:pypi/jinja2@2.10" } ]
}
```

## What changed

- **`cyclonedx.Render(deps, vulns, toolVersion)`** — each component gains a `bom-ref` (the purl, with a deterministic `#n` suffix for the same package declared in two manifests — `dedupeDeps` keys on the full `DepRef` incl. source, so same-purl components can coexist). Each vulnerability carries the **CVE-preferred id** (matching the synthesized finding's RuleID), an **OSV `source`** URL, a **severity `rating`**, an upgrade **`recommendation`**, and an **`affects[].ref`** → the component's `bom-ref`. The array is omitted (BOM byte-identical to before) when there are no vulnerabilities.
- **`scan.go`** passes `result.Vulnerabilities` (populated only under `--vuln-scan`; nil otherwise).

## Bundled bug fix

While verifying, the BOM surfaced a pre-existing matcher bug: `vulndb.firstFixed` returned a **GIT range's commit SHA** as the fixed version, producing nonsense advice — *"Upgrade requests to c45d7c49… or later"* — in both the finding's `SuggestedFix` and the new BOM `recommendation`. `recordAffects` already skips `GIT` ranges; `firstFixed` now does too, so requests resolves to `2.20.0`. (Confirmed: 0 recommendations contain a 40-hex SHA after the fix.)

## Determinism / contract

`vulnerabilities[]` is sorted by a total key (id, then affected dep), so the BOM stays byte-stable. The BOM is not folded into `ScanID`. An inventory-only BOM (no `--vuln-scan`) omits the array and is unchanged apart from the new component `bom-ref`.

## Tests

- `TestRender_Vulnerabilities` (id/source/rating/recommendation + `affects`→`bom-ref` linkage), `TestRender_VulnsOrderIndependent`, `TestRender_NoVulnsOmitsArray`.
- `TestMatch_GitRangeFixedSkipped` (GIT commit SHA skipped in favor of the ECOSYSTEM range's `2.20.0`).
- Full suite green (19 packages), gofmt + vet clean.

Refs: TR-271