### PR TITLE
feat(mcp): add opt-in vuln_scan arg to the scan tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,9 +633,11 @@ stderr.
 
 It exposes two tools:
 
-- `scan` — input `{ "path": "<dir>", "rules_ref": "<branch-or-tag>"? }`. Scans
-  `path` and returns the full scan result (findings, scores, discovered
-  inventory) as JSON — the same shape as `--format json`.
+- `scan` — input `{ "path": "<dir>", "rules_ref": "<branch-or-tag>"?, "vuln_scan": true? }`.
+  Scans `path` and returns the full scan result (findings, scores, discovered
+  inventory) as JSON — the same shape as `--format json`. Set `vuln_scan: true`
+  to also match declared dependencies against a pinned OSV snapshot and report
+  known CVEs (mirrors `--vuln-scan`; off by default).
 - `version` — reports the build version, commit, and date.
 
 Register it with an MCP client by pointing the client at the binary with the

--- a/cmd/trustabl/mcp.go
+++ b/cmd/trustabl/mcp.go
@@ -113,6 +113,10 @@ func runMCP(ctx context.Context, f mcpFlags, level logx.Level) error {
 			Progress:       progress.NewNop(),
 			Log:            log,
 			Ctx:            ctx,
+			// Opt-in OSV vulnerability matching (mirrors the CLI's --vuln-scan);
+			// the OSV offline switch reuses --no-rules-update, as the CLI does.
+			VulnScan:     req.VulnScan,
+			VulnNoUpdate: f.noRulesUpdate,
 		}
 		return scanner.Run(cfg)
 	}

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -16,10 +16,13 @@ const protocolVersion = "2024-11-05"
 
 // ScanRequest is the input schema for the `scan` tool. Path is required and
 // names a local directory or repository to scan; RulesRef optionally pins the
-// detection-rules branch or tag (mirrors the CLI's --rules-ref).
+// detection-rules branch or tag (mirrors the CLI's --rules-ref). VulnScan opts
+// the call into OSV dependency-vulnerability matching (mirrors --vuln-scan): off
+// by default, so a scan stays offline-capable and fast unless the client asks.
 type ScanRequest struct {
 	Path     string `json:"path"`
 	RulesRef string `json:"rules_ref,omitempty"`
+	VulnScan bool   `json:"vuln_scan,omitempty"`
 }
 
 // ScanFunc runs a scan for the `scan` tool and returns the deterministic
@@ -156,7 +159,7 @@ func (s *Server) toolsListResult() map[string]any {
 }
 
 // scanInputSchema is the JSON Schema for the `scan` tool input. path is
-// required; rules_ref is optional.
+// required; rules_ref and vuln_scan are optional.
 const scanInputSchema = `{
   "type": "object",
   "properties": {
@@ -167,6 +170,10 @@ const scanInputSchema = `{
     "rules_ref": {
       "type": "string",
       "description": "Optional detection-rules branch or tag to use (default: the rules repo's default branch)."
+    },
+    "vuln_scan": {
+      "type": "boolean",
+      "description": "Match declared dependencies against a pinned OSV snapshot and report known CVEs in 'vulnerabilities' and as findings (default false; fetches the OSV database on first use, then reuses the cache)."
     }
   },
   "required": ["path"],

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -150,6 +150,49 @@ func TestScanTool_ReturnsFindings(t *testing.T) {
 	}
 }
 
+// TestScanTool_VulnScanArg proves the optional vuln_scan tool argument is parsed
+// from the call and threaded into the ScanRequest — the seam the production
+// handler reads to set Config.VulnScan. It also locks the input schema and the
+// ScanRequest struct in sync (the schema must advertise vuln_scan).
+func TestScanTool_VulnScanArg(t *testing.T) {
+	var got ScanRequest
+	srv := New(func(_ context.Context, req ScanRequest) (models.ScanResult, error) {
+		got = req
+		return models.ScanResult{ScanID: "x"}, nil
+	}, VersionInfo{Version: "test"})
+
+	call := mustJSON(t, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name":      "scan",
+			"arguments": map[string]any{"path": "/repo", "vuln_scan": true},
+		},
+	})
+	resps := roundTrip(t, srv, call)
+	if len(resps) != 1 || resps[0].Error != nil {
+		t.Fatalf("unexpected response: %+v", resps)
+	}
+	if got.Path != "/repo" {
+		t.Errorf("path = %q, want /repo", got.Path)
+	}
+	if !got.VulnScan {
+		t.Errorf("vuln_scan arg was not threaded into ScanRequest: %+v", got)
+	}
+
+	// The schema must advertise vuln_scan, or a client never knows to send it.
+	var schema struct {
+		Properties map[string]json.RawMessage `json:"properties"`
+	}
+	if err := json.Unmarshal([]byte(scanInputSchema), &schema); err != nil {
+		t.Fatalf("scanInputSchema invalid: %v", err)
+	}
+	if _, ok := schema.Properties["vuln_scan"]; !ok {
+		t.Errorf("scanInputSchema does not advertise vuln_scan: %v", schema.Properties)
+	}
+}
+
 // TestScanTool_MissingPath returns an isError tool result, not a protocol
 // error: the model should see a usable message.
 func TestScanTool_MissingPath(t *testing.T) {


### PR DESCRIPTION
## Summary

The CLI grew `--vuln-scan` (OSV CVE matching), but the MCP `scan` tool didn't expose it — so MCP clients got the dependency inventory and rule findings, but never the CVE findings or the `vulnerabilities[]` array. This closes that parity gap.

Adds an optional **`vuln_scan`** boolean to the scan tool input that threads through to `Config.VulnScan`. Off by default, so a scan stays offline-capable and fast unless the client opts in; the OSV offline switch reuses `--no-rules-update`, mirroring the CLI.

Verified through the real MCP protocol (`tools/call` with `vuln_scan: true` against a repo pinning vulnerable deps):
```
MCP scan WITH vuln_scan:true →
  vulnerabilities[]: 22
  CVE/GHSA/PYSEC findings: 22
  e.g. CVE-2026-27205  requirements.txt:4  medium
```
Without the arg (or `vuln_scan: false`), the scan behaves exactly as before — inventory + rule findings, no network beyond rule resolution.

## What changed

- **`mcpserver.ScanRequest`** gains `vuln_scan` (`bool`, `omitempty`), and **`scanInputSchema`** advertises it so a client knows to send it.
- **`cmd/trustabl/mcp.go`** sets `Config.VulnScan = req.VulnScan` and `Config.VulnNoUpdate = f.noRulesUpdate`.
- The MCP output already passed `models.ScanResult` through unchanged (`json.MarshalIndent(result)`), so the `vulnerabilities` and CVE findings flow with **no serialization change**.
- README: documents the new `vuln_scan` arg on the `scan` tool.

## Tests

- `TestScanTool_VulnScanArg` — drives a `tools/call` with `vuln_scan: true` over the in-memory protocol pipes and asserts the arg threads into `ScanRequest`, plus that `scanInputSchema` advertises `vuln_scan` (keeps the schema and struct in sync).
- Full suite green (19 packages), gofmt + vet clean.

Refs: TR-271