### PR TITLE
Gemini CLI extension and OpenAI Codex plugin support

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "trustabl",
+  "version": "0.1.4",
+  "description": "Self-audit AI agent, tool, and MCP-server code for security and reliability misconfigurations with Trustabl, the static analyzer for the OpenAI Agents SDK, Claude Agent SDK, Google ADK, and MCP. Ships two skills: trustabl-scan scans your agent code with Trustabl (via a bundled MCP server) right after you write or change it, before you commit — optionally matching your declared dependencies against the OSV database for known CVEs — and trustabl-enrich applies the scan findings directly to your source files as targeted code edits.",
+  "author": {
+    "name": "Trustabl",
+    "url": "https://github.com/trustabl"
+  },
+  "homepage": "https://github.com/trustabl/trustabl",
+  "repository": "https://github.com/trustabl/trustabl",
+  "license": "Apache-2.0",
+  "keywords": [
+    "security",
+    "static-analysis",
+    "agents",
+    "mcp",
+    "openai-agents-sdk",
+    "claude-agent-sdk",
+    "google-adk"
+  ],
+  "skills": "./skills/"
+}

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,2 @@
+@./skills/trustabl-scan/SKILL.md
+@./skills/trustabl-enrich/SKILL.md

--- a/README.md
+++ b/README.md
@@ -647,6 +647,27 @@ Register it with an MCP client by pointing the client at the binary with the
 claude mcp add trustabl -- trustabl mcp
 ```
 
+For Gemini CLI, add to `~/.gemini/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "trustabl": {
+      "command": "trustabl",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+For OpenAI Codex, add to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.trustabl]
+command = "trustabl"
+args = ["mcp"]
+```
+
 Or configure it directly in a client's MCP config (the `mcpServers` stdio
 shape used by Claude Desktop / Cursor):
 
@@ -699,6 +720,104 @@ run (offline first session, an unsupported platform, or missing `curl`/`tar`) it
 falls back to whatever `trustabl` is on `PATH`; the system-wide install stays a
 consented step inside `trustabl-scan`. The plugin runs no network service of its
 own and modifies nothing outside the scan target.
+
+### Gemini CLI extension (self-audit at generation time)
+
+Trustabl ships a Gemini CLI extension under [`gemini-extension.json`](gemini-extension.json)
+with the same two skills available in the Claude Code plugin.
+
+**Prerequisites.** Install the Trustabl binary first — the extension does not
+auto-install it the way the Claude Code plugin does (Gemini CLI has no private
+plugin data directory):
+
+```bash
+# macOS / Linux
+brew install trustabl/tap/trustabl
+
+# Windows
+scoop bucket add trustabl https://github.com/trustabl/scoop-bucket
+scoop install trustabl
+```
+
+**Install the extension:**
+
+```bash
+gemini extensions install https://github.com/trustabl/trustabl
+```
+
+**Register the MCP server** so Gemini CLI can call `mcp__trustabl__scan`. Add
+to `~/.gemini/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "trustabl": {
+      "command": "trustabl",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+**How it works.** When a Gemini CLI session starts, the extension injects
+[`GEMINI.md`](GEMINI.md) as context, which pulls in the full `trustabl-scan`
+and `trustabl-enrich` skill content via `@` imports. Gemini then treats those
+skills exactly as it would any loaded context: it runs the scan after you write
+or change agent, tool, or MCP-server code, and offers to apply findings via
+`trustabl-enrich`. The MCP tool is named `mcp__trustabl__scan` — the same name
+as in Claude Code.
+
+**Update the extension later:**
+
+```bash
+gemini extensions update trustabl
+```
+
+### OpenAI Codex plugin (self-audit at generation time)
+
+Trustabl ships an OpenAI Codex plugin under [`.codex-plugin/`](.codex-plugin/)
+with the same two skills.
+
+**Prerequisites.** Install the Trustabl binary first:
+
+```bash
+# macOS / Linux
+brew install trustabl/tap/trustabl
+
+# Windows
+scoop bucket add trustabl https://github.com/trustabl/scoop-bucket
+scoop install trustabl
+```
+
+**Install the plugin.** In Codex CLI, open the plugin search interface and
+search for `trustabl`:
+
+```bash
+/plugins
+```
+
+Search for `trustabl` and select **Install Plugin**. In the Codex App, go to
+**Plugins** in the sidebar, find Trustabl under the Security category, and
+click **+**.
+
+**Register the MCP server** so Codex can call `mcp__trustabl__scan`. Add to
+`~/.codex/config.toml`:
+
+```toml
+[mcp_servers.trustabl]
+command = "trustabl"
+args = ["mcp"]
+```
+
+**How it works.** Codex reads [`.codex-plugin/plugin.json`](.codex-plugin/plugin.json),
+which points `"skills": "./skills/"`. Codex loads the `trustabl-scan` and
+`trustabl-enrich` skills from that directory automatically — no explicit
+invocation step required. Skills trigger when you write or modify agent, tool,
+or MCP-server code, and Codex applies findings via `trustabl-enrich`. The MCP
+tool is named `mcp__trustabl__scan` — the same name as in Claude Code and Gemini CLI.
+
+To enable subagent delegation in Codex (used by `trustabl-enrich` for parallel
+file edits), set `multi_agent = true` in `~/.codex/config.toml`.
 
 ### "rules are newer than this Trustabl build"
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,6 @@
+{
+  "name": "trustabl",
+  "description": "Self-audit AI agent, tool, and MCP-server code for security and reliability misconfigurations with Trustabl — the static analyzer for the OpenAI Agents SDK, Claude Agent SDK, Google ADK, and MCP.",
+  "version": "0.1.4",
+  "contextFileName": "GEMINI.md"
+}


### PR DESCRIPTION
Ship gemini-extension.json and GEMINI.md so users can install the Trustabl Gemini CLI extension; the context file inlines both skills via @ imports. Add .codex-plugin/plugin.json so the Codex plugin loader discovers and loads the trustabl-scan and trustabl-enrich skills from ./skills/. Update README with install, MCP server config, and workflow instructions for both platforms.