### PR TITLE
chore(plugin): update Claude Code plugin + skills to trustabl 0.1.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "trustabl",
-  "version": "0.1.2",
-  "description": "Self-audit AI agent, tool, and MCP-server code for security and reliability misconfigurations with Trustabl, the static analyzer for the OpenAI Agents SDK, Claude Agent SDK, Google ADK, and MCP. Ships two skills: trustabl-scan scans your agent code with Trustabl (via a bundled MCP server) right after you write or change it, before you commit, and trustabl-enrich applies the scan findings directly to your source files as targeted code edits.",
+  "version": "0.1.4",
+  "description": "Self-audit AI agent, tool, and MCP-server code for security and reliability misconfigurations with Trustabl, the static analyzer for the OpenAI Agents SDK, Claude Agent SDK, Google ADK, and MCP. Ships two skills: trustabl-scan scans your agent code with Trustabl (via a bundled MCP server) right after you write or change it, before you commit — optionally matching your declared dependencies against the OSV database for known CVEs — and trustabl-enrich applies the scan findings directly to your source files as targeted code edits.",
   "homepage": "https://github.com/trustabl/trustabl",
   "author": { "name": "Trustabl", "url": "https://github.com/trustabl" },
   "license": "Apache-2.0",

--- a/scripts/lib-trustabl.sh
+++ b/scripts/lib-trustabl.sh
@@ -7,8 +7,10 @@
 # stream and must not be polluted.
 
 # Pinned CLI version the plugin targets. The MCP `scan` tool needs >= 0.1.3
-# (0.1.2 has no `mcp` subcommand). Bump on a plugin release to move users on.
-TRUSTABL_VERSION="0.1.3"
+# (0.1.2 has no `mcp` subcommand); 0.1.4 adds dependency vulnerability scanning
+# (the `vuln_scan` tool arg / `--vuln-scan`) and renames a finding's `line` to
+# `start_line`/`end_line`. Bump on a plugin release to move users on.
+TRUSTABL_VERSION="0.1.4"
 TRUSTABL_REPO="trustabl/trustabl"
 TRUSTABL_INSTALL_HINT="install with 'brew install trustabl/tap/trustabl' (macOS/Linux), 'scoop install trustabl' (Windows), or download from https://github.com/${TRUSTABL_REPO}/releases"
 

--- a/skills/trustabl-enrich/SKILL.md
+++ b/skills/trustabl-enrich/SKILL.md
@@ -46,9 +46,15 @@ If the input cannot be parsed or contains zero findings, report clearly and stop
 - Fix (primary): `result.fixes[0].description.text` — present on most results
 - Fix (fallback): `runs[0].tool.driver.rules[]` — match on `id == ruleId`, read `help.text`; use when `fixes` array is absent
 
+**JSON extraction path:**
+- Findings: `findings[]`
+- File + line range: `file_path` + `start_line` … `end_line` (1-indexed, inclusive; a single-line finding sets `end_line == start_line`; both are `0` for repo-level findings with no location). Note: Trustabl 0.1.4 renamed the former flat `line` field to `start_line` / `end_line` — read those, not `line`.
+- Explanation: `explanation` · Fix: `suggested_fix`
+- Also present per finding: `rule_id`, `scope`, `severity`, `confidence`. Dependency CVE findings (when the scan ran with `--vuln-scan` / `vuln_scan`) appear in the same `findings` array — the advisory id (CVE / GHSA / PYSEC) is the `rule_id`, and `start_line` points at the dependency's line in its manifest. The structured `vulnerabilities[]` array carries the same matches with `fixed_in` versions.
+
 ## Workflow
 
-1. **Parse** — detect the format and normalize every finding into: `file`, `line`, `rule_id`, `scope`, `severity`, `confidence`, `explanation`, `suggested_fix`.
+1. **Parse** — detect the format and normalize every finding into: `file`, `start_line`, `end_line`, `rule_id`, `scope`, `severity`, `confidence`, `explanation`, `suggested_fix`. (For SARIF, `end_line` may be absent for a single-line region — fall back to `start_line`.)
 
 2. **Summarize** — render a Markdown table before touching any file:
 
@@ -74,7 +80,7 @@ INPUTS
 You will receive:
 1. The current content of a source file
 2. A list of findings for that file, each with:
-   - line: flagged line number
+   - start_line / end_line: the flagged line range (1-indexed, inclusive; equal for a single-line finding)
    - rule_id: Trustabl rule that fired
    - scope: tool | agent | subagent | repo
    - severity: info | low | medium | high | critical
@@ -106,7 +112,7 @@ SCOPE GUIDE
 
 RULES
 - The scan's `explanation` and `suggested_fix` fields are the authoritative spec. Do not invent a different solution.
-- line_start and line_end MUST include the flagged line. Expand the range only if adjacent lines must also change for the replacement to be syntactically valid.
+- line_start and line_end MUST include the flagged range (start_line..end_line). Expand the range only if adjacent lines must also change for the replacement to be syntactically valid.
 - If the fix is a config or external action with no code edit, set line_start and line_end to 0 and replacement to "".
 - Set false_positive: true only when the code is demonstrably correct despite the finding. Populate reason with the specific evidence.
 - Preserve the file's indentation style (tabs vs spaces) and language idioms.

--- a/skills/trustabl-scan/SKILL.md
+++ b/skills/trustabl-scan/SKILL.md
@@ -39,9 +39,11 @@ Invoke after you have just written or changed any of these, before committing:
 - Agent guardrails (`@input_guardrail` / `@output_guardrail`) or
   `.claude/settings.json` permission settings.
 
-Languages understood today: Python and TypeScript (`.ts` / `.tsx` / `.mts` /
-`.cts`). JavaScript and Go files are inventoried but not AST-parsed, so no tools
-or agents are extracted from them.
+Languages understood today: Python, TypeScript, and JavaScript (`.ts` / `.tsx` /
+`.mts` / `.cts` / `.js` / `.jsx` / `.mjs` / `.cjs`) for tools and agents, plus
+MCP-server tool discovery in Go, C#, PHP, and Rust. The dependency BOM (and
+`--vuln-scan`) spans all of those package ecosystems — pip, npm, Go modules,
+NuGet, Composer, and Cargo.
 
 ## How to run the scan
 
@@ -52,6 +54,10 @@ the repo you just edited:
 - `mcp__trustabl__scan` with `{"path": "."}` — scan the current repo.
 - Optionally `{"path": ".", "rules_ref": "<branch-or-tag>"}` to pin the
   detection-rules ref.
+- Optionally `{"path": ".", "vuln_scan": true}` to also match the repo's declared
+  dependencies against a pinned OSV database and report known CVEs as findings
+  (plus a structured `vulnerabilities[]` array). Off by default; the first use
+  downloads the OSV snapshot, then reuses the cache.
 
 The tool returns the full scan result as JSON — the same `ScanResult` shape as
 the CLI's `--format json` output, with a `findings` array to reason over. There
@@ -69,6 +75,8 @@ on `PATH`:
 "$TRUSTABL_BIN" scan . --format json          # JSON, same shape the tool returns
 "$TRUSTABL_BIN" scan . --strict               # exit 1 on low+ findings (info/META never fail)
 "$TRUSTABL_BIN" scan . --detectors claude_sdk # narrow to one SDK: claude_sdk|openai_sdk|google_adk|openshell
+"$TRUSTABL_BIN" scan . --vuln-scan            # also match declared deps against OSV → CVE findings
+"$TRUSTABL_BIN" scan . --bom-out bom.json     # write a CycloneDX SBOM (+ VEX vulnerabilities under --vuln-scan)
 ```
 
 In the CLI fallback the exit code is the gate: `0` = no findings of medium
@@ -107,6 +115,13 @@ audit", or "this dep is declared but unused") are honest coverage signals, not
 defects, and never fail the build. Two agents in the same repo can be in very
 different postures, so always fix the agent the finding names, not the repo as a
 whole.
+
+**Dependency vulnerabilities** (only when the scan ran with `--vuln-scan` or the
+`vuln_scan: true` tool arg): each known CVE in a declared, concretely-pinned
+dependency is a finding whose `rule_id` is the advisory id (CVE / GHSA / PYSEC),
+located at the dependency's line in its manifest, with the fixed version in
+`suggested_fix`. They flow through the same severity gate as rule findings — fix
+by upgrading the dependency to the noted version.
 
 ## Remediation loop
 


### PR DESCRIPTION
Updates the bundled Claude Code plugin and its two skills for the **v0.1.4** release.

## Changes

- **Pinned CLI → 0.1.4** (`scripts/lib-trustabl.sh`) and **plugin version → 0.1.4** (`.claude-plugin/plugin.json`). The plugin's SessionStart bootstrap downloads + checksum-verifies + installs this version into its private data dir.
- **`trustabl-enrich` skill — JSON parsing fix (required):** v0.1.4 renamed a finding's flat `line` field to **`start_line` / `end_line`**. The skill now reads those (added an explicit JSON extraction path naming the fields), and passes the flagged line *range* to the enrichment model. SARIF path unchanged (`region.startLine` still exists; the skill's own `line_start`/`line_end` replacement-range schema is unaffected).
- **`trustabl-scan` skill — new capabilities:** documents `--vuln-scan` / the `vuln_scan: true` tool arg (OSV dependency-CVE matching) and `--bom-out` (CycloneDX SBOM + VEX), adds a "Dependency vulnerabilities" finding note, and refreshes the stale language line (JavaScript is now parsed for tools/agents; Go/C#/PHP/Rust have MCP-server tool discovery).

## Verified

- `plugin.json` valid JSON; all three shell scripts pass `sh -n`.
- The v0.1.4 release assets the pinned download targets (`trustabl_0.1.4_*.tar.gz`, `checksums.txt`) return HTTP 200.
- **End-to-end:** ran the real `scripts/check-trustabl.sh` against a temp data dir — it downloaded, checksum-verified, and installed v0.1.4, exported `$TRUSTABL_BIN`, and `trustabl version` → `Trustabl 0.1.4`.
- No stale `0.1.2` / `0.1.3` references remain.

Markdown + shell + JSON only — no engine code change.