### PR TITLE
test(llm): isolate llm key-store tests from the developer's real API key

### DIFF
--- a/cmd/trustabl/llm_test.go
+++ b/cmd/trustabl/llm_test.go
@@ -8,12 +8,28 @@ import (
 	"github.com/trustabl/trustabl/internal/llm"
 )
 
-// setLLMConfigDir overrides the LLM config directory for the duration of the test.
+// llmEnvVars are the environment variables llm.Load consults before the
+// on-disk config. Tests must neutralize all of them so a key or model in the
+// developer's shell never bleeds into a test (and never leaks into output).
+var llmEnvVars = []string{
+	"ANTHROPIC_API_KEY",
+	"OPENAI_API_KEY",
+	"GOOGLE_API_KEY",
+	"TRUSTABL_LLM_MODEL",
+}
+
+// setLLMConfigDir isolates the LLM config for the duration of the test: it
+// points the key store at an isolated dir and clears the env-var key/model
+// path so no test reads or prints the developer's real API key. t.Setenv
+// auto-restores the values on cleanup, leaving the real environment intact.
 func setLLMConfigDir(t *testing.T, dir string) {
 	t.Helper()
 	old := llm.ConfigDir
 	llm.ConfigDir = dir
 	t.Cleanup(func() { llm.ConfigDir = old })
+	for _, k := range llmEnvVars {
+		t.Setenv(k, "")
+	}
 }
 
 func TestLLMList_NoConfig(t *testing.T) {

--- a/internal/llm/llm_test.go
+++ b/internal/llm/llm_test.go
@@ -8,16 +8,28 @@ import (
 	"github.com/trustabl/trustabl/internal/llm"
 )
 
-// setConfigDir overrides the config directory for the duration of the test
-// and clears the env-var key path so tests are isolated from a caller's shell.
+// llmEnvVars are the environment variables Load consults before the on-disk
+// config. Tests must neutralize all of them so a key or model in the
+// developer's shell never bleeds into a test (and never leaks into output).
+var llmEnvVars = []string{
+	"ANTHROPIC_API_KEY",
+	"OPENAI_API_KEY",
+	"GOOGLE_API_KEY",
+	"TRUSTABL_LLM_MODEL",
+}
+
+// setConfigDir overrides the config directory for the duration of the test and
+// clears the env-var key/model path so tests are isolated from a caller's
+// shell. Clearing uses t.Setenv (which auto-restores on cleanup) rather than
+// os.Unsetenv, so the developer's real environment is left intact.
 func setConfigDir(t *testing.T, dir string) {
 	t.Helper()
 	old := llm.ConfigDir
 	llm.ConfigDir = dir
 	t.Cleanup(func() { llm.ConfigDir = old })
-	os.Unsetenv("ANTHROPIC_API_KEY")
-	os.Unsetenv("OPENAI_API_KEY")
-	os.Unsetenv("GOOGLE_API_KEY")
+	for _, k := range llmEnvVars {
+		t.Setenv(k, "")
+	}
 }
 
 func TestLoad_Defaults(t *testing.T) {


### PR DESCRIPTION
## Problem

`llm.Load()` consults the env vars `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GOOGLE_API_KEY` / `TRUSTABL_LLM_MODEL` **before** it reads the on-disk config at `llm.ConfigDir`. The LLM tests overrode `ConfigDir` to a `t.TempDir()`, so the disk path was isolated, but the env-var short-circuit was not guarded:

- **`cmd/trustabl/llm_test.go`** (`setLLMConfigDir`) cleared **none** of those env vars. On a machine with a real key in the shell (e.g. an OpenAI `sk-proj-...`), `Load()` returned the real key and it was printed **in full** on failure, e.g. `Key not persisted, got "sk-proj-..."`. That is a credential leak into test output and CI logs, and it caused `TestLLMKeyGet_WithKey`, `TestLLMKeySet_ValidArg`, `TestLLMKeyDelete_Confirm`, `TestLLMModelSet`, `TestLLMProviderList_WithConfig` (and others) to fail.
- **`internal/llm/llm_test.go`** (`setConfigDir`) cleared the three key vars but via non-restoring `os.Unsetenv`, and missed `TRUSTABL_LLM_MODEL`, which leaks into the `TestLoad_EnvVarKey_*` model assertions.

## Fix

Both test helpers now neutralize all four env vars with `t.Setenv(k, "")`, which auto-restores the original values on cleanup (unlike `os.Unsetenv`), leaving the developer's real environment intact.

No production change was needed: the `llm.ConfigDir` override already isolated the on-disk path; only the env-var short-circuit in `Load()` was unguarded in the tests.

## Verification

Simulated "real key present" with a **fake** key+model (`OPENAI_API_KEY=sk-proj-FAKE...`, `TRUSTABL_LLM_MODEL=evil-model`), never touching a real key:

- Before: `cmd/trustabl` 9 failures (full key leaked); `internal/llm` `TestLoad_EnvVarKey_*` failures.
- After: `go test ./internal/llm/ ./cmd/trustabl/` with the injected env is **identical to the clean-env baseline**, and a `grep` for the fake-key substring over verbose output returns **0** matches. No key reaches test output.

## Reviewer note

`internal/llm` still shows one failure on Windows, `TestSave_FilePermissions` (`0666` vs `0600`). That is a **pre-existing, platform-specific** quirk unrelated to this change (`os.Chmod` on Windows only toggles the read-only bit and cannot produce Unix `0600`); it passes on Linux CI. It was failing on `main` before this PR and is left untouched here.