### PR TITLE
TR-324 Arm production genesis floor at first published statement version

### DIFF
--- a/internal/rulesource/genesis.go
+++ b/internal/rulesource/genesis.go
@@ -14,10 +14,15 @@ package rulesource
 // build-time constant on purpose: it is only as fresh as the engine binary, the
 // same trade-off as the embedded trust keyring.
 var genesisFloors = map[string]int64{
-	// "production": 1750000000,  // set to the first production statement's EXACT
-	// `version` field — an epoch-seconds integer under rulesctl's default scheme,
-	// NOT an ordinal. A wrong unit silently disarms (too low) or over-arms (too
-	// high) anti-rollback, so copy the published statement's version verbatim.
+	// The EXACT `version` of the first production statement published to
+	// channel-production (2026-06-16T19:56:20Z) — an epoch-seconds integer under
+	// rulesctl's default scheme, NOT an ordinal, copied verbatim from the signed
+	// statement. A fresh machine rejects any production statement older than this
+	// on first contact; later publishes have a larger epoch-seconds version and
+	// advance the per-machine recorded floor from here. Bump this on a deliberate
+	// cadence as the channel ages. A wrong unit silently disarms (too low) or
+	// over-arms (too high) anti-rollback.
+	"production": 1781639780,
 }
 
 // genesisFloor returns the embedded minimum trusted version for channel, or 0

--- a/internal/rulesource/genesis_test.go
+++ b/internal/rulesource/genesis_test.go
@@ -2,10 +2,26 @@ package rulesource
 
 import (
 	"errors"
+	"os"
 	"testing"
 
 	"github.com/trustabl/trustabl/internal/rulesign"
 )
+
+// realGenesisFloors snapshots the build-embedded genesis floors before the suite
+// zeroes the runtime map (see TestMain). The production-floor pin test asserts
+// against this snapshot; every other test then drives the floor explicitly from a
+// clean (no-floor) baseline, so synthetic small-version statements aren't blocked
+// by the real, epoch-seconds-scale production floor.
+var realGenesisFloors = map[string]int64{}
+
+func TestMain(m *testing.M) {
+	for k, v := range genesisFloors {
+		realGenesisFloors[k] = v
+	}
+	genesisFloors = map[string]int64{}
+	os.Exit(m.Run())
+}
 
 // TestReleaseSource_GenesisFloorRejectsBelowOnFreshMachine proves the
 // build-embedded genesis floor blunts trust-on-first-use: a brand-new machine
@@ -45,5 +61,18 @@ func TestReleaseSource_GenesisFloorRejectsBelowOnFreshMachine(t *testing.T) {
 func TestGenesisFloor_DefaultsToZero(t *testing.T) {
 	if got := genesisFloor("a-channel-with-no-floor"); got != 0 {
 		t.Fatalf("genesisFloor(unset) = %d, want 0", got)
+	}
+}
+
+// TestGenesisFloor_ProductionPinned freezes the production floor to the EXACT
+// version of the first production statement (channel-production, published
+// 2026-06-16T19:56:20Z). It guards against the entry being dropped or its unit
+// changed — either silently disarms anti-rollback for every fresh machine that
+// resolves production. Bump this in lockstep with genesis.go when the floor is
+// deliberately advanced.
+func TestGenesisFloor_ProductionPinned(t *testing.T) {
+	const firstProductionVersion int64 = 1781639780
+	if got := realGenesisFloors["production"]; got != firstProductionVersion {
+		t.Fatalf("embedded genesisFloors[production] = %d, want %d (first published statement version)", got, firstProductionVersion)
 	}
 }


### PR DESCRIPTION
## What

Sets `genesisFloors["production"] = 1781639780` in `internal/rulesource/genesis.go`
— the EXACT `version` of the first production statement published to
`channel-production` (2026-06-16T19:56:20Z).

## Why

The genesis floor is the build-embedded anti-rollback minimum a machine that has
**never** recorded a statement starts from. Until production published, the floor
was unset (0), so a fresh machine would trust-on-first-use accept any
validly-signed, in-window statement — letting an attacker who MITMs that first
resolve pin the machine to an older (but legitimately signed) statement pointing
at a stale bundle. With the floor set to the first statement's version, first
contact now rejects anything older; later publishes carry a larger
epoch-seconds version and advance the per-machine recorded floor from here.

## Verified end-to-end

A binary built from this change scanned the live production channel on a **cold
cache**:
- `rules_from_cache: false` (fetched over the network)
- `rules_origin: {signed: true, channel: production}` (no custom/watermark)
- `rules_version: 41b2fda7…`, schema 12, signature verified against the embedded key
- The floor (1781639780) accepts the exact statement it is derived from on a fresh machine.

## Tests

- `internal/rulesource/genesis_test.go`: a package `TestMain` now snapshots the
  build-embedded floors and zeroes the runtime map for the suite, so the existing
  mechanism tests keep driving small synthetic versions while a new
  `TestGenesisFloor_ProductionPinned` asserts the real shipped value (guards
  against the entry being dropped or its unit changed).
- `go test ./internal/rulesource/ ./internal/rulesign/` and the `cmd/trustabl`
  rules/cutover tests pass. (Full `./...` not run here: unrelated `internal/llm`
  tests read a real local API key — separate isolation task.)

This arms anti-rollback for production; it does **not** flip the default rules
source (still `git`). The default flip is the separate follow-up (TR-325).