### PR TITLE
fix(progress): drop the useless step bar for cached vuln-db resolution

### DIFF
--- a/internal/progress/tty.go
+++ b/internal/progress/tty.go
@@ -127,8 +127,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case setDetailMsg:
+		// SetDetail means "spinner + status line, no bar" — so it also clears a
+		// prior determinate fraction bar (e.g. switching from a download to a fast
+		// cache load), per its documented semantics.
 		if s := m.current(); s != nil {
-			s.detail = msg.detail
+			s.detail, s.hasFraction = msg.detail, false
 		}
 		return m, nil
 	case setProgressMsg:

--- a/internal/progress/tty_test.go
+++ b/internal/progress/tty_test.go
@@ -139,6 +139,27 @@ func TestModelSetProgressShowsFractionBar(t *testing.T) {
 	}
 }
 
+// SetDetail after SetProgress must drop the bar back to a spinner+status line —
+// this is what lets the vuln-scan resolve phase switch from a download bar to a
+// no-bar cache-load status without leaving a frozen bar behind.
+func TestModelSetDetailClearsFractionBar(t *testing.T) {
+	m := newModel()
+	m2, _ := m.Update(startPhaseMsg{key: "vuln-resolve", label: "Resolving"})
+	m3, _ := m2.(model).Update(setProgressMsg{fraction: 0.5, detail: "downloading npm — 45 MB / 197 MB"})
+	if s := m3.(model).current(); !s.hasFraction {
+		t.Fatal("precondition: SetProgress should set hasFraction")
+	}
+	m4, _ := m3.(model).Update(setDetailMsg{detail: "loaded PyPI (cached, 2/2)"})
+	mm := m4.(model)
+	if s := mm.current(); s.hasFraction {
+		t.Error("SetDetail must clear the fraction bar (hasFraction=false)")
+	}
+	v := mm.View()
+	if !strings.Contains(v, "loaded PyPI (cached, 2/2)") {
+		t.Errorf("view should show the cache status, got %q", v)
+	}
+}
+
 // completedLine renders a finished stage: a check mark, the stage
 // label, and its summary — but suppresses the summary when it's already in the
 // label (the clone label carries the URL, so it must not be doubled).

--- a/internal/scanner/vuln.go
+++ b/internal/scanner/vuln.go
@@ -18,10 +18,11 @@ import (
 //
 // rep drives two live phases, owned here so the work and the UI stay together:
 //
-//  1. "Resolving vulnerability database" — the OSV download, with a determinate
-//     bar that climbs smoothly by bytes: each ecosystem owns 1/N of the bar, and
-//     within a download the bar advances by Content-Length, so a one-ecosystem
-//     pull fills 0→100% as it downloads instead of jumping on completion.
+//  1. "Resolving vulnerability database" — the OSV pull. A determinate bar is
+//     shown ONLY while actually downloading, where it climbs by bytes
+//     (Content-Length) so a big pull fills 0→100%. A cache load is instant and
+//     has no bytes, so it shows a spinner + status line instead of a meaningless
+//     step bar that would just jump 0→100% per database.
 //  2. "Scanning dependencies" — the local match, with a fresh bar that advances
 //     per package and a status line naming the package currently being scanned.
 //
@@ -39,20 +40,27 @@ func runVulnScan(deps []models.DepRef, noUpdate bool, cacheDir string, rep progr
 			}
 			idx := float64(p.Index - 1) // 0-based slot for this ecosystem
 			switch {
-			case p.Finished:
-				rep.SetProgress(float64(p.Index)/float64(total), finishedVulnDetail(p))
 			case p.BytesRead > 0 && p.BytesTotal > 0:
+				// Real download with a known size → determinate byte bar.
 				frac := float64(p.BytesRead) / float64(p.BytesTotal)
 				if frac > 1 {
 					frac = 1
 				}
 				rep.SetProgress((idx+frac)/float64(total),
 					fmt.Sprintf("downloading %s (%d/%d) — %s / %s", p.OSVEcosystem, p.Index, total, humanizeBytes(p.BytesRead), humanizeBytes(p.BytesTotal)))
-			case p.BytesRead > 0: // downloading, content length unknown
-				rep.SetProgress(idx/float64(total),
-					fmt.Sprintf("downloading %s (%d/%d) — %s", p.OSVEcosystem, p.Index, total, humanizeBytes(p.BytesRead)))
-			default: // ecosystem started
-				rep.SetProgress(idx/float64(total), "resolving "+p.OSVEcosystem+" database…")
+			case p.BytesRead > 0:
+				// Downloading, size unknown → spinner + running byte count.
+				rep.SetDetail(fmt.Sprintf("downloading %s (%d/%d) — %s", p.OSVEcosystem, p.Index, total, humanizeBytes(p.BytesRead)))
+			case p.Finished && p.FromCache:
+				// Cache load is instant → spinner + status, no jumpy step bar.
+				rep.SetDetail(fmt.Sprintf("loaded %s — %d advisories (cached, %d/%d)", p.OSVEcosystem, p.Records, p.Index, total))
+			case p.Finished:
+				// A downloaded ecosystem finished → leave its byte bar full.
+				rep.SetProgress(float64(p.Index)/float64(total), finishedVulnDetail(p))
+			default:
+				// Ecosystem started; not yet known whether it downloads or is
+				// cached → spinner only, no bar.
+				rep.SetDetail("resolving " + p.OSVEcosystem + " database…")
 			}
 		},
 	})


### PR DESCRIPTION
## The problem

The "Resolving vulnerability database" bar was **useless when loading from cache** — it jumped `0 → 50 → 100` for two cached databases. A determinate bar only means something when there's a measurable, slow quantity to track (bytes during a download); a cache load is instant and has no bytes, so the bar just stepped by ecosystem count.

## The fix

Show the determinate bar **only while actually downloading** (where it climbs by `Content-Length`); a **cache load now shows a spinner + status line, no bar**.

Cached (was a 0/50/100 flash):
```
=== Resolving vulnerability database ===
  ⠙  resolving PyPI database…
  ⠙  loaded PyPI — 20359 advisories (cached, 1/1)
  ✔  19940 advisories
```
Fresh download (unchanged — the byte bar is genuinely useful here):
```
  ⠙       resolving PyPI database…
  [  2%]  downloading PyPI — 527 KB / 23.3 MB
  [ 17%]  downloading PyPI — 4.0 MB / 23.3 MB    …climbing
```

`SetDetail` now also clears a prior determinate fraction bar — matching its documented "status line without a count/bar" semantics — so a **mixed** resolve (one database downloaded, another cached) transitions from the byte bar to the cache-load status without leaving a frozen bar behind.

## Determinism / contract

Progress is stderr-only; results and `ScanID` unchanged.

## Tests

- `TestModelSetDetailClearsFractionBar` — `SetDetail` after `SetProgress` drops the bar back to a spinner+status line.
- Full suite green (19 packages), gofmt + vet clean.

Refs: TR-271