### PR TITLE
fix(progress): smooth byte-driven bar for the --vuln-scan OSV download

### DIFF
--- a/internal/progress/plain.go
+++ b/internal/progress/plain.go
@@ -24,9 +24,10 @@ func (r *plainReporter) StartPhase(key, label string) {
 	// in a non-UTF-8 console or log where U+2026 mojibakes.
 	fmt.Fprintf(r.w, "[%s] %s...\n", key, label)
 }
-func (r *plainReporter) SetTotal(int)            {}
-func (r *plainReporter) Advance(string)          {}
-func (r *plainReporter) SetDetail(string)        {}
-func (r *plainReporter) ResetPhase()             {}
-func (r *plainReporter) EndPhase(summary string) { fmt.Fprintf(r.w, "[%s] %s\n", r.key, summary) }
-func (r *plainReporter) Fatal(err error)         { fmt.Fprintf(r.w, "[%s] failed: %v\n", r.key, err) }
+func (r *plainReporter) SetTotal(int)                {}
+func (r *plainReporter) Advance(string)              {}
+func (r *plainReporter) SetDetail(string)            {}
+func (r *plainReporter) SetProgress(float64, string) {}
+func (r *plainReporter) ResetPhase()                 {}
+func (r *plainReporter) EndPhase(summary string)     { fmt.Fprintf(r.w, "[%s] %s\n", r.key, summary) }
+func (r *plainReporter) Fatal(err error)             { fmt.Fprintf(r.w, "[%s] failed: %v\n", r.key, err) }

--- a/internal/progress/reporter.go
+++ b/internal/progress/reporter.go
@@ -14,13 +14,14 @@ const (
 // Reporter receives progress events. All wording (labels/summaries) is supplied
 // by the caller; implementations only render.
 type Reporter interface {
-	StartPhase(key, label string) // begin a phase
-	SetTotal(n int)               // optional: switch the phase to an n-step bar
-	Advance(detail string)        // tick the bar; detail = current file/entity
-	SetDetail(detail string)      // set the live detail line without a count/bar (spinner phases: clone sub-phase, network status)
-	ResetPhase()                  // clear the active phase's bar/count/detail back to a bare spinner (e.g. a clone falling back from a counted fetch to an uncounted one)
-	EndPhase(summary string)      // finish: emit a persistent "[key] summary"
-	Fatal(err error)              // a phase failed; tear the UI down cleanly
+	StartPhase(key, label string)                // begin a phase
+	SetTotal(n int)                              // optional: switch the phase to an n-step bar
+	Advance(detail string)                       // tick the bar; detail = current file/entity
+	SetDetail(detail string)                     // set the live detail line without a count/bar (spinner phases: clone sub-phase, network status)
+	SetProgress(fraction float64, detail string) // determinate bar at an explicit 0..1 fill (e.g. a byte-driven download), with a detail line and no N/M counter
+	ResetPhase()                                 // clear the active phase's bar/count/detail back to a bare spinner (e.g. a clone falling back from a counted fetch to an uncounted one)
+	EndPhase(summary string)                     // finish: emit a persistent "[key] summary"
+	Fatal(err error)                             // a phase failed; tear the UI down cleanly
 }
 
 // PickMode resolves the render mode from output settings. isTTY reflects whether
@@ -40,10 +41,11 @@ type nopReporter struct{}
 // NewNop returns a Reporter that does nothing.
 func NewNop() Reporter { return nopReporter{} }
 
-func (nopReporter) StartPhase(string, string) {}
-func (nopReporter) SetTotal(int)              {}
-func (nopReporter) Advance(string)            {}
-func (nopReporter) SetDetail(string)          {}
-func (nopReporter) ResetPhase()               {}
-func (nopReporter) EndPhase(string)           {}
-func (nopReporter) Fatal(error)               {}
+func (nopReporter) StartPhase(string, string)   {}
+func (nopReporter) SetTotal(int)                {}
+func (nopReporter) Advance(string)              {}
+func (nopReporter) SetDetail(string)            {}
+func (nopReporter) SetProgress(float64, string) {}
+func (nopReporter) ResetPhase()                 {}
+func (nopReporter) EndPhase(string)             {}
+func (nopReporter) Fatal(error)                 {}

--- a/internal/progress/tty.go
+++ b/internal/progress/tty.go
@@ -43,6 +43,10 @@ type startPhaseMsg struct{ key, label string }
 type setTotalMsg struct{ n int }
 type advanceMsg struct{ detail string }
 type setDetailMsg struct{ detail string }
+type setProgressMsg struct {
+	fraction float64
+	detail   string
+}
 type resetPhaseMsg struct{}
 type endPhaseMsg struct{ summary string }
 type doneMsg struct{}
@@ -60,6 +64,8 @@ type stage struct {
 	key, label   string
 	state        int
 	total, count int
+	fraction     float64 // determinate 0..1 fill when hasFraction (byte-driven download bar)
+	hasFraction  bool
 	detail       string
 	summary      string
 	err          error
@@ -110,12 +116,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case setTotalMsg:
 		if s := m.current(); s != nil {
-			s.total = msg.n
+			s.total, s.hasFraction = msg.n, false
 		}
 		return m, nil
 	case advanceMsg:
 		if s := m.current(); s != nil {
 			s.count++
+			s.hasFraction = false
 			s.detail = msg.detail
 		}
 		return m, nil
@@ -124,13 +131,26 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			s.detail = msg.detail
 		}
 		return m, nil
+	case setProgressMsg:
+		// Determinate fraction bar (byte-driven download): set an explicit 0..1
+		// fill so the bar climbs smoothly with the bytes, not in per-step jumps.
+		if s := m.current(); s != nil {
+			f := msg.fraction
+			if f < 0 {
+				f = 0
+			} else if f > 1 {
+				f = 1
+			}
+			s.fraction, s.hasFraction, s.detail = f, true, msg.detail
+		}
+		return m, nil
 	case resetPhaseMsg:
 		// Drop the active phase back to a bare spinner: a counted fetch that
 		// failed and is now retrying via an uncounted path must not leave a stale
 		// bar frozen mid-fill (the bar branch in renderStage outranks detail, so
 		// total/count have to be cleared, not just the detail overwritten).
 		if s := m.current(); s != nil {
-			s.total, s.count, s.detail = 0, 0, ""
+			s.total, s.count, s.detail, s.hasFraction = 0, 0, "", false
 		}
 		return m, nil
 	case endPhaseMsg:
@@ -213,6 +233,11 @@ func (m model) renderStage(s *stage, withSpinner bool) string {
 		lead = "•"
 	}
 	switch {
+	case s.hasFraction:
+		// Determinate fraction bar (byte-driven download): the bar fill follows the
+		// explicit fraction and the detail carries the human "14.2 MB / 23.1 MB" —
+		// no N/M counter, since the unit is bytes, not steps.
+		return fmt.Sprintf("%s %s %s  %s", lead, s.label, m.bar.ViewAs(s.fraction), s.detail)
 	case s.total > 0:
 		// Known total → an accurate bar (inventory/analysis, and the clone's
 		// receiving-objects phase). Clamp: a count that overshoots total (a bad
@@ -303,8 +328,11 @@ func (r *TTYReporter) StartPhase(key, label string) { r.send(startPhaseMsg{key, 
 func (r *TTYReporter) SetTotal(n int)               { r.send(setTotalMsg{n}) }
 func (r *TTYReporter) Advance(detail string)        { r.send(advanceMsg{detail}) }
 func (r *TTYReporter) SetDetail(detail string)      { r.send(setDetailMsg{detail}) }
-func (r *TTYReporter) ResetPhase()                  { r.send(resetPhaseMsg{}) }
-func (r *TTYReporter) EndPhase(summary string)      { r.send(endPhaseMsg{summary}) }
-func (r *TTYReporter) Fatal(err error)              { r.send(fatalMsg{err}) }
+func (r *TTYReporter) SetProgress(fraction float64, detail string) {
+	r.send(setProgressMsg{fraction, detail})
+}
+func (r *TTYReporter) ResetPhase()             { r.send(resetPhaseMsg{}) }
+func (r *TTYReporter) EndPhase(summary string) { r.send(endPhaseMsg{summary}) }
+func (r *TTYReporter) Fatal(err error)         { r.send(fatalMsg{err}) }
 
 var _ Reporter = (*TTYReporter)(nil)

--- a/internal/progress/tty_test.go
+++ b/internal/progress/tty_test.go
@@ -106,6 +106,39 @@ func TestModelSetDetailShowsSpinnerLineNoBar(t *testing.T) {
 	}
 }
 
+// setProgressMsg drives a determinate fraction bar (byte-driven download): the
+// fill follows the explicit 0..1 fraction and the detail carries the human byte
+// counts, with no N/M step counter. This is what makes the vuln-scan download bar
+// climb smoothly instead of jumping per ecosystem.
+func TestModelSetProgressShowsFractionBar(t *testing.T) {
+	m := newModel()
+	m2, _ := m.Update(startPhaseMsg{key: "vuln-scan", label: "Vulnerability scan"})
+	m3, _ := m2.(model).Update(setProgressMsg{fraction: 0.5, detail: "downloading PyPI (1/1) — 12.0 MB / 23.0 MB"})
+	mm := m3.(model)
+	s := mm.current()
+	if s == nil || !s.hasFraction || s.fraction != 0.5 {
+		t.Fatalf("after setProgress: stage fraction state wrong: %+v", s)
+	}
+	v := mm.View()
+	if !strings.Contains(v, "Vulnerability scan") || !strings.Contains(v, "12.0 MB / 23.0 MB") {
+		t.Errorf("view should show label + byte detail, got %q", v)
+	}
+	if !strings.Contains(v, "━") && !strings.Contains(v, "─") {
+		t.Errorf("fraction phase must render a bar, got %q", v)
+	}
+	// A bare slash in the byte detail is fine; the point is no "<count>/<total>"
+	// STEP counter (which would imply discrete ecosystem steps, the old behavior).
+	if strings.Contains(v, " 1/1 ") || strings.Contains(v, " 0/1 ") {
+		t.Errorf("fraction bar must not render an N/M step counter, got %q", v)
+	}
+
+	// A fraction > 1 is clamped (a byte overrun must not overfill the bar).
+	m4, _ := mm.Update(setProgressMsg{fraction: 1.7, detail: "matching"})
+	if s := m4.(model).current(); s.fraction != 1 {
+		t.Errorf("fraction should clamp to 1, got %v", s.fraction)
+	}
+}
+
 // completedLine renders a finished stage: a check mark, the stage
 // label, and its summary — but suppresses the summary when it's already in the
 // label (the clone label carries the URL, so it must not be doubled).

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -332,13 +332,14 @@ func TestScanExamples_NoCrash(t *testing.T) {
 // which phases fired.
 type recordingReporter struct{ phases []string }
 
-func (r *recordingReporter) StartPhase(key, _ string) { r.phases = append(r.phases, key) }
-func (r *recordingReporter) SetTotal(int)             {}
-func (r *recordingReporter) Advance(string)           {}
-func (r *recordingReporter) SetDetail(string)         {}
-func (r *recordingReporter) ResetPhase()              {}
-func (r *recordingReporter) EndPhase(string)          {}
-func (r *recordingReporter) Fatal(error)              {}
+func (r *recordingReporter) StartPhase(key, _ string)    { r.phases = append(r.phases, key) }
+func (r *recordingReporter) SetTotal(int)                {}
+func (r *recordingReporter) Advance(string)              {}
+func (r *recordingReporter) SetDetail(string)            {}
+func (r *recordingReporter) SetProgress(float64, string) {}
+func (r *recordingReporter) ResetPhase()                 {}
+func (r *recordingReporter) EndPhase(string)             {}
+func (r *recordingReporter) Fatal(error)                 {}
 
 // A local target resolves instantly (no clone), so the scan must NOT emit a
 // "clone" phase — otherwise local scans would show a spurious "Cloning" line.

--- a/internal/scanner/vuln.go
+++ b/internal/scanner/vuln.go
@@ -16,34 +16,45 @@ import (
 // The scan never queries the OSV API per dependency — matching is against the
 // cached snapshot only.
 //
-// rep drives the live progress display: a step bar over the ecosystems being
-// pulled, with a status line showing the current download (and its byte count)
-// or the cache hit. Progress is stderr-only and never affects the result.
+// rep drives the live progress display with a single determinate bar that climbs
+// smoothly across the whole resolve: each ecosystem contributes 1/N of the bar,
+// and within a download the bar advances by bytes (Content-Length), so a one-
+// ecosystem pull fills 0→100% as it downloads rather than jumping on completion.
+// The status line tracks the current step (resolving / downloading X / Y MB /
+// matching). Progress is stderr-only and never affects the result.
 func runVulnScan(deps []models.DepRef, noUpdate bool, cacheDir string, rep progress.Reporter) (vulns []models.DepVuln, version string, err error) {
-	sized := false
 	res, err := vulndb.Resolve(vulndb.ResolveConfig{
 		Ecosystems: depEcosystems(deps),
 		NoUpdate:   noUpdate,
 		CacheDir:   cacheDir,
 		OnProgress: func(p vulndb.ResolveProgress) {
-			if !sized {
-				rep.SetTotal(p.Total) // size the bar to the ecosystem count on the first event
-				sized = true
+			total := p.Total
+			if total < 1 {
+				total = 1
 			}
+			idx := float64(p.Index - 1) // 0-based slot for this ecosystem
 			switch {
 			case p.Finished:
-				rep.Advance(finishedVulnDetail(p))
-			case p.BytesRead > 0:
-				rep.SetDetail(fmt.Sprintf("downloading %s database — %s", p.OSVEcosystem, humanizeBytes(p.BytesRead)))
-			default:
-				rep.SetDetail("resolving " + p.OSVEcosystem + " database…")
+				rep.SetProgress(float64(p.Index)/float64(total), finishedVulnDetail(p))
+			case p.BytesRead > 0 && p.BytesTotal > 0:
+				frac := float64(p.BytesRead) / float64(p.BytesTotal)
+				if frac > 1 {
+					frac = 1
+				}
+				rep.SetProgress((idx+frac)/float64(total),
+					fmt.Sprintf("downloading %s (%d/%d) — %s / %s", p.OSVEcosystem, p.Index, total, humanizeBytes(p.BytesRead), humanizeBytes(p.BytesTotal)))
+			case p.BytesRead > 0: // downloading, content length unknown
+				rep.SetProgress(idx/float64(total),
+					fmt.Sprintf("downloading %s (%d/%d) — %s", p.OSVEcosystem, p.Index, total, humanizeBytes(p.BytesRead)))
+			default: // ecosystem started
+				rep.SetProgress(idx/float64(total), "resolving "+p.OSVEcosystem+" database…")
 			}
 		},
 	})
 	if err != nil {
 		return nil, "", err
 	}
-	rep.SetDetail(fmt.Sprintf("matching %d dependencies against the OSV snapshot", len(deps)))
+	rep.SetProgress(1, fmt.Sprintf("matching %d dependencies against the OSV snapshot", len(deps)))
 	return vulndb.Match(deps, res.DB), res.Version, nil
 }
 

--- a/internal/vulndb/resolve.go
+++ b/internal/vulndb/resolve.go
@@ -55,13 +55,15 @@ type ResolveConfig struct {
 
 // ResolveProgress reports per-ecosystem resolution progress to the optional
 // ResolveConfig.OnProgress hook. It fires once when an ecosystem starts, again
-// for roughly every 1 MiB downloaded, and once when the ecosystem finishes
-// (loaded from the network or the cache, or skipped when neither is available).
+// for roughly every 512 KiB downloaded (with BytesRead/BytesTotal for a smooth
+// download fraction), and once when the ecosystem finishes (loaded from the
+// network or the cache, or skipped when neither is available).
 type ResolveProgress struct {
 	OSVEcosystem string // OSV export name being resolved, e.g. "PyPI", "npm"
 	Index        int    // 1-based position in the resolve order
 	Total        int    // total ecosystems being resolved
 	BytesRead    int64  // cumulative bytes downloaded so far (0 if cached / just started)
+	BytesTotal   int64  // total bytes to download (HTTP Content-Length; 0 if unknown), for a download progress fraction
 	Finished     bool   // the ecosystem is done (data loaded or skipped)
 	FromCache    bool   // Finished: loaded from cache, no successful fetch
 	Records      int    // Finished: number of advisory records loaded
@@ -126,7 +128,7 @@ func Resolve(cfg ResolveConfig) (*Resolved, error) {
 		// Cache-first: fetch only when online AND (forced, or the cache is missing
 		// or stale). A fresh cache is reused without touching the network.
 		if !cfg.NoUpdate && (cfg.ForceRefresh || cacheStale(dest, maxAge)) {
-			onBytes := func(n int64) { report(ResolveProgress{BytesRead: n}) }
+			onBytes := func(read, total int64) { report(ResolveProgress{BytesRead: read, BytesTotal: total}) }
 			if fetched, ferr := fetchExport(client, baseURL, osvEco, onBytes); ferr == nil {
 				thisFromCache = false
 				_ = atomicWrite(dest, fetched) // cache best-effort; use the bytes regardless
@@ -176,8 +178,10 @@ func cacheStale(path string, maxAge time.Duration) bool {
 }
 
 // fetchExport downloads {base}/{osvEcosystem}/all.zip, streaming byte progress
-// to onBytes (which may be nil) so a UI can show download status.
-func fetchExport(client *http.Client, base, osvEco string, onBytes func(int64)) ([]byte, error) {
+// to onBytes (which may be nil) so a UI can show download status. onBytes
+// receives (bytesRead, contentLength); contentLength is 0 when the server does
+// not advertise it.
+func fetchExport(client *http.Client, base, osvEco string, onBytes func(read, total int64)) ([]byte, error) {
 	url := fmt.Sprintf("%s/%s/all.zip", base, osvEco)
 	resp, err := client.Get(url)
 	if err != nil {
@@ -187,26 +191,27 @@ func fetchExport(client *http.Client, base, osvEco string, onBytes func(int64)) 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("vulndb: GET %s: %s", url, resp.Status)
 	}
-	return readAllProgress(resp.Body, onBytes)
+	return readAllProgress(resp.Body, resp.ContentLength, onBytes)
 }
 
-// readAllProgress reads r to completion, invoking onBytes with the cumulative
-// byte count at ~1 MiB granularity (and once more with the exact final total) so
-// a UI can show download progress without being flooded. onBytes may be nil. The
-// returned bytes are identical to io.ReadAll(r) — progress never alters the data,
-// so the snapshot hash (and thus ScanID) is unaffected.
-func readAllProgress(r io.Reader, onBytes func(int64)) ([]byte, error) {
+// readAllProgress reads r to completion, invoking onBytes(bytesRead, total) at
+// ~512 KiB granularity (and once more with the exact final count) so a UI can
+// show a smooth download bar without being flooded. total is the content length
+// (<=0 if unknown). onBytes may be nil. The returned bytes are identical to
+// io.ReadAll(r) — progress never alters the data, so the snapshot hash (and thus
+// ScanID) is unaffected.
+func readAllProgress(r io.Reader, total int64, onBytes func(read, total int64)) ([]byte, error) {
 	var buf bytes.Buffer
 	chunk := make([]byte, 64*1024)
-	var total, reported int64
+	var read, reported int64
 	for {
 		n, rerr := r.Read(chunk)
 		if n > 0 {
 			buf.Write(chunk[:n])
-			total += int64(n)
-			if onBytes != nil && total-reported >= 1<<20 {
-				onBytes(total)
-				reported = total
+			read += int64(n)
+			if onBytes != nil && read-reported >= 1<<19 {
+				onBytes(read, total)
+				reported = read
 			}
 		}
 		if rerr == io.EOF {
@@ -216,8 +221,8 @@ func readAllProgress(r io.Reader, onBytes func(int64)) ([]byte, error) {
 			return nil, rerr
 		}
 	}
-	if onBytes != nil && total != reported {
-		onBytes(total)
+	if onBytes != nil && read != reported {
+		onBytes(read, total)
 	}
 	return buf.Bytes(), nil
 }

--- a/internal/vulndb/resolve_test.go
+++ b/internal/vulndb/resolve_test.go
@@ -57,9 +57,13 @@ func TestResolve_OfflineNoCacheIsEmpty(t *testing.T) {
 // reports a monotonic byte count ending at the exact total, and returns the full
 // data unchanged (so the snapshot hash is unaffected).
 func TestReadAllProgress_ReportsCumulativeBytes(t *testing.T) {
-	data := bytes.Repeat([]byte("x"), 3<<20) // 3 MiB → reports near 1/2/3 MiB
+	data := bytes.Repeat([]byte("x"), 3<<20) // 3 MiB → reports at ~512 KiB steps
 	var reports []int64
-	out, err := readAllProgress(bytes.NewReader(data), func(n int64) { reports = append(reports, n) })
+	var sawTotal int64
+	out, err := readAllProgress(bytes.NewReader(data), int64(len(data)), func(read, total int64) {
+		reports = append(reports, read)
+		sawTotal = total
+	})
 	if err != nil {
 		t.Fatalf("readAllProgress: %v", err)
 	}
@@ -77,12 +81,15 @@ func TestReadAllProgress_ReportsCumulativeBytes(t *testing.T) {
 	if last := reports[len(reports)-1]; last != int64(len(data)) {
 		t.Errorf("final report %d != total %d", last, len(data))
 	}
+	if sawTotal != int64(len(data)) {
+		t.Errorf("content-length passed to hook = %d, want %d", sawTotal, len(data))
+	}
 }
 
 // TestReadAllProgress_NilCallback proves a nil hook is safe (the vulndb-pull /
 // no-UI path).
 func TestReadAllProgress_NilCallback(t *testing.T) {
-	out, err := readAllProgress(bytes.NewReader([]byte("hello")), nil)
+	out, err := readAllProgress(bytes.NewReader([]byte("hello")), 5, nil)
 	if err != nil || string(out) != "hello" {
 		t.Fatalf("readAllProgress(nil) = %q, %v", out, err)
 	}


### PR DESCRIPTION
## The bug

The `--vuln-scan` progress bar was driven by **ecosystem-completion steps** (`SetTotal(N)` + `Advance` per ecosystem), so it only moved 0 → 1/N → … → done. The actual slow part — the multi-MB OSV download — only updated the *detail text*, never the bar fill. So a single-ecosystem (Python-only) pull sat **frozen at 0%** for the entire ~23 MB download, then snapped to 100%; a two-ecosystem repo went **0 → 50 → 100** (exactly what was reported). There was also no clear status progression during "scanning".

## The fix — a determinate, byte-driven bar

- Add **`Reporter.SetProgress(fraction float64, detail string)`** — fills the bar to an explicit 0..1 value with a detail line and **no N/M step counter** (the unit is bytes, not steps). Implemented in the TTY reporter (a new `setProgressMsg` + a `hasFraction` render branch); no-op in plain/nop.
- Drive it from `runVulnScan` with a **global byte-weighted fraction**: each ecosystem owns `1/N` of the bar, and within a download the bar advances by bytes (HTTP `Content-Length`). So a one-ecosystem pull climbs **0 → 100% smoothly**, and a multi-ecosystem resolve climbs continuously across all of them.
- The status line now tracks every step: `resolving PyPI…` → `downloading PyPI (1/1) — 11.7 MB / 23.3 MB` (climbing) → `matching N dependencies`.
- `readAllProgress` now reports `(bytesRead, contentLength)` at ~512 KiB granularity (was 1 MiB) for a fluid fill.

## Verified against live OSV

The bar fraction climbing through a real 23.3 MB PyPI pull (~2% steps):
```
[                    ]   0%  ?/?
[=                   ]   6%  1.5MB/23.3MB
[==========          ]  50%  11.7MB/23.3MB
[====================]  99%  23.1MB/23.3MB
[====================] 100%  23.3MB/23.3MB
```
Cached ecosystems (no bytes) still step instantly; that's correct — there's nothing to animate.

## Determinism / contract

Progress is stderr-only and never touches `ScanResult`. `readAllProgress` returns the same bytes as before (content-length is read-only metadata), so the snapshot hash and `ScanID` are unchanged.

## Tests

- `TestModelSetProgressShowsFractionBar` — the TTY model renders a fraction bar + byte detail, no N/M counter, and clamps `fraction > 1`.
- `readAllProgress` tests updated for the `(read, total)` hook (assert the content length is passed through).
- Full suite green (19 packages), gofmt + vet clean.

Refs: TR-271