### PR TITLE
feat(codex): add marketplace catalog for plugin discovery

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "trustabl",
+  "interface": {
+    "displayName": "Trustabl"
+  },
+  "plugins": [
+    {
+      "name": "trustabl",
+      "source": {
+        "source": "local",
+        "path": "./"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "security"
+    }
+  ]
+}


### PR DESCRIPTION
Codex requires a `.agents/plugins/marketplace.json` catalog file in the repo so that after running `codex plugin marketplace add trustabl/trustabl` it can find and install the plugin with `codex plugin add trustabl@trustabl`.

Without this file the marketplace source is added but the plugin listing is empty, producing "plugin not found" on install.