### PR TITLE
fix(vulndb): make OSV snapshot resolution cache-first

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -470,8 +470,11 @@ For each language recon cleared, do the AST work and produce a `RepoInventory`:
 - **Vulnerability matching** ([`internal/vulndb`](internal/vulndb), opt-in via
   `--vuln-scan`) — the CVE layer on top of the BOM (TR-271). After analysis the
   scanner resolves a **pinned** OSV snapshot — each ecosystem's published OSV
-  export fetched from osv.dev, cached under the user cache dir with an offline
-  fallback (`trustabl vulndb pull` pre-warms it) — and matches every
+  export fetched from osv.dev and cached under the user cache dir, **cache-first**:
+  a cached export younger than `DefaultMaxAge` (24h) is reused without
+  re-downloading (so repeated scans don't re-pull tens of MB), a missing or stale
+  one is fetched, `trustabl vulndb pull` forces a refresh, and `--no-rules-update`
+  pins to the cache at any age (offline) — and matches every
   concretely-pinned `DepRef` against it: per-ecosystem version semantics (PEP 440
   for pypi, semver for the rest), the OSV introduced/fixed/last_affected range
   algorithm, and a CVSS 3.x base-score → severity bucketing. Each hit becomes a

--- a/README.md
+++ b/README.md
@@ -335,10 +335,12 @@ and reports each affected package as a finding carrying the advisory ID
 so a vulnerable dependency fails the scan through the normal severity gate and
 exit codes and lands in the JSON / SARIF output alongside the rule findings, on
 `ScanResult.vulnerabilities`. Unlike the rest of a scan it is **opt-in and
-online**: the OSV snapshot is fetched from osv.dev on first use and cached under
-your user cache directory (offline fallback thereafter). Run `trustabl vulndb
-pull` to pre-download the database so a later `--vuln-scan` runs fully offline
-(e.g. in CI or an air-gapped build). Only concretely-pinned versions are matched
+online**: the OSV snapshot is fetched from osv.dev on first use, cached under
+your user cache directory, and then **cache-first** — a later `--vuln-scan`
+reuses the cached database (no re-download) until it is older than 24h, so
+repeated scans are fast and offline-capable. `trustabl vulndb pull` refreshes the
+cache on demand; `--no-rules-update` pins to the cache at any age (fully offline).
+Only concretely-pinned versions are matched
 — a declared range (`^1.0`, `>=2`) can't be resolved to one version without a
 lockfile, so it is left unmatched rather than guessed. The snapshot version is
 folded into the `ScanID` only when `--vuln-scan` is on, so the result is honest

--- a/cmd/trustabl/vulndb.go
+++ b/cmd/trustabl/vulndb.go
@@ -41,8 +41,9 @@ pulled from osv.dev — this can be a sizable download.`,
 			log.Verbosef("vulndb pull: fetching OSV databases for all supported ecosystems")
 			defer log.Timer("vulndb pull")()
 			res, err := vulndb.Resolve(vulndb.ResolveConfig{
-				Ecosystems: vulndb.AllEcosystems(),
-				NoUpdate:   noUpdate,
+				Ecosystems:   vulndb.AllEcosystems(),
+				NoUpdate:     noUpdate,
+				ForceRefresh: !noUpdate, // pull refreshes the cached snapshot on demand
 			})
 			if err != nil {
 				return fmt.Errorf("vulndb pull: %w", err)

--- a/internal/vulndb/resolve.go
+++ b/internal/vulndb/resolve.go
@@ -22,6 +22,13 @@ import (
 // the OSV API, so determinism and the no-network contract hold.
 const osvExportBaseURL = "https://osv-vulnerabilities.storage.googleapis.com"
 
+// DefaultMaxAge is how long a cached OSV export is reused before --vuln-scan
+// re-fetches it. A day keeps repeated scans fast (a Python repo's PyPI export is
+// ~23 MB; npm's is far larger) while staying reasonably fresh. `vulndb pull`
+// (ForceRefresh) refreshes on demand; --no-rules-update (NoUpdate) pins to the
+// cache at any age.
+const DefaultMaxAge = 24 * time.Hour
+
 // ResolveConfig drives snapshot resolution.
 type ResolveConfig struct {
 	// Ecosystems is the set of trustabl ecosystem ids present in the BOM (pypi,
@@ -29,7 +36,16 @@ type ResolveConfig struct {
 	// Python-only repo never downloads npm's (huge) database.
 	Ecosystems []string
 	CacheDir   string // empty => os.UserCacheDir()/trustabl/vulndb
-	NoUpdate   bool   // offline: use the cache only, never fetch
+	NoUpdate   bool   // offline: use the cache only, never fetch (at any age)
+	// ForceRefresh fetches every ecosystem even if a fresh cache exists — used by
+	// `vulndb pull` to refresh the pinned snapshot on demand.
+	ForceRefresh bool
+	// MaxAge reuses a cached ecosystem export younger than this without
+	// re-fetching; an older or missing one is fetched (unless NoUpdate). Zero
+	// selects DefaultMaxAge. This is what makes repeated --vuln-scan runs reuse
+	// the cached download instead of pulling tens of MB every time.
+	MaxAge     time.Duration
+	BaseURL    string // OSV export base; empty => osvExportBaseURL (overridable for a mirror or tests)
 	HTTPClient *http.Client
 	// OnProgress, if set, receives per-ecosystem resolution events for a UI
 	// (progress bar / status line). It is advisory only — it never affects the
@@ -58,11 +74,13 @@ type Resolved struct {
 	FromCache bool   // true if every ecosystem came from cache (no successful fetch)
 }
 
-// Resolve loads the OSV snapshot for the BOM's ecosystems: it fetches each
-// ecosystem's all.zip (unless NoUpdate), caches it, and falls back to the cache
-// when the network is unavailable. The returned Version is a stable hash of the
-// exact bytes used, so a scan is honest about which snapshot produced its
-// findings.
+// Resolve loads the OSV snapshot for the BOM's ecosystems. It is CACHE-FIRST:
+// for each ecosystem it reuses the cached all.zip when present and younger than
+// MaxAge, fetching only a missing or stale one (so repeated --vuln-scan runs
+// don't re-download tens of MB each time). NoUpdate pins to the cache at any age;
+// ForceRefresh always fetches. A fetch failure falls back to whatever is cached.
+// The returned Version is a stable hash of the exact bytes used, so a scan is
+// honest about which snapshot produced its findings.
 func Resolve(cfg ResolveConfig) (*Resolved, error) {
 	cacheDir := cfg.CacheDir
 	if cacheDir == "" {
@@ -75,6 +93,14 @@ func Resolve(cfg ResolveConfig) (*Resolved, error) {
 	client := cfg.HTTPClient
 	if client == nil {
 		client = &http.Client{Timeout: 180 * time.Second}
+	}
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = osvExportBaseURL
+	}
+	maxAge := cfg.MaxAge
+	if maxAge <= 0 {
+		maxAge = DefaultMaxAge
 	}
 
 	ecos := uniqueOSVEcosystems(cfg.Ecosystems)
@@ -97,9 +123,11 @@ func Resolve(cfg ResolveConfig) (*Resolved, error) {
 		dest := filepath.Join(cacheDir, sanitizeEco(osvEco)+".zip")
 		var data []byte
 		thisFromCache := true
-		if !cfg.NoUpdate {
+		// Cache-first: fetch only when online AND (forced, or the cache is missing
+		// or stale). A fresh cache is reused without touching the network.
+		if !cfg.NoUpdate && (cfg.ForceRefresh || cacheStale(dest, maxAge)) {
 			onBytes := func(n int64) { report(ResolveProgress{BytesRead: n}) }
-			if fetched, ferr := fetchExport(client, osvEco, onBytes); ferr == nil {
+			if fetched, ferr := fetchExport(client, baseURL, osvEco, onBytes); ferr == nil {
 				thisFromCache = false
 				_ = atomicWrite(dest, fetched) // cache best-effort; use the bytes regardless
 				data = fetched
@@ -135,10 +163,22 @@ func Resolve(cfg ResolveConfig) (*Resolved, error) {
 	}, nil
 }
 
+// cacheStale reports whether the cached export at path is missing or older than
+// maxAge and so should be re-fetched. This is a cache-freshness decision based on
+// file mtime only — it never affects the resolved snapshot's Version (the content
+// hash of the bytes used) or the report, so determinism holds.
+func cacheStale(path string, maxAge time.Duration) bool {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return true // missing or unreadable → fetch
+	}
+	return time.Since(fi.ModTime()) > maxAge
+}
+
 // fetchExport downloads {base}/{osvEcosystem}/all.zip, streaming byte progress
 // to onBytes (which may be nil) so a UI can show download status.
-func fetchExport(client *http.Client, osvEco string, onBytes func(int64)) ([]byte, error) {
-	url := fmt.Sprintf("%s/%s/all.zip", osvExportBaseURL, osvEco)
+func fetchExport(client *http.Client, base, osvEco string, onBytes func(int64)) ([]byte, error) {
+	url := fmt.Sprintf("%s/%s/all.zip", base, osvEco)
 	resp, err := client.Get(url)
 	if err != nil {
 		return nil, err

--- a/internal/vulndb/resolve_test.go
+++ b/internal/vulndb/resolve_test.go
@@ -3,9 +3,13 @@ package vulndb
 import (
 	"archive/zip"
 	"bytes"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestLoadRecordsFromZip(t *testing.T) {
@@ -123,5 +127,91 @@ func TestResolve_OnProgressReportsEachEcosystem(t *testing.T) {
 	}
 	if !last.FromCache || last.Records != 1 || last.OSVEcosystem != "PyPI" || last.Index != 1 || last.Total != 1 {
 		t.Errorf("unexpected finish event: %+v", last)
+	}
+}
+
+func TestCacheStale(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "x.zip")
+	if !cacheStale(p, time.Hour) {
+		t.Error("a missing file must be stale (fetch)")
+	}
+	if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if cacheStale(p, time.Hour) {
+		t.Error("a just-written file must be fresh (no fetch)")
+	}
+	old := time.Now().Add(-2 * time.Hour)
+	_ = os.Chtimes(p, old, old)
+	if !cacheStale(p, time.Hour) {
+		t.Error("a 2h-old file must be stale vs a 1h maxAge")
+	}
+}
+
+// TestResolve_CacheFirst is the regression guard for the re-download bug: a fresh
+// cache must be reused without re-fetching; only a missing/stale cache (or
+// ForceRefresh) hits the network. A counting fake OSV server makes the fetch
+// count observable.
+func TestResolve_CacheFirst(t *testing.T) {
+	var z bytes.Buffer
+	zw := zip.NewWriter(&z)
+	w, _ := zw.Create("GHSA-srv.json")
+	_, _ = w.Write([]byte(`{"id":"GHSA-srv","affected":[{"package":{"ecosystem":"PyPI","name":"requests"}}]}`))
+	_ = zw.Close()
+	zipBytes := z.Bytes()
+
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		_, _ = w.Write(zipBytes)
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	cfg := ResolveConfig{Ecosystems: []string{"pypi"}, CacheDir: dir, BaseURL: srv.URL}
+
+	// 1) cold cache → one fetch, cached.
+	if _, err := Resolve(cfg); err != nil {
+		t.Fatal(err)
+	}
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Fatalf("cold cache: want 1 fetch, got %d", got)
+	}
+	// 2) fresh cache → reused, NO new fetch (the bug this guards).
+	if _, err := Resolve(cfg); err != nil {
+		t.Fatal(err)
+	}
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Fatalf("fresh cache: want the cache reused (still 1 fetch), got %d", got)
+	}
+	// 3) stale cache → re-fetch.
+	old := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(filepath.Join(dir, "PyPI.zip"), old, old); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Resolve(cfg); err != nil {
+		t.Fatal(err)
+	}
+	if got := atomic.LoadInt32(&hits); got != 2 {
+		t.Fatalf("stale cache: want a re-fetch (2 total), got %d", got)
+	}
+	// 4) ForceRefresh → fetch even though the cache is now fresh.
+	cfg.ForceRefresh = true
+	if _, err := Resolve(cfg); err != nil {
+		t.Fatal(err)
+	}
+	if got := atomic.LoadInt32(&hits); got != 3 {
+		t.Fatalf("ForceRefresh: want a forced fetch (3 total), got %d", got)
+	}
+	// 5) NoUpdate → never fetch, even when stale.
+	old2 := time.Now().Add(-72 * time.Hour)
+	_ = os.Chtimes(filepath.Join(dir, "PyPI.zip"), old2, old2)
+	cfg.ForceRefresh, cfg.NoUpdate = false, true
+	if _, err := Resolve(cfg); err != nil {
+		t.Fatal(err)
+	}
+	if got := atomic.LoadInt32(&hits); got != 3 {
+		t.Fatalf("NoUpdate: want no fetch (still 3), got %d", got)
 	}
 }


### PR DESCRIPTION
## The bug

Every online `--vuln-scan` **re-downloaded the entire OSV export** — PyPI's is ~23 MB, npm's far larger. `Resolve` fetched unconditionally and only *read* the cache as an offline fallback, so the cache was effectively write-only:

```go
if !cfg.NoUpdate { fetch... }   // always fetched when online
if data == nil { /* read cache */ }  // cache only when the fetch failed
```

Measured before the fix — two back-to-back scans of the same repo with a populated cache:
```
run 1 (cold): real 3.24s
run 2 (warm): real 3.19s     ← 23 MB PyPI.zip in cache, re-downloaded anyway
```

## The fix — cache-first

Resolution now reuses a cached ecosystem export when it is present and younger than `DefaultMaxAge` (24h), fetching only a **missing or stale** one. A fetch failure still falls back to whatever is cached.

```
run 1 (cold): real 3.83s   (downloads)
run 2 (warm): real 1.27s   (reuses cache — no download)
same vulnerabilities: True
same scan_id:         True   ← snapshot now pinned within the TTL
```

As a bonus, this makes repeated `--vuln-scan` runs produce a **stable `ScanID`** within the window (the snapshot is genuinely pinned) instead of flip-flopping whenever live OSV data changed between runs.

## What changed

- **`ResolveConfig`** gains:
  - `MaxAge time.Duration` — cache reuse window (0 ⇒ 24h).
  - `ForceRefresh bool` — always fetch (used by `vulndb pull`).
  - `BaseURL string` — overridable OSV base (enterprise mirror / test injection).
- **`cacheStale(path, maxAge)`** gates the fetch on file mtime. This is a cache-freshness decision only — it never affects the snapshot `Version` (the content hash of the bytes used) or the report, so determinism holds.
- **`vulndb pull`** sets `ForceRefresh` to refresh on demand; **`--no-rules-update`** (`NoUpdate`) still pins to the cache at any age (fully offline).

## Modes

| Invocation | Behavior |
|---|---|
| `scan --vuln-scan` | reuse cache < 24h; fetch if missing/stale |
| `scan --vuln-scan --no-rules-update` | cache only, never fetch (offline) |
| `vulndb pull` | force-refresh the cache |

## Tests

- `TestResolve_CacheFirst` — regression guard via a request-counting fake OSV server: fresh cache reused (no fetch), stale cache re-fetched, `ForceRefresh` forces a fetch, `NoUpdate` never fetches.
- `TestCacheStale` — missing/fresh/aged mtime cases.
- Full suite green (19 packages), gofmt + vet clean.

Refs: TR-271