### PR TITLE
Extend SKILL.md body parsing with shell, credential, dynamic-args, and skill-chain detection

### DIFF
--- a/internal/analysis/skills.go
+++ b/internal/analysis/skills.go
@@ -55,7 +55,7 @@ func DiscoverSkills(manifest models.ScanManifest) []models.SkillDef {
 			continue
 		}
 		tokens := splitToolsTokens([]string(parsed.AllowedTools))
-		dynExec, urls, markers := parseSkillBody(string(body))
+		dynExec, hasShellExec, urls, markers, hasCredLiteral, hasDynamicArgs, skillRefs := parseSkillBody(string(body))
 		out = append(out, models.SkillDef{
 			Name:                   parsed.Name,
 			Description:            parsed.Description,
@@ -69,8 +69,12 @@ func DiscoverSkills(manifest models.ScanManifest) []models.SkillDef {
 			Agent:                  parsed.Agent,
 			HasHooks:               parsed.Hooks.Kind == yaml.MappingNode && len(parsed.Hooks.Content) > 0,
 			DynamicExecCommands:    dynExec,
+			HasShellExec:           hasShellExec,
 			ExternalURLs:           urls,
 			InjectionMarkers:       markers,
+			HasCredentialLiteral:   hasCredLiteral,
+			HasDynamicArgs:         hasDynamicArgs,
+			ReferencesSkills:       skillRefs,
 			BundledFiles:           bundledFiles(manifest.RepoRoot, p),
 			Location:               models.Location{FilePath: p, Line: startLine, EndLine: endLine},
 		})
@@ -96,6 +100,29 @@ var (
 	// obfuscated injected instructions. The 160-char floor keeps ordinary hashes,
 	// tokens, and short data URIs from tripping this (low-confidence) signal.
 	skillBase64BlobRe = regexp.MustCompile(`[A-Za-z0-9+/]{160,}={0,2}`)
+	// skillShellFenceRe matches an ordinary ```bash or ```sh fenced code block
+	// (model-invocation time shell, distinct from the pre-model ```! exec fence).
+	skillShellFenceRe = regexp.MustCompile("(?m)^```(?:bash|sh)(?:\\s|$)")
+	// skillShellInlineRe matches subshell syntax and common shell-invocation
+	// patterns in non-fenced body text.
+	skillShellInlineRe = regexp.MustCompile(`\$\(|\bsubprocess\b|\bos\.system\b`)
+	// skillCredentialLiteralRe matches hardcoded secret VALUES committed in the
+	// SKILL.md body itself (not bundled scripts). Mirrors bundledSecretLiteralRe
+	// for the body surface.
+	skillCredentialLiteralRe = regexp.MustCompile(
+		`AKIA[0-9A-Z]{16}` + // AWS access key id
+			`|ghp_[0-9A-Za-z]{36}` + // GitHub personal access token (classic)
+			`|github_pat_[0-9A-Za-z_]{82}` + // GitHub fine-grained PAT
+			`|xox[baprs]-[0-9A-Za-z-]{10,72}` + // Slack token
+			`|sk-[A-Za-z0-9]{40,}` + // OpenAI-style secret key
+			`|AIza[0-9A-Za-z_-]{35}` + // Google API key
+			`|-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----`) // private-key block header
+	// skillDynamicArgsRe matches $ARGUMENTS (the Claude Code user-text
+	// placeholder) and common template-interpolation patterns.
+	skillDynamicArgsRe = regexp.MustCompile(`\$ARGUMENTS|\{\{[^}]+\}\}|\$INPUT\b|\$USER_INPUT\b`)
+	// skillChainRefRe matches references to other skill invocations in the body.
+	// Group 1 captures the skill name from /skill <name> or skill: <name>.
+	skillChainRefRe = regexp.MustCompile(`(?i)/skill\s+(\S+)`)
 )
 
 // zeroWidthChars are invisible code points used to smuggle injected instructions
@@ -130,10 +157,10 @@ func hasBidiControl(s string) bool {
 }
 
 // parseSkillBody extracts security-relevant facts from the markdown body of a
-// SKILL.md (everything below the frontmatter). Output is deterministic: commands
-// and URLs are returned in first-seen order with duplicates removed; markers are
-// fixed symbolic tokens. See models.SkillDef for field semantics.
-func parseSkillBody(body string) (dynExec, urls, markers []string) {
+// SKILL.md (everything below the frontmatter). Output is deterministic: commands,
+// URLs, and skill refs are returned in first-seen order with duplicates removed;
+// markers are fixed symbolic tokens. See models.SkillDef for field semantics.
+func parseSkillBody(body string) (dynExec []string, hasShellExec bool, urls []string, markers []string, hasCredLiteral, hasDynamicArgs bool, skillRefs []string) {
 	// Fenced ```! blocks: every non-blank line until the closing fence is a
 	// pre-model shell command. Scanned first, so a multi-line block is captured
 	// ahead of the inline pass.
@@ -155,6 +182,7 @@ func parseSkillBody(body string) (dynExec, urls, markers []string) {
 	for _, m := range skillInlineExecRe.FindAllStringSubmatch(body, -1) {
 		dynExec = append(dynExec, strings.TrimSpace(m[1]))
 	}
+	hasShellExec = skillShellFenceRe.MatchString(body) || skillShellInlineRe.MatchString(body)
 	urls = skillExternalURLRe.FindAllString(body, -1)
 	if skillInjectionPhraseRe.MatchString(body) {
 		markers = append(markers, "instruction-override-phrase")
@@ -171,7 +199,12 @@ func parseSkillBody(body string) (dynExec, urls, markers []string) {
 	if skillBase64BlobRe.MatchString(body) {
 		markers = append(markers, "long-base64-blob")
 	}
-	return dedupeStrings(dynExec), dedupeStrings(urls), markers
+	hasCredLiteral = skillCredentialLiteralRe.MatchString(body)
+	hasDynamicArgs = skillDynamicArgsRe.MatchString(body)
+	for _, m := range skillChainRefRe.FindAllStringSubmatch(body, -1) {
+		skillRefs = append(skillRefs, m[1])
+	}
+	return dedupeStrings(dynExec), hasShellExec, dedupeStrings(urls), markers, hasCredLiteral, hasDynamicArgs, dedupeStrings(skillRefs)
 }
 
 // dedupeStrings returns in with duplicates removed, preserving first-seen order.

--- a/internal/analysis/skills_test.go
+++ b/internal/analysis/skills_test.go
@@ -252,6 +252,138 @@ func TestSkills_FrontmatterFields(t *testing.T) {
 	}
 }
 
+func TestSkills_BodyFacts_ShellExec(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"bash-fence", "---\nname: s\n---\n\n```bash\necho hi\n```\n"},
+		{"sh-fence", "---\nname: s\n---\n\n```sh\nls\n```\n"},
+		{"subshell-dollar-paren", "---\nname: s\n---\n\noutput=$(ls)\n"},
+		{"subprocess", "---\nname: s\n---\n\nsubprocess.run(['ls'])\n"},
+		{"os-system", "---\nname: s\n---\n\nos.system('ls')\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFixture(t, dir, "x/SKILL.md", tc.body)
+			manifest := models.ScanManifest{RepoRoot: dir, MarkdownFiles: []string{"x/SKILL.md"}}
+			got := analysis.DiscoverSkills(manifest)
+			if len(got) != 1 {
+				t.Fatalf("got %d skills, want 1", len(got))
+			}
+			if !got[0].HasShellExec {
+				t.Errorf("HasShellExec = false, want true for %q", tc.name)
+			}
+		})
+	}
+	// Clean body must not flag.
+	t.Run("clean-body", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFixture(t, dir, "x/SKILL.md", "---\nname: s\n---\n\nJust markdown prose.\n")
+		manifest := models.ScanManifest{RepoRoot: dir, MarkdownFiles: []string{"x/SKILL.md"}}
+		got := analysis.DiscoverSkills(manifest)
+		if len(got) != 1 {
+			t.Fatalf("got %d skills, want 1", len(got))
+		}
+		if got[0].HasShellExec {
+			t.Error("HasShellExec = true for clean body, want false")
+		}
+	})
+}
+
+func TestSkills_BodyFacts_CredentialLiteral(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		// AKIAIOSFODNN7EXAMPLE is the public AWS-docs synthetic key (16 uppercase alphanums after AKIA).
+		{"aws-key", "---\nname: s\n---\n\nkey: AKIAIOSFODNN7EXAMPLE\n"},
+		{"gh-token", "---\nname: s\n---\n\nghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n"},
+		{"slack-token", "---\nname: s\n---\n\nxoxb-111-222-abcdefghij\n"},
+		{"pem-header", "---\nname: s\n---\n\n-----BEGIN PRIVATE KEY-----\nMIIE...\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFixture(t, dir, "x/SKILL.md", tc.body)
+			manifest := models.ScanManifest{RepoRoot: dir, MarkdownFiles: []string{"x/SKILL.md"}}
+			got := analysis.DiscoverSkills(manifest)
+			if len(got) != 1 {
+				t.Fatalf("got %d skills, want 1", len(got))
+			}
+			if !got[0].HasCredentialLiteral {
+				t.Errorf("HasCredentialLiteral = false, want true for %q", tc.name)
+			}
+		})
+	}
+	t.Run("clean-body", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFixture(t, dir, "x/SKILL.md", "---\nname: s\n---\n\nJust markdown prose.\n")
+		manifest := models.ScanManifest{RepoRoot: dir, MarkdownFiles: []string{"x/SKILL.md"}}
+		got := analysis.DiscoverSkills(manifest)
+		if len(got) != 1 {
+			t.Fatalf("got %d skills, want 1", len(got))
+		}
+		if got[0].HasCredentialLiteral {
+			t.Error("HasCredentialLiteral = true for clean body, want false")
+		}
+	})
+}
+
+func TestSkills_BodyFacts_DynamicArgs(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"ARGUMENTS", "---\nname: s\n---\n\nRun with $ARGUMENTS\n"},
+		{"template-braces", "---\nname: s\n---\n\n{{user_input}}\n"},
+		{"INPUT", "---\nname: s\n---\n\nProcess $INPUT now\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFixture(t, dir, "x/SKILL.md", tc.body)
+			manifest := models.ScanManifest{RepoRoot: dir, MarkdownFiles: []string{"x/SKILL.md"}}
+			got := analysis.DiscoverSkills(manifest)
+			if len(got) != 1 {
+				t.Fatalf("got %d skills, want 1", len(got))
+			}
+			if !got[0].HasDynamicArgs {
+				t.Errorf("HasDynamicArgs = false, want true for %q", tc.name)
+			}
+		})
+	}
+	t.Run("clean-body", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFixture(t, dir, "x/SKILL.md", "---\nname: s\n---\n\nJust markdown prose.\n")
+		manifest := models.ScanManifest{RepoRoot: dir, MarkdownFiles: []string{"x/SKILL.md"}}
+		got := analysis.DiscoverSkills(manifest)
+		if len(got) != 1 {
+			t.Fatalf("got %d skills, want 1", len(got))
+		}
+		if got[0].HasDynamicArgs {
+			t.Error("HasDynamicArgs = true for clean body, want false")
+		}
+	})
+}
+
+func TestSkills_BodyFacts_ReferencesSkills(t *testing.T) {
+	dir := t.TempDir()
+	body := "---\nname: s\n---\n\n/skill deploy\n/skill deploy\n/skill test-runner\n"
+	writeFixture(t, dir, "x/SKILL.md", body)
+	manifest := models.ScanManifest{RepoRoot: dir, MarkdownFiles: []string{"x/SKILL.md"}}
+	got := analysis.DiscoverSkills(manifest)
+	if len(got) != 1 {
+		t.Fatalf("got %d skills, want 1", len(got))
+	}
+	// Duplicates should be removed; order is first-seen.
+	want := []string{"deploy", "test-runner"}
+	if !reflect.DeepEqual(got[0].ReferencesSkills, want) {
+		t.Errorf("ReferencesSkills = %v, want %v", got[0].ReferencesSkills, want)
+	}
+}
+
 // TestSkills_CorpusFixtures runs discovery over the committed synthetic skill
 // corpus and asserts the enriched facts end-to-end (body + bundled files +
 // frontmatter), the same fixtures the CSKILL-* rule tests fire against.

--- a/internal/models/agent.go
+++ b/internal/models/agent.go
@@ -180,9 +180,16 @@ type SubagentDef struct {
 // dynamic-context injection (the inline !`cmd` form and ```! fenced blocks),
 // which Claude Code runs during preprocessing, before the model sees the
 // rendered skill — so model-level prompt-injection defenses never see them.
-// ExternalURLs and InjectionMarkers carry the indirect- and direct-injection
-// signals found in the body. BundledFiles inventories the skill's other shipped
-// files (scripts are the highest-risk bundled surface).
+// HasShellExec flags ordinary shell-code patterns in the body (```bash/sh fences,
+// $() subshell syntax, subprocess/os.system calls) that run at model-invocation
+// time, not preprocessing time. ExternalURLs and InjectionMarkers carry the
+// indirect- and direct-injection signals found in the body.
+// HasCredentialLiteral flags a hardcoded secret VALUE in the body (AWS/GH/Slack
+// tokens, private-key headers). HasDynamicArgs flags $ARGUMENTS or template
+// interpolation ({{...}}) — user-controlled text embedded directly in the skill
+// body. ReferencesSkills lists other skill names the body chains to.
+// BundledFiles inventories the skill's other shipped files (scripts are the
+// highest-risk bundled surface).
 type SkillDef struct {
 	Name                   string        `json:"name"`
 	Description            string        `json:"description,omitempty"`
@@ -196,8 +203,12 @@ type SkillDef struct {
 	Agent                  string        `json:"agent,omitempty"`
 	HasHooks               bool          `json:"has_hooks,omitempty"`
 	DynamicExecCommands    []string      `json:"dynamic_exec_commands,omitempty"`
+	HasShellExec           bool          `json:"has_shell_exec,omitempty"`
 	ExternalURLs           []string      `json:"external_urls,omitempty"`
 	InjectionMarkers       []string      `json:"injection_markers,omitempty"`
+	HasCredentialLiteral   bool          `json:"has_credential_literal,omitempty"`
+	HasDynamicArgs         bool          `json:"has_dynamic_args,omitempty"`
+	ReferencesSkills       []string      `json:"references_skills,omitempty"`
 	BundledFiles           []BundledFile `json:"bundled_files,omitempty"`
 	Location                             // file_path = SKILL.md path
 }


### PR DESCRIPTION
Summary

This PR extends Trustabl's skill discovery to analyze the full content of a SKILL.md file, not just its frontmatter. Previously, everything below the opening --- block was read from disk but immediately discarded. Now that body content is scanned for four additional security-relevant patterns.

What's new

Four new fields are added to the SkillDef struct that gets emitted in scan results and JSON output:

- HasShellExec — flags ordinary shell code in the body: bash/sh fenced code blocks, $() subshell syntax, and subprocess/os.system calls. This is distinct from the existing DynamicExecCommands field, which captures only the special !-exec form that Claude Code runs before the model even sees the skill.
- HasCredentialLiteral — flags a hardcoded secret value committed directly in the SKILL.md body: AWS access key IDs, GitHub tokens, Slack tokens, OpenAI-style API keys, Google API keys, and private key PEM headers.
- HasDynamicArgs — flags user-controlled text interpolation in the body: $ARGUMENTS (the Claude Code placeholder that gets replaced with whatever the user typed), and template patterns like {{user_input}}.
- ReferencesSkills — a deduplicated list of other skill names the body chains to via /skill <name>.

All four fields only appear in JSON output when non-zero (they use omitempty), so existing scan output is unaffected for clean skills.

Why this matters

The SKILL.md body is a meaningful attack surface. A skill with shell code, a committed credential, or unguarded user input in its body is riskier than its frontmatter alone suggests. These new facts give future detection rules the raw signal they need to flag those patterns without re-reading or re-parsing the file.

Tests

Four new test functions cover each new fact with per-pattern positive cases and a clean-body negative case. All existing skill tests continue to pass.

What this does not change

No rule YAML is modified in this PR. These fields are inputs for future CSKILL-* rules — the detection logic itself comes in a follow-up.