### PR TITLE
feat(progress): per-package progress during the dependency scan

### DIFF
--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -449,8 +449,7 @@ func Run(cfg Config) (models.ScanResult, error) {
 	var vulns []models.DepVuln
 	var vulnDBVersion string
 	if cfg.VulnScan {
-		rep.StartPhase("vuln-scan", "Vulnerability scan")
-		rep.SetDetail(fmt.Sprintf("%d dependencies in scope", len(inventory.Dependencies)))
+		// runVulnScan owns its two progress phases (resolve + scan).
 		v, ver, verr := runVulnScan(inventory.Dependencies, cfg.VulnNoUpdate, cfg.VulnCacheDir, rep)
 		if verr != nil {
 			log.Verbosef("vuln-scan: %v (continuing without vuln findings)", verr)
@@ -458,7 +457,6 @@ func Run(cfg Config) (models.ScanResult, error) {
 			vulns, vulnDBVersion = v, ver
 			findings = append(findings, vulnFindings(vulns)...)
 		}
-		rep.EndPhase(fmt.Sprintf("%d vulnerabilities across %d dependencies", len(vulns), len(inventory.Dependencies)))
 		log.Verbosef("vuln-scan: OSV snapshot %s · %d dependency vulnerabilities", vulnDBVersion, len(vulns))
 	}
 

--- a/internal/scanner/vuln.go
+++ b/internal/scanner/vuln.go
@@ -16,13 +16,18 @@ import (
 // The scan never queries the OSV API per dependency — matching is against the
 // cached snapshot only.
 //
-// rep drives the live progress display with a single determinate bar that climbs
-// smoothly across the whole resolve: each ecosystem contributes 1/N of the bar,
-// and within a download the bar advances by bytes (Content-Length), so a one-
-// ecosystem pull fills 0→100% as it downloads rather than jumping on completion.
-// The status line tracks the current step (resolving / downloading X / Y MB /
-// matching). Progress is stderr-only and never affects the result.
+// rep drives two live phases, owned here so the work and the UI stay together:
+//
+//  1. "Resolving vulnerability database" — the OSV download, with a determinate
+//     bar that climbs smoothly by bytes: each ecosystem owns 1/N of the bar, and
+//     within a download the bar advances by Content-Length, so a one-ecosystem
+//     pull fills 0→100% as it downloads instead of jumping on completion.
+//  2. "Scanning dependencies" — the local match, with a fresh bar that advances
+//     per package and a status line naming the package currently being scanned.
+//
+// Progress is stderr-only and never affects the result.
 func runVulnScan(deps []models.DepRef, noUpdate bool, cacheDir string, rep progress.Reporter) (vulns []models.DepVuln, version string, err error) {
+	rep.StartPhase("vuln-resolve", "Resolving vulnerability database")
 	res, err := vulndb.Resolve(vulndb.ResolveConfig{
 		Ecosystems: depEcosystems(deps),
 		NoUpdate:   noUpdate,
@@ -52,10 +57,30 @@ func runVulnScan(deps []models.DepRef, noUpdate bool, cacheDir string, rep progr
 		},
 	})
 	if err != nil {
+		rep.EndPhase("unavailable")
 		return nil, "", err
 	}
-	rep.SetProgress(1, fmt.Sprintf("matching %d dependencies against the OSV snapshot", len(deps)))
-	return vulndb.Match(deps, res.DB), res.Version, nil
+	rep.EndPhase(fmt.Sprintf("%d advisories", res.DB.Len()))
+
+	// Phase 2: scan each declared dependency against the snapshot. The bar
+	// advances per package and the detail names the one being scanned; updates are
+	// throttled to ~100 frames so a huge BOM doesn't flood the render channel.
+	rep.StartPhase("vuln-scan", "Scanning dependencies")
+	total := len(deps)
+	step := total / 100
+	if step < 1 {
+		step = 1
+	}
+	scanned := 0
+	vulns = vulndb.Match(deps, res.DB, func(d models.DepRef) {
+		scanned++
+		if scanned == total || scanned%step == 0 {
+			rep.SetProgress(float64(scanned)/float64(total),
+				fmt.Sprintf("scanning %s %s (%d/%d)", d.Name, d.Version, scanned, total))
+		}
+	})
+	rep.EndPhase(fmt.Sprintf("%d vulnerabilities across %d dependencies", len(vulns), total))
+	return vulns, res.Version, nil
 }
 
 // finishedVulnDetail renders the persistent detail for a resolved ecosystem,

--- a/internal/vulndb/match.go
+++ b/internal/vulndb/match.go
@@ -124,10 +124,16 @@ func (db *DB) Len() int {
 }
 
 // Match returns the vulnerabilities affecting deps, sorted and de-duplicated.
-// Only concretely-pinned deps are considered (see package doc).
-func Match(deps []models.DepRef, db *DB) []models.DepVuln {
+// Only concretely-pinned deps are considered (see package doc). onDep, if set,
+// is called with each dependency as it is checked — for a per-package progress
+// display. It fires for every declared dep, including the ranges that are then
+// skipped, so a UI can show the scan working through the whole BOM.
+func Match(deps []models.DepRef, db *DB, onDep func(models.DepRef)) []models.DepVuln {
 	var out []models.DepVuln
 	for _, d := range deps {
+		if onDep != nil {
+			onDep(d)
+		}
 		if !isConcreteVersion(d.Version) {
 			continue
 		}

--- a/internal/vulndb/match_test.go
+++ b/internal/vulndb/match_test.go
@@ -61,7 +61,7 @@ func TestMatch_RealRecords(t *testing.T) {
 		{Name: "left-pad", Version: "1.0.0", Ecosystem: "npm", Source: "package.json"},         // withdrawn record → no match
 	}
 
-	got := Match(deps, db)
+	got := Match(deps, db, nil)
 	if len(got) != 4 {
 		t.Fatalf("want 4 vulns, got %d: %+v", len(got), got)
 	}
@@ -107,11 +107,34 @@ func TestMatch_GitRangeFixedSkipped(t *testing.T) {
 			},
 		}},
 	}
-	got := Match([]models.DepRef{{Name: "requests", Version: "2.19.0", Ecosystem: "pypi", Source: "requirements.txt"}}, NewDB([]Record{rec}))
+	got := Match([]models.DepRef{{Name: "requests", Version: "2.19.0", Ecosystem: "pypi", Source: "requirements.txt"}}, NewDB([]Record{rec}), nil)
 	if len(got) != 1 {
 		t.Fatalf("want 1 vuln, got %d: %+v", len(got), got)
 	}
 	if got[0].FixedIn != "2.20.0" {
 		t.Errorf("FixedIn = %q, want 2.20.0 (the GIT commit SHA must be skipped)", got[0].FixedIn)
+	}
+}
+
+// TestMatch_OnDepFiresPerDependency proves the per-package progress hook fires
+// once for every declared dep — concrete and skipped-range alike — in order.
+// This is what drives the "Scanning dependencies" bar and the package name shown.
+func TestMatch_OnDepFiresPerDependency(t *testing.T) {
+	db := NewDB(realisticRecords())
+	deps := []models.DepRef{
+		{Name: "lodash", Version: "4.17.4", Ecosystem: "npm"},
+		{Name: "ranged", Version: "^1.0.0", Ecosystem: "npm"}, // a range → skipped internally, still reported
+		{Name: "requests", Version: "2.19.0", Ecosystem: "pypi"},
+	}
+	var seen []string
+	Match(deps, db, func(d models.DepRef) { seen = append(seen, d.Name) })
+	want := []string{"lodash", "ranged", "requests"}
+	if len(seen) != len(want) {
+		t.Fatalf("onDep fired %d times, want %d (every dep): %v", len(seen), len(want), seen)
+	}
+	for i := range want {
+		if seen[i] != want[i] {
+			t.Errorf("onDep[%d] = %q, want %q (must fire for every dep, in order)", i, seen[i], want[i])
+		}
 	}
 }


### PR DESCRIPTION
## What

The `--vuln-scan` phase filled the bar during the OSV **download**, then ran the actual **match** (scanning each dependency against the database) as one invisible step — no feedback on which package was being scanned. This splits it into **two visible phases**, and the scan phase reports each package.

```
=== Resolving vulnerability database ===
  [  0%] resolving PyPI database…
  [100%] PyPI — 20359 advisories (cached)
  done -> 19940 advisories
=== Scanning dependencies ===
  [ 25%] scanning flask 2.3.3 (1/4)
  [ 50%] scanning jinja2 2.10 (2/4)
  [ 75%] scanning pyyaml 5.1 (3/4)
  [100%] scanning requests 2.19.0 (4/4)
  done -> 22 vulnerabilities across 4 dependencies
```

## How

- **`vulndb.Match`** gains an `onDep func(models.DepRef)` callback, fired once per declared dependency — concrete and skipped-range alike, in order — so a UI can show the scan working through the whole BOM.
- **`runVulnScan`** now owns two progress phases: `Resolving vulnerability database` (the byte-driven download bar from the prior change) and a fresh `Scanning dependencies` bar driven by `onDep`, advancing per package with the package name + `(i/N)` count in the status line. Updates are throttled to ~100 frames so a large BOM can't flood the render channel.
- **`scanner.go`** Step 4b no longer manages the vuln phase (moved into `runVulnScan`, so the work and its UI live together).

## Determinism / contract

Progress is stderr-only; `Match` returns the same vulnerabilities (the callback is a side-channel), so the result and `ScanID` are unchanged.

## Tests

- `TestMatch_OnDepFiresPerDependency` — the hook fires once per dep, in order, including a skipped range.
- Existing `Match` callers updated for the new arg; integration (`TestScan_VulnScan_OfflineFixture`) still green.
- Full suite green (19 packages), gofmt + vet clean.

Refs: TR-271