### PR TITLE
feat: scan-result attestation (trustabl attest / verify + scan --attest)

### DIFF
--- a/.github/workflows/attestation.yml
+++ b/.github/workflows/attestation.yml
@@ -1,0 +1,64 @@
+name: Attestation
+
+# CI for the scan-attestation feature, split out from the main test workflow
+# (test.yml) so attestation runs (and the cosign install) are isolated.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch: # manual trigger for the keyless job (see attest-keyless)
+
+env:
+  CGO_ENABLED: "1" # tree-sitter is a C library; see ARCHITECTURE.md §9
+
+jobs:
+  attest-e2e:
+    # Hermetic, key-mode proof of the attestation feature: scan -> attest ->
+    # verify -> tamper -> verify-fails, plus the scan --attest path. No OIDC, no
+    # Rekor — deterministic assurance that the cosign integration is wired right.
+    # This is the spike that cannot run on a dev box without cosign installed.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - uses: sigstore/cosign-installer@v3
+
+      - name: Attestation e2e (key mode)
+        run: bash scripts/attest-e2e.sh
+
+  attest-keyless:
+    # Production-path proof: keyless signing with the runner's ambient GitHub OIDC
+    # identity through Fulcio + Rekor, then verifying against that identity. Manual
+    # only (workflow_dispatch) BECAUSE every run writes a permanent entry to the
+    # PUBLIC Rekor transparency log — we do not want that on every push. Run it
+    # on demand to confirm the keyless wiring; the per-PR assurance is attest-e2e.
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # mint the OIDC token cosign exchanges with Fulcio
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - uses: sigstore/cosign-installer@v3
+
+      - name: Keyless attest + verify
+        run: |
+          go build -o /tmp/trustabl ./cmd/trustabl
+          # A scan may exit 1 on findings; we only need the JSON report written.
+          /tmp/trustabl scan . --json-out /tmp/report.json --no-progress || true
+          /tmp/trustabl attest /tmp/report.json --bundle /tmp/att.bundle.json
+          /tmp/trustabl verify /tmp/report.json --bundle /tmp/att.bundle.json \
+            --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/attestation.yml@${{ github.ref }}" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  workflow_dispatch: # manual trigger for the keyless attestation job (see attest-keyless)
 
 env:
   CGO_ENABLED: "1" # tree-sitter is a C library; see ARCHITECTURE.md §9
@@ -65,53 +64,3 @@ jobs:
 
       - name: Check fixture is in sync with production rules
         run: RULES_REPO="$GITHUB_WORKSPACE/.rules" bash scripts/check-rules-sync.sh
-
-  attest-e2e:
-    # Hermetic, key-mode proof of the attestation feature: scan -> attest ->
-    # verify -> tamper -> verify-fails, plus the scan --attest path. No OIDC, no
-    # Rekor — deterministic assurance that the cosign integration is wired right.
-    # This is the spike that cannot run on a dev box without cosign installed.
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-          cache: true
-
-      - uses: sigstore/cosign-installer@v3
-
-      - name: Attestation e2e (key mode)
-        run: bash scripts/attest-e2e.sh
-
-  attest-keyless:
-    # Production-path proof: keyless signing with the runner's ambient GitHub OIDC
-    # identity through Fulcio + Rekor, then verifying against that identity. Manual
-    # only (workflow_dispatch) BECAUSE every run writes a permanent entry to the
-    # PUBLIC Rekor transparency log — we do not want that on every push. Run it
-    # on demand to confirm the keyless wiring; the per-PR assurance is attest-e2e.
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write # mint the OIDC token cosign exchanges with Fulcio
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-          cache: true
-
-      - uses: sigstore/cosign-installer@v3
-
-      - name: Keyless attest + verify
-        run: |
-          go build -o /tmp/trustabl ./cmd/trustabl
-          # A scan may exit 1 on findings; we only need the JSON report written.
-          /tmp/trustabl scan . --json-out /tmp/report.json --no-progress || true
-          /tmp/trustabl attest /tmp/report.json --bundle /tmp/att.bundle.json
-          /tmp/trustabl verify /tmp/report.json --bundle /tmp/att.bundle.json \
-            --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/test.yml@${{ github.ref }}" \
-            --certificate-oidc-issuer "https://token.actions.githubusercontent.com"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch: # manual trigger for the keyless attestation job (see attest-keyless)
 
 env:
   CGO_ENABLED: "1" # tree-sitter is a C library; see ARCHITECTURE.md §9
@@ -64,3 +65,53 @@ jobs:
 
       - name: Check fixture is in sync with production rules
         run: RULES_REPO="$GITHUB_WORKSPACE/.rules" bash scripts/check-rules-sync.sh
+
+  attest-e2e:
+    # Hermetic, key-mode proof of the attestation feature: scan -> attest ->
+    # verify -> tamper -> verify-fails, plus the scan --attest path. No OIDC, no
+    # Rekor — deterministic assurance that the cosign integration is wired right.
+    # This is the spike that cannot run on a dev box without cosign installed.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - uses: sigstore/cosign-installer@v3
+
+      - name: Attestation e2e (key mode)
+        run: bash scripts/attest-e2e.sh
+
+  attest-keyless:
+    # Production-path proof: keyless signing with the runner's ambient GitHub OIDC
+    # identity through Fulcio + Rekor, then verifying against that identity. Manual
+    # only (workflow_dispatch) BECAUSE every run writes a permanent entry to the
+    # PUBLIC Rekor transparency log — we do not want that on every push. Run it
+    # on demand to confirm the keyless wiring; the per-PR assurance is attest-e2e.
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # mint the OIDC token cosign exchanges with Fulcio
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - uses: sigstore/cosign-installer@v3
+
+      - name: Keyless attest + verify
+        run: |
+          go build -o /tmp/trustabl ./cmd/trustabl
+          # A scan may exit 1 on findings; we only need the JSON report written.
+          /tmp/trustabl scan . --json-out /tmp/report.json --no-progress || true
+          /tmp/trustabl attest /tmp/report.json --bundle /tmp/att.bundle.json
+          /tmp/trustabl verify /tmp/report.json --bundle /tmp/att.bundle.json \
+            --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/test.yml@${{ github.ref }}" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com"

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1242,6 +1242,26 @@ schema validator, which rejects a `fixes[]` entry lacking `artifactChanges`. Lik
 JSON, SARIF is a pure function of `ScanResult`: no clocks, no map-iteration
 leakage, byte-stable per `ScanID`.
 
+### Scan attestation (`internal/attest`)
+
+`internal/attest` turns a `ScanResult` into a signed, verifiable claim about the
+**scanned repo** (not the Trustabl binary — that is attested separately by the
+release workflow's build-provenance). It holds **no keys and no crypto of its
+own**: `BuildPredicate` renders a deterministic in-toto predicate (predicateType
+`https://trustabl.dev/attestation/scan/v1`) derived only from `ScanResult` — so it
+is byte-stable and is **not** folded into `ScanID` — and the package shells out to
+the **cosign** CLI (`attest-blob` / `verify-blob-attestation`) for all signing and
+verification. The attestation **subject** is the canonical JSON report itself
+(cosign signs its sha256); a repo has no single artifact digest, and the report
+already pins the scanned state, so signing the report is simpler and more
+reproducible than signing a source archive. Signing is **keyless by default**
+(ambient CI OIDC via Fulcio/Rekor) with a `--key` escape hatch for offline/private
+signing; the **signer is whoever runs the scan**, never trustabl.dev. `cmd/trustabl`
+exposes it two ways sharing one `doAttest` core — a standalone `trustabl attest
+<report.json>` and a `scan --attest` flag — while `trustabl verify` is a separate
+consumer-side command that pins the signer identity and OIDC issuer. cosign is an
+**optional runtime dependency**: a plain `scan` never touches it.
+
 **Report destination (`--output` / `-o`).** `cmd/trustabl` renders the chosen
 format to bytes (`renderReport`) and then writes them either to stdout or, when
 `--output <path>` is set, to that file (`writeReport`). Rendering is decoupled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ to follow Semantic Versioning once it reaches 1.0.
 
 ### Added
 
+- **Scan attestation (opt-in).** New `internal/attest` package plus `trustabl
+  attest` / `trustabl verify` subcommands and a `scan --attest` flag. Trustabl
+  renders a deterministic in-toto predicate (type
+  `https://trustabl.dev/attestation/scan/v1`) from a `ScanResult` and shells out
+  to the **cosign** CLI to sign the JSON report (the attestation subject) and to
+  verify it. Signing is **keyless by default** (ambient CI OIDC; the event is
+  logged to the public Rekor transparency log) with a `--key` escape hatch for
+  offline/private signing (`--no-tlog`). Verification is consumer-side and pins
+  the signer identity + OIDC issuer. Requires the cosign CLI on PATH; a plain
+  `scan` is unchanged and free of any new dependency. The predicate is **not**
+  folded into `ScanID`.
 - **Signed rules distribution — trust core (opt-in).** New `internal/rulesign`
   package: a reproducible bundle digest (sha256 over a normalized tar), an
   embedded Ed25519 trust keyring (verify-by-key-ID with validity windows,

--- a/README.md
+++ b/README.md
@@ -459,6 +459,35 @@ includes a `checksums.txt` and a build-provenance attestation; verify with:
 gh attestation verify <archive> --repo trustabl/trustabl
 ```
 
+### cosign (optional — only for scan attestation)
+
+Trustabl's `attest` / `verify` commands and `scan --attest` shell out to the
+[cosign](https://docs.sigstore.dev/cosign/system_config/installation/) CLI —
+cosign does the signing and verification, and Trustabl ships no keys of its own.
+It is needed **only** if you use attestation; a plain `scan` never touches it.
+
+```sh
+# macOS / Linux
+brew install cosign
+# Windows
+scoop install cosign
+```
+
+In CI you do not install it by hand — the Trustabl GitHub Action and GitLab
+component add `sigstore/cosign-installer` for you. A quick local check (key mode:
+fully offline, no transparency log):
+
+```sh
+cosign generate-key-pair                 # set COSIGN_PASSWORD="" to skip the prompt
+trustabl scan . --json-out report.json
+trustabl attest report.json --key cosign.key --no-tlog
+trustabl verify report.json --key cosign.pub --no-tlog   # exit 0 = verified
+```
+
+Keyless signing (no private key to manage) is the default in CI, where an ambient
+OIDC identity exists; it also records the signature in the public Rekor
+transparency log. See [Use](#use) for the full command surface.
+
 ### Claude Code plugin
 
 The plugin installs two skills (`trustabl-scan` and `trustabl-enrich`), a
@@ -581,6 +610,20 @@ trustabl scan ./repo --json-out trustabl.json --sarif-out trustabl.sarif
 
 # Exit 1 on any finding regardless of severity
 trustabl scan ./repo --strict
+
+# --- Attestation (opt-in; requires the cosign CLI on PATH) -------------------
+# Sign the JSON report into a cosign attestation of the SCANNED repo's result.
+# Keyless by default: in CI it uses the runner's ambient OIDC identity (no keys
+# to manage) and logs the signing event to the PUBLIC Rekor transparency log.
+trustabl scan ./repo --json-out trustabl.json --attest
+trustabl attest trustabl.json                       # same, as a separate step
+# Offline / private signing with a key (no public transparency log):
+trustabl attest trustabl.json --key cosign.key --no-tlog
+# Verify (run where you CONSUME the attestation). Keyless pins who signed + issuer:
+trustabl verify trustabl.json \
+  --certificate-identity https://github.com/OWNER/REPO/.github/workflows/scan.yml@refs/heads/main \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+trustabl verify trustabl.json --key cosign.pub --no-tlog   # key-mode, offline
 
 # Download / refresh the detection rule packs into the local cache
 trustabl rules pull

--- a/README.md
+++ b/README.md
@@ -458,6 +458,26 @@ includes a `checksums.txt` and a build-provenance attestation; verify with:
 ```sh
 gh attestation verify <archive> --repo trustabl/trustabl
 ```
+## Attestation
+### Test Usage Example
+#### **Prerequisite and setup:**
+Install cosign **2.4.x** version
+
+##### Add to target folder path:
+`export PATH="<folder_path>:$PATH"`
+
+##### Export and Generate Key Pair:
+`export COSIGN_PASSWORD="" `
+skip the passphrase prompt (omit for a real key)
+
+`cosign generate-key-pair`
+writes cosign.key (private) + cosign.pub (public)
+
+##### Trustabl Scan and Attest:
+`./trustabl.exe scan https://github.com/google/adk-samples --json-out report.json --attest --attest-key cosign.key --attest-bundle att.bundle.json --attest-no-tlog`
+
+##### VERIFICATION
+`./trustabl.exe verify report.json --key cosign.pub --bundle att.bundle.json --no-tlog`
 
 ### cosign (optional — only for scan attestation)
 

--- a/README.md
+++ b/README.md
@@ -474,15 +474,56 @@ scoop install cosign
 ```
 
 In CI you do not install it by hand — the Trustabl GitHub Action and GitLab
-component add `sigstore/cosign-installer` for you. A quick local check (key mode:
-fully offline, no transparency log):
+component add `sigstore/cosign-installer` for you.
+
+#### Scan with attestation — step by step (key mode, offline)
+
+Key mode signs with a local key pair and skips the public transparency log — no
+browser, no network, ideal for a laptop or air-gapped run.
+
+> **cosign version:** the `--no-tlog` flag needs cosign **2.4.x**. cosign 2.5+
+> removed the underlying `--tlog-upload` flag, so the command errors there — pin
+> 2.4.3 if you hit that. On a PATH install the command is `trustabl`; for a local
+> Windows build it is `.\trustabl.exe`.
+
+**Step 0 — install cosign** (see the commands above for your OS).
+
+**Step 1 — generate a signing key pair:**
 
 ```sh
-cosign generate-key-pair                 # set COSIGN_PASSWORD="" to skip the prompt
-trustabl scan . --json-out report.json
-trustabl attest report.json --key cosign.key --no-tlog
-trustabl verify report.json --key cosign.pub --no-tlog   # exit 0 = verified
+export COSIGN_PASSWORD=""        # skip the passphrase prompt (omit for a real key)
+cosign generate-key-pair         # writes cosign.key (private) + cosign.pub (public)
 ```
+
+**Step 2 — scan and sign in one step:**
+
+```sh
+trustabl scan https://github.com/google/adk-samples \
+  --json-out report.json \
+  --attest --attest-key cosign.key --attest-bundle att.bundle.json --attest-no-tlog
+```
+
+Writes `report.json` (the scan result), `trustabl-predicate.json`, and the signed
+`att.bundle.json`. Exit 1 only means findings were present — the bundle is still
+written (it signs the verdict, pass or fail).
+
+**Step 3 — verify (consumer side):**
+
+```sh
+trustabl verify report.json --key cosign.pub --bundle att.bundle.json --no-tlog
+```
+
+`Verified OK`, exit 0 — the report is authentic and unmodified.
+
+**Step 4 — (optional) prove tamper detection:**
+
+```sh
+echo '{"tampered":true}' >> report.json
+trustabl verify report.json --key cosign.pub --bundle att.bundle.json --no-tlog
+```
+
+Verification now FAILS (exit 1): the signature is bound to the exact report bytes,
+so any edit is caught.
 
 Keyless signing (no private key to manage) is the default in CI, where an ambient
 OIDC identity exists; it also records the signature in the public Rekor

--- a/cmd/trustabl/attest.go
+++ b/cmd/trustabl/attest.go
@@ -131,5 +131,9 @@ func cosignMissingError() error {
 	fmt.Fprintln(os.Stderr,
 		"Trustabl shells out to the cosign CLI for signing and verification; install it:")
 	fmt.Fprintln(os.Stderr, "  https://docs.sigstore.dev/cosign/system_config/installation/")
+	fmt.Fprintln(os.Stderr,
+		"If cosign is already downloaded, add its folder to PATH — a binary sitting in")
+	fmt.Fprintln(os.Stderr,
+		"the current directory is not enough, and each new shell needs PATH set again.")
 	return exitCodeError{2}
 }

--- a/cmd/trustabl/attest.go
+++ b/cmd/trustabl/attest.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/trustabl/trustabl/internal/attest"
+	"github.com/trustabl/trustabl/internal/logx"
+	"github.com/trustabl/trustabl/internal/models"
+)
+
+// Default output paths shared by the `attest` subcommand and the `scan --attest`
+// convenience flag, so both produce the same file names.
+const (
+	defaultAttestBundle    = "trustabl-attestation.bundle.json"
+	defaultAttestPredicate = "trustabl-predicate.json"
+)
+
+// attestFlags is the shared config for both attestation entry points (the
+// subcommand and scan --attest). One struct, one core (doAttest), so the two
+// paths can never drift in how they sign.
+type attestFlags struct {
+	keyRef       string
+	bundleOut    string
+	predicateOut string
+	noTLog       bool
+}
+
+func newAttestCommand() *cobra.Command {
+	var f attestFlags
+	cmd := &cobra.Command{
+		Use:   "attest <report.json>",
+		Short: "Sign a scan report into a verifiable attestation",
+		Long: `Attest a Trustabl scan report with cosign.
+
+<report.json> is a scan result written by "trustabl scan --format json" (or
+--json-out). attest builds a deterministic predicate from it and signs the report
+itself as the attestation subject, producing a sigstore bundle a consumer can
+later verify with "trustabl verify".
+
+Signing requires the cosign CLI on PATH (https://docs.sigstore.dev/cosign). By
+default it signs KEYLESS: in CI it uses the runner's ambient OIDC identity (no
+keys to manage) and records the signature in the public Rekor transparency log.
+Pass --key to sign with a private key instead — for offline, air-gapped, or
+private signing that must not write to a public log (combine with --no-tlog).
+
+What gets attested is the SCANNED repo's result, not the Trustabl binary; the
+signer is whoever runs this command, never trustabl.dev.`,
+		Example: `  # Keyless (in CI): scan to JSON, then attest
+  trustabl scan . --format json -o report.json
+  trustabl attest report.json
+
+  # Key-mode, fully offline (no transparency log)
+  cosign generate-key-pair
+  trustabl attest report.json --key cosign.key --no-tlog`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runAttest(args[0], f, logLevelFor(cmd))
+		},
+	}
+	cmd.Flags().StringVar(&f.keyRef, "key", "",
+		"cosign private-key reference; omit for keyless signing (ambient CI OIDC identity)")
+	cmd.Flags().StringVarP(&f.bundleOut, "bundle", "o", defaultAttestBundle,
+		"write the signed attestation bundle to this file")
+	cmd.Flags().StringVar(&f.predicateOut, "predicate-out", defaultAttestPredicate,
+		"write the generated predicate to this file")
+	cmd.Flags().BoolVar(&f.noTLog, "no-tlog", false,
+		"do not upload the signature to the public Rekor transparency log (offline/private signing)")
+	return cmd
+}
+
+// runAttest is the subcommand path: load a persisted report, then sign it.
+func runAttest(reportPath string, f attestFlags, level logx.Level) error {
+	log := logx.New(os.Stderr, level, diagColor(false))
+	result, err := readScanResult(reportPath)
+	if err != nil {
+		return err
+	}
+	return doAttest(*result, reportPath, f, log)
+}
+
+// doAttest is the single signing core shared by the subcommand and scan --attest.
+// It writes the predicate next to the report, then drives cosign to sign the
+// report (the subject) and emit the bundle. reportPath must already exist on disk
+// — cosign signs the bytes at that path, and a verifier re-supplies the same file.
+func doAttest(result models.ScanResult, reportPath string, f attestFlags, log *logx.Logger) error {
+	pred := attest.BuildPredicate(result, version)
+	predBytes, err := pred.JSON()
+	if err != nil {
+		return fmt.Errorf("building attestation predicate: %w", err)
+	}
+	if err := os.WriteFile(f.predicateOut, predBytes, 0o644); err != nil {
+		return fmt.Errorf("writing predicate to %s: %w", f.predicateOut, err)
+	}
+	log.Verbosef("attest: wrote predicate to %s", f.predicateOut)
+
+	if err := attest.Attest(context.Background(), attest.AttestOptions{
+		Blob:      reportPath,
+		Predicate: f.predicateOut,
+		Bundle:    f.bundleOut,
+		KeyRef:    f.keyRef,
+		NoTLog:    f.noTLog,
+	}); err != nil {
+		return attestExitError(err)
+	}
+	log.Verbosef("attest: wrote attestation bundle to %s", f.bundleOut)
+	fmt.Fprintf(os.Stderr, "Attestation written: %s (predicate %s, subject %s)\n",
+		f.bundleOut, f.predicateOut, reportPath)
+	return nil
+}
+
+// attestExitError turns an attest.Attest failure into the right CLI exit. A
+// missing cosign gets the actionable install message; anything else is a generic
+// signing failure (exit 2). The reporter has already streamed cosign's own stderr.
+func attestExitError(err error) error {
+	if errors.Is(err, attest.ErrCosignNotFound) {
+		return cosignMissingError()
+	}
+	fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+	return exitCodeError{2}
+}
+
+// cosignMissingError prints how to install cosign and returns the scanner-error
+// exit code. Shared by the attest and verify paths.
+func cosignMissingError() error {
+	fmt.Fprintln(os.Stderr, "cosign was not found on PATH.")
+	fmt.Fprintln(os.Stderr,
+		"Trustabl shells out to the cosign CLI for signing and verification; install it:")
+	fmt.Fprintln(os.Stderr, "  https://docs.sigstore.dev/cosign/system_config/installation/")
+	return exitCodeError{2}
+}

--- a/cmd/trustabl/main.go
+++ b/cmd/trustabl/main.go
@@ -3,6 +3,8 @@
 // Subcommands:
 //
 //	trustabl scan <target> [flags]   primary command: scan a repo
+//	trustabl attest <report.json>    sign a scan report into an attestation (cosign)
+//	trustabl verify <report.json>    verify a scan attestation (consumer side)
 //	trustabl enrich [flags]          enrich a scan result with AI fixes
 //	trustabl mcp [flags]             run a stdio MCP server exposing the scan
 //	trustabl rules pull [flags]      pre-fetch the detection rule packs
@@ -17,9 +19,9 @@
 //	2  scanner / I/O error, or no usable rules (none resolved, incompatible
 //	   schema, or a resolved pack that contains zero rules)
 //
-// Each subcommand lives in its own file (scan.go, version.go, rules.go, mcp.go,
-// llm.go). This file owns the root command wiring, the build metadata, and the
-// shared exit-code error type.
+// Each subcommand lives in its own file (scan.go, attest.go, verify.go,
+// version.go, rules.go, mcp.go, llm.go). This file owns the root command wiring,
+// the build metadata, and the shared exit-code error type.
 package main
 
 import (
@@ -91,6 +93,8 @@ with --strict), 2 = scanner error or no usable rules.`,
 	rootCmd.PersistentFlags().Bool("debug", false,
 		"debug diagnostics on stderr: everything --verbose shows plus per-phase timing and per-entity/per-finding detail (implies --verbose)")
 	rootCmd.AddCommand(newScanCommand())
+	rootCmd.AddCommand(newAttestCommand())
+	rootCmd.AddCommand(newVerifyCommand())
 	rootCmd.AddCommand(newVersionCommand())
 	rootCmd.AddCommand(newRulesCommand())
 	rootCmd.AddCommand(newVulnDBCommand())

--- a/cmd/trustabl/scan.go
+++ b/cmd/trustabl/scan.go
@@ -42,6 +42,10 @@ type scanFlags struct {
 	sarifOut      string
 	bomOut        string
 	vulnScan      bool
+	attest        bool
+	attestKey     string
+	attestBundle  string
+	attestNoTLog  bool
 }
 
 func newScanCommand() *cobra.Command {
@@ -135,6 +139,14 @@ Exit codes:
 		"also write a CycloneDX BOM of the repo's declared dependencies to this file")
 	cmd.Flags().BoolVar(&f.vulnScan, "vuln-scan", false,
 		"match dependencies against a pinned OSV snapshot and report known CVEs (off by default; fetches the OSV database on first use, then caches it)")
+	cmd.Flags().BoolVar(&f.attest, "attest", false,
+		"after the scan, sign the JSON report into a cosign attestation (requires cosign on PATH; keyless by default — see 'trustabl attest')")
+	cmd.Flags().StringVar(&f.attestKey, "attest-key", "",
+		"cosign private-key reference for --attest; omit for keyless signing")
+	cmd.Flags().StringVar(&f.attestBundle, "attest-bundle", defaultAttestBundle,
+		"output path for the --attest signed bundle")
+	cmd.Flags().BoolVar(&f.attestNoTLog, "attest-no-tlog", false,
+		"with --attest, do not upload the signature to the public Rekor transparency log")
 	return cmd
 }
 
@@ -523,6 +535,34 @@ func finishScan(result models.ScanResult, jobErr error, f scanFlags, log *logx.L
 	}
 	if f.sarifOut != "" {
 		log.Verbosef("output: wrote SARIF to %s", f.sarifOut)
+	}
+
+	// --attest signs the JSON report into a cosign attestation. The subject must be
+	// a persisted file (cosign signs bytes on disk and a verifier re-supplies the
+	// same file), so reuse --json-out when set, else write the canonical report to a
+	// default path with the identical bytes (jsonBytes). A signing failure here is
+	// its own exit path — it must not masquerade as a findings exit, so we return it
+	// before computing the findings exit code below.
+	if f.attest {
+		reportPath := f.jsonOut
+		if reportPath == "" {
+			reportPath = "trustabl-report.json"
+			b, err := jsonBytes(result)
+			if err != nil {
+				return err
+			}
+			if err := os.WriteFile(reportPath, b, 0o644); err != nil {
+				return fmt.Errorf("write %s for --attest: %w", reportPath, err)
+			}
+		}
+		if err := doAttest(result, reportPath, attestFlags{
+			keyRef:       f.attestKey,
+			bundleOut:    f.attestBundle,
+			predicateOut: defaultAttestPredicate,
+			noTLog:       f.attestNoTLog,
+		}, log); err != nil {
+			return err
+		}
 	}
 
 	code := exitCode(result, f.strict)

--- a/cmd/trustabl/verify.go
+++ b/cmd/trustabl/verify.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/trustabl/trustabl/internal/attest"
+	"github.com/trustabl/trustabl/internal/logx"
+)
+
+type verifyFlags struct {
+	bundle       string
+	keyRef       string
+	certIdentity string
+	certIssuer   string
+	noTLog       bool
+}
+
+func newVerifyCommand() *cobra.Command {
+	var f verifyFlags
+	cmd := &cobra.Command{
+		Use:   "verify <report.json>",
+		Short: "Verify a scan attestation against its report",
+		Long: `Verify a Trustabl scan attestation with cosign.
+
+This is the consumer side: run it where you CONSUME an attestation (a deploy gate,
+an admission controller, a downstream pipeline), against the report file and the
+bundle the producer published. It confirms the bundle is a valid Trustabl
+attestation for exactly these report bytes, signed by the identity you pin.
+
+<report.json> must be byte-identical to the report that was attested (it is the
+signed subject). Verification requires the cosign CLI on PATH.
+
+Keyless verify (the default) REQUIRES --certificate-identity and
+--certificate-oidc-issuer: without pinning who signed and which OIDC issuer minted
+the cert, verification would accept any Fulcio certificate. For a key-signed
+attestation pass --key (the public key) instead.
+
+Exit codes: 0 = verified, 1 = verification failed, 2 = usage error or cosign
+missing.`,
+		Example: `  # Keyless: pin the GitHub Actions workflow that signed it
+  trustabl verify report.json \
+    --certificate-identity https://github.com/OWNER/REPO/.github/workflows/scan.yml@refs/heads/main \
+    --certificate-oidc-issuer https://token.actions.githubusercontent.com
+
+  # Key-mode, offline
+  trustabl verify report.json --key cosign.pub --no-tlog`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runVerify(args[0], f, logLevelFor(cmd))
+		},
+	}
+	cmd.Flags().StringVar(&f.bundle, "bundle", defaultAttestBundle,
+		"the attestation bundle to verify")
+	cmd.Flags().StringVar(&f.keyRef, "key", "",
+		"cosign public key for key-mode verify; omit for keyless")
+	cmd.Flags().StringVar(&f.certIdentity, "certificate-identity", "",
+		"keyless: required signer identity (e.g. the signing workflow URI)")
+	cmd.Flags().StringVar(&f.certIssuer, "certificate-oidc-issuer", "",
+		"keyless: required OIDC issuer (e.g. https://token.actions.githubusercontent.com)")
+	cmd.Flags().BoolVar(&f.noTLog, "no-tlog", false,
+		"do not require a Rekor transparency-log entry (offline/private verify)")
+	return cmd
+}
+
+func runVerify(reportPath string, f verifyFlags, level logx.Level) error {
+	log := logx.New(os.Stderr, level, diagColor(false))
+	// Keyless verification without an identity + issuer accepts any Fulcio cert —
+	// fail fast with a clear message rather than performing a meaningless check.
+	if f.keyRef == "" && (f.certIdentity == "" || f.certIssuer == "") {
+		fmt.Fprintln(os.Stderr,
+			"keyless verify requires --certificate-identity and --certificate-oidc-issuer")
+		fmt.Fprintln(os.Stderr,
+			"(or pass --key <public-key> to verify a key-signed attestation).")
+		return exitCodeError{2}
+	}
+
+	log.Verbosef("verify: report %s · bundle %s · keyless=%v", reportPath, f.bundle, f.keyRef == "")
+	err := attest.Verify(context.Background(), attest.VerifyOptions{
+		Blob:         reportPath,
+		Bundle:       f.bundle,
+		KeyRef:       f.keyRef,
+		CertIdentity: f.certIdentity,
+		CertIssuer:   f.certIssuer,
+		NoTLog:       f.noTLog,
+	})
+	switch {
+	case err == nil:
+		fmt.Fprintf(os.Stderr, "Attestation verified: %s (bundle %s)\n", reportPath, f.bundle)
+		return nil
+	case errors.Is(err, attest.ErrCosignNotFound):
+		return cosignMissingError()
+	case errors.Is(err, attest.ErrVerifyFailed):
+		fmt.Fprintln(os.Stderr, "Attestation verification FAILED.")
+		return exitCodeError{1}
+	default:
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return exitCodeError{2}
+	}
+}

--- a/internal/attest/cosign.go
+++ b/internal/attest/cosign.go
@@ -1,0 +1,131 @@
+package attest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// Sentinel errors so the CLI can map a cosign outcome to the right exit code and
+// message.
+var (
+	// ErrCosignNotFound means the cosign binary is not on PATH. Attestation and
+	// verification both require it; Trustabl ships no signing code of its own.
+	ErrCosignNotFound = errors.New("attest: cosign not found on PATH")
+	// ErrVerifyFailed means cosign ran and reported the attestation did not verify
+	// — a bad signature, a wrong identity, tampered report bytes, or a missing
+	// transparency-log entry. Distinct from an exec error so the CLI can return
+	// exit 1 (verification failed) rather than exit 2 (could not run).
+	ErrVerifyFailed = errors.New("attest: attestation verification failed")
+)
+
+// cosignBinary is the executable name; a package var so a test can point it at a
+// guaranteed-absent name to exercise the not-found path hermetically. Production
+// never changes it.
+var cosignBinary = "cosign"
+
+// AttestOptions configures a single `cosign attest-blob` invocation.
+type AttestOptions struct {
+	Blob      string // path to the subject blob (the canonical scan-report JSON)
+	Predicate string // path to the predicate JSON file
+	Bundle    string // output path for the signed sigstore bundle
+	KeyRef    string // cosign private-key reference; empty selects keyless (ambient OIDC)
+	NoTLog    bool   // do not upload the signature to the public Rekor transparency log
+}
+
+// attestArgs builds the cosign argv (without the binary name). Pure and
+// table-tested, so the flag wiring is verified without invoking cosign.
+func attestArgs(o AttestOptions) []string {
+	args := []string{
+		"attest-blob",
+		"--predicate", o.Predicate,
+		"--type", PredicateType,
+		"--bundle", o.Bundle,
+		"--yes", // non-interactive: the operator opted in by running attest
+	}
+	if o.KeyRef != "" {
+		args = append(args, "--key", o.KeyRef)
+	}
+	if o.NoTLog {
+		args = append(args, "--tlog-upload=false")
+	}
+	// The subject blob is the trailing positional argument.
+	return append(args, o.Blob)
+}
+
+// Attest signs o.Blob with cosign, embedding o.Predicate, and writes o.Bundle.
+// Keyless (empty KeyRef) mints an ephemeral cert from the ambient OIDC identity;
+// with KeyRef it signs with that key. cosign owns all crypto. Returns
+// ErrCosignNotFound when cosign is absent, or a wrapped error when cosign runs
+// but fails (e.g. keyless with no OIDC identity available).
+func Attest(ctx context.Context, o AttestOptions) error {
+	err := run(ctx, attestArgs(o))
+	if err == nil || errors.Is(err, ErrCosignNotFound) {
+		return err
+	}
+	return fmt.Errorf("attest: cosign signing failed: %w", err)
+}
+
+// VerifyOptions configures a single `cosign verify-blob-attestation` invocation.
+type VerifyOptions struct {
+	Blob         string // the subject blob to check against the attestation
+	Bundle       string // the signed bundle produced by Attest
+	KeyRef       string // public key for key-mode verify; empty selects keyless
+	CertIdentity string // keyless: the signer identity the cert must carry
+	CertIssuer   string // keyless: the OIDC issuer the cert must come from
+	NoTLog       bool   // do not require/verify a Rekor transparency-log entry
+}
+
+func verifyArgs(o VerifyOptions) []string {
+	args := []string{
+		"verify-blob-attestation",
+		"--type", PredicateType,
+		"--bundle", o.Bundle,
+	}
+	if o.KeyRef != "" {
+		args = append(args, "--key", o.KeyRef)
+	} else {
+		// Keyless verification is meaningless without pinning who signed and where:
+		// an unconstrained verify accepts any Fulcio cert. The CLI requires both.
+		args = append(args,
+			"--certificate-identity", o.CertIdentity,
+			"--certificate-oidc-issuer", o.CertIssuer)
+	}
+	if o.NoTLog {
+		args = append(args, "--insecure-ignore-tlog=true")
+	}
+	return append(args, o.Blob)
+}
+
+// Verify checks that o.Bundle is a valid Trustabl attestation for o.Blob. It
+// returns nil when cosign confirms it, ErrVerifyFailed when cosign ran but
+// rejected it, ErrCosignNotFound when cosign is absent, or a wrapped exec error
+// otherwise.
+func Verify(ctx context.Context, o VerifyOptions) error {
+	err := run(ctx, verifyArgs(o))
+	if err == nil || errors.Is(err, ErrCosignNotFound) {
+		return err
+	}
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		// cosign ran and exited non-zero: the attestation did not verify.
+		return ErrVerifyFailed
+	}
+	return fmt.Errorf("attest: running cosign: %w", err)
+}
+
+// run executes cosign with args, returning ErrCosignNotFound when the binary is
+// missing and the raw error otherwise (callers interpret *exec.ExitError).
+// cosign's human-readable progress goes to stderr — never our stdout — so the
+// byte-stable scan report on stdout is never perturbed.
+func run(ctx context.Context, args []string) error {
+	if _, err := exec.LookPath(cosignBinary); err != nil {
+		return ErrCosignNotFound
+	}
+	cmd := exec.CommandContext(ctx, cosignBinary, args...)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/internal/attest/cosign_test.go
+++ b/internal/attest/cosign_test.go
@@ -1,0 +1,80 @@
+package attest
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+)
+
+func TestAttestArgs(t *testing.T) {
+	t.Run("keyless", func(t *testing.T) {
+		got := attestArgs(AttestOptions{Predicate: "p.json", Bundle: "b.json", Blob: "report.json"})
+		want := []string{
+			"attest-blob", "--predicate", "p.json", "--type", PredicateType,
+			"--bundle", "b.json", "--yes", "report.json",
+		}
+		if !slices.Equal(got, want) {
+			t.Errorf("attestArgs keyless = %v, want %v", got, want)
+		}
+	})
+	t.Run("key + no-tlog", func(t *testing.T) {
+		got := attestArgs(AttestOptions{Predicate: "p.json", Bundle: "b.json", Blob: "report.json", KeyRef: "k.key", NoTLog: true})
+		want := []string{
+			"attest-blob", "--predicate", "p.json", "--type", PredicateType,
+			"--bundle", "b.json", "--yes", "--key", "k.key", "--tlog-upload=false", "report.json",
+		}
+		if !slices.Equal(got, want) {
+			t.Errorf("attestArgs key = %v, want %v", got, want)
+		}
+	})
+}
+
+func TestVerifyArgs(t *testing.T) {
+	t.Run("keyless", func(t *testing.T) {
+		got := verifyArgs(VerifyOptions{Bundle: "b.json", Blob: "report.json", CertIdentity: "id", CertIssuer: "iss"})
+		want := []string{
+			"verify-blob-attestation", "--type", PredicateType, "--bundle", "b.json",
+			"--certificate-identity", "id", "--certificate-oidc-issuer", "iss", "report.json",
+		}
+		if !slices.Equal(got, want) {
+			t.Errorf("verifyArgs keyless = %v, want %v", got, want)
+		}
+	})
+	t.Run("key + no-tlog", func(t *testing.T) {
+		got := verifyArgs(VerifyOptions{Bundle: "b.json", Blob: "report.json", KeyRef: "k.pub", NoTLog: true})
+		want := []string{
+			"verify-blob-attestation", "--type", PredicateType, "--bundle", "b.json",
+			"--key", "k.pub", "--insecure-ignore-tlog=true", "report.json",
+		}
+		if !slices.Equal(got, want) {
+			t.Errorf("verifyArgs key = %v, want %v", got, want)
+		}
+	})
+}
+
+// withMissingCosign points the package at a binary that cannot exist on PATH, so
+// the not-found path is exercised regardless of whether the test host has cosign
+// installed.
+func withMissingCosign(t *testing.T) {
+	t.Helper()
+	old := cosignBinary
+	cosignBinary = "cosign-not-installed-9f3c1a"
+	t.Cleanup(func() { cosignBinary = old })
+}
+
+func TestAttest_CosignMissing(t *testing.T) {
+	withMissingCosign(t)
+	err := Attest(context.Background(), AttestOptions{Blob: "report.json", Predicate: "p.json", Bundle: "b.json"})
+	if !errors.Is(err, ErrCosignNotFound) {
+		t.Fatalf("Attest err = %v, want ErrCosignNotFound", err)
+	}
+}
+
+func TestVerify_CosignMissing(t *testing.T) {
+	withMissingCosign(t)
+	err := Verify(context.Background(), VerifyOptions{Blob: "report.json", Bundle: "b.json", KeyRef: "k.pub"})
+	if !errors.Is(err, ErrCosignNotFound) {
+		t.Fatalf("Verify err = %v, want ErrCosignNotFound", err)
+	}
+}

--- a/internal/attest/predicate.go
+++ b/internal/attest/predicate.go
@@ -1,0 +1,113 @@
+// Package attest builds Trustabl scan attestations and drives the cosign CLI to
+// sign and verify them. Trustabl holds no signing keys of its own: it produces a
+// deterministic in-toto predicate from a ScanResult and shells out to cosign,
+// which owns all of the keyless (Fulcio/Rekor/OIDC) or private-key cryptography.
+//
+// The unit of trust is the canonical scan-report JSON: its sha256 is the
+// attestation subject, so a verifier binds the predicate to the exact bytes
+// Trustabl produced. A repo has no single natural artifact digest, and the report
+// already pins the scanned state (its ScanID folds the code + rules identity), so
+// signing the report is both simpler and more reproducible than signing a source
+// archive.
+package attest
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/trustabl/trustabl/internal/models"
+)
+
+// PredicateType is the in-toto predicateType URI stamped on every Trustabl scan
+// attestation. The /v1 suffix versions the predicate schema: a consumer pins this
+// exact URI, so a future breaking change ships as /v2 rather than silently
+// redefining v1.
+const PredicateType = "https://trustabl.dev/attestation/scan/v1"
+
+// Verdict values. "fail" means the scan found at least one finding of medium
+// severity or higher — the same gate the default (non-strict) exit code uses
+// (see cmd/trustabl exitCode), so a consumer reading the predicate verdict and a
+// CI step reading the exit code agree. info/low findings do not fail the verdict.
+const (
+	VerdictPass = "pass"
+	VerdictFail = "fail"
+)
+
+// SeverityCounts is the per-severity finding histogram embedded in the predicate.
+// A fixed-field struct (not a map) keeps the rendered JSON byte-stable.
+type SeverityCounts struct {
+	Critical int `json:"critical"`
+	High     int `json:"high"`
+	Medium   int `json:"medium"`
+	Low      int `json:"low"`
+	Info     int `json:"info"`
+}
+
+// Predicate is the claim a Trustabl scan attestation makes about the scanned repo.
+// Every field is derived deterministically from the ScanResult (plus the engine
+// version, threaded in like the SARIF renderer takes it) — no wall-clock, no map
+// iteration — so the same scan yields byte-identical predicate bytes. It is a
+// downstream artifact and is deliberately NOT folded into ScanID.
+//
+// There is intentionally no commit field in v1: the data model carries no commit
+// SHA, and the subject (the report's sha256) plus ScanID already pin the scanned
+// state cryptographically. Binding a human-friendly commit label is a follow-up.
+type Predicate struct {
+	ScanID         string         `json:"scanId"`
+	EngineVersion  string         `json:"engineVersion"`
+	RulesSHA       string         `json:"rulesSha"`
+	RulesOrigin    string         `json:"rulesOrigin"`
+	Repo           string         `json:"repo"`
+	OverallScore   float64        `json:"overallScore"`
+	Verdict        string         `json:"verdict"`
+	SeverityCounts SeverityCounts `json:"severityCounts"`
+}
+
+// BuildPredicate derives the deterministic predicate from a scan result.
+// engineVersion is threaded in from the CLI (the same value the SARIF renderer
+// receives) because the build version lives in package main, not here.
+func BuildPredicate(r models.ScanResult, engineVersion string) Predicate {
+	var counts SeverityCounts
+	for _, f := range r.Findings {
+		switch f.Severity {
+		case models.SeverityCritical:
+			counts.Critical++
+		case models.SeverityHigh:
+			counts.High++
+		case models.SeverityMedium:
+			counts.Medium++
+		case models.SeverityLow:
+			counts.Low++
+		case models.SeverityInfo:
+			counts.Info++
+		}
+	}
+	verdict := VerdictPass
+	if counts.Critical > 0 || counts.High > 0 || counts.Medium > 0 {
+		verdict = VerdictFail
+	}
+	return Predicate{
+		ScanID:         r.ScanID,
+		EngineVersion:  engineVersion,
+		RulesSHA:       r.RulesVersion,
+		RulesOrigin:    r.RulesOrigin.Tag(),
+		Repo:           r.Repo,
+		OverallScore:   r.OverallScore,
+		Verdict:        verdict,
+		SeverityCounts: counts,
+	}
+}
+
+// JSON renders the predicate as canonical, indented bytes with a trailing newline
+// — the same shape as the scan report (cmd/trustabl jsonBytes), so the file
+// Trustabl writes and the bytes cosign embeds are stable and diffable.
+func (p Predicate) JSON() ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "  ")
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(p); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/internal/attest/predicate_test.go
+++ b/internal/attest/predicate_test.go
@@ -1,0 +1,96 @@
+package attest
+
+import (
+	"testing"
+
+	"github.com/trustabl/trustabl/internal/models"
+)
+
+func sampleResult() models.ScanResult {
+	return models.ScanResult{
+		ScanID:       "scan-123",
+		Repo:         "https://github.com/owner/repo",
+		OverallScore: 0.5,
+		RulesVersion: "abc123",
+		RulesOrigin:  models.RulesOrigin{Signed: true, Channel: "production"},
+		Findings: []models.Finding{
+			{Severity: models.SeverityHigh},
+			{Severity: models.SeverityMedium},
+			{Severity: models.SeverityLow},
+			{Severity: models.SeverityInfo},
+		},
+	}
+}
+
+// TestBuildPredicate_JSONGolden pins the exact predicate bytes: the attestation
+// is only as reproducible as this rendering, so a formatting change must be a
+// deliberate, reviewed diff (and, per the /vN convention, a new predicate type).
+func TestBuildPredicate_JSONGolden(t *testing.T) {
+	got, err := BuildPredicate(sampleResult(), "1.2.3").JSON()
+	if err != nil {
+		t.Fatalf("JSON: %v", err)
+	}
+	want := `{
+  "scanId": "scan-123",
+  "engineVersion": "1.2.3",
+  "rulesSha": "abc123",
+  "rulesOrigin": "signed:production",
+  "repo": "https://github.com/owner/repo",
+  "overallScore": 0.5,
+  "verdict": "fail",
+  "severityCounts": {
+    "critical": 0,
+    "high": 1,
+    "medium": 1,
+    "low": 1,
+    "info": 1
+  }
+}
+`
+	if string(got) != want {
+		t.Errorf("predicate JSON mismatch:\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+// TestBuildPredicate_Deterministic guards the determinism contract: the same scan
+// must render byte-identical predicate bytes every time (no map iteration, no
+// wall-clock leaking in).
+func TestBuildPredicate_Deterministic(t *testing.T) {
+	r := sampleResult()
+	a, err := BuildPredicate(r, "1.2.3").JSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := BuildPredicate(r, "1.2.3").JSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(a) != string(b) {
+		t.Errorf("non-deterministic predicate bytes:\n%s\n!=\n%s", a, b)
+	}
+}
+
+// TestBuildPredicate_Verdict checks the pass/fail gate mirrors the default
+// (non-strict) exit code: medium-or-higher fails, info/low pass.
+func TestBuildPredicate_Verdict(t *testing.T) {
+	cases := []struct {
+		name     string
+		findings []models.Finding
+		want     string
+	}{
+		{"empty", nil, VerdictPass},
+		{"info only", []models.Finding{{Severity: models.SeverityInfo}}, VerdictPass},
+		{"low only", []models.Finding{{Severity: models.SeverityLow}}, VerdictPass},
+		{"medium fails", []models.Finding{{Severity: models.SeverityMedium}}, VerdictFail},
+		{"high fails", []models.Finding{{Severity: models.SeverityHigh}}, VerdictFail},
+		{"critical fails", []models.Finding{{Severity: models.SeverityCritical}}, VerdictFail},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := BuildPredicate(models.ScanResult{Findings: tc.findings}, "v")
+			if p.Verdict != tc.want {
+				t.Errorf("verdict = %q, want %q", p.Verdict, tc.want)
+			}
+		})
+	}
+}

--- a/scripts/attest-e2e.sh
+++ b/scripts/attest-e2e.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# attest-e2e.sh — hermetic, key-mode end-to-end test of Trustabl scan attestation.
+#
+#   scan -> attest -> verify (expect PASS) -> tamper -> verify (expect FAIL)
+#   plus the `scan --attest` one-shot path.
+#
+# It runs in KEY mode with --no-tlog, so it needs NO OIDC identity and NO network
+# for the cryptography (only the scan's rule resolution may touch the network /
+# cache). The KEYLESS path needs CI ambient OIDC and is exercised in CI, not here.
+#
+# Usage:  scripts/attest-e2e.sh [target]      (target defaults to this repo)
+# Skips cleanly (exit 0) when cosign is not installed — it is an optional dep.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+target="${1:-$repo_root}"
+target="$(cd "$target" 2>/dev/null && pwd || echo "$target")" # absolutize a dir target
+
+note() { printf '\n=== %s ===\n' "$*"; }
+fail=0
+# check <desc> <expected-exit> <actual-exit>
+check() {
+	if [ "$2" -eq "$3" ]; then
+		printf 'PASS  %s (exit %s)\n' "$1" "$3"
+	else
+		printf 'FAIL  %s (want exit %s, got %s)\n' "$1" "$2" "$3"
+		fail=1
+	fi
+}
+
+if ! command -v cosign >/dev/null 2>&1; then
+	echo "SKIP: cosign not found on PATH."
+	echo "      install it to run this e2e: https://docs.sigstore.dev/cosign/system_config/installation/"
+	exit 0
+fi
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+export COSIGN_PASSWORD="" # non-interactive key generation + signing
+
+note "build trustabl"
+bin="$work/trustabl"
+(cd "$repo_root" && go build -o "$bin" ./cmd/trustabl)
+
+note "generate cosign key pair (key mode — no OIDC, no log)"
+(cd "$work" && cosign generate-key-pair >/dev/null)
+key="$work/cosign.key"
+pub="$work/cosign.pub"
+
+# Run the binary from $work so any relative default outputs (e.g. the predicate
+# from `scan --attest`) land in the temp dir, never in the repo.
+cd "$work"
+report="$work/report.json"
+bundle="$work/att.bundle.json"
+pred="$work/predicate.json"
+
+note "scan target -> JSON report"
+# The scan may exit 1 on findings; that is fine — we only need a valid JSON report.
+set +e
+"$bin" scan "$target" --json-out "$report" --no-progress >/dev/null 2>"$work/scan.err"
+scan_exit=$?
+set -e
+if [ ! -s "$report" ]; then
+	echo "FAIL: scan wrote no report (exit $scan_exit). Rules must be resolvable (network or cache):"
+	tail -n 5 "$work/scan.err" | sed 's/^/  scan: /'
+	exit 1
+fi
+echo "report written ($(wc -c <"$report" | tr -d ' ') bytes), scan exit $scan_exit"
+
+note "attest the report (key mode, no transparency log)"
+set +e
+"$bin" attest "$report" --key "$key" --bundle "$bundle" --predicate-out "$pred" --no-tlog
+check "attest succeeds" 0 $?
+set -e
+[ -s "$bundle" ] && echo "bundle written" || { echo "FAIL: no bundle"; fail=1; }
+[ -s "$pred" ] && echo "predicate written" || { echo "FAIL: no predicate"; fail=1; }
+
+note "verify the untouched report (expect PASS / exit 0)"
+set +e
+"$bin" verify "$report" --key "$pub" --bundle "$bundle" --no-tlog
+check "verify untampered report" 0 $?
+set -e
+
+note "tamper the report, then verify (expect FAIL / exit 1)"
+printf '\n{"tampered":true}\n' >>"$report"
+set +e
+"$bin" verify "$report" --key "$pub" --bundle "$bundle" --no-tlog
+check "tampered report is rejected" 1 $?
+set -e
+
+note "scan --attest one-shot path"
+report2="$work/report2.json"
+bundle2="$work/att2.bundle.json"
+set +e
+"$bin" scan "$target" --json-out "$report2" \
+	--attest --attest-key "$key" --attest-bundle "$bundle2" --attest-no-tlog \
+	--no-progress >/dev/null 2>>"$work/scan.err"
+set -e
+if [ -s "$bundle2" ]; then
+	set +e
+	"$bin" verify "$report2" --key "$pub" --bundle "$bundle2" --no-tlog
+	check "scan --attest bundle verifies" 0 $?
+	set -e
+else
+	echo "FAIL: scan --attest wrote no bundle"
+	fail=1
+fi
+
+note "result"
+if [ "$fail" -eq 0 ]; then
+	echo "ALL ATTESTATION E2E CHECKS PASSED"
+else
+	echo "SOME CHECKS FAILED"
+fi
+exit "$fail"


### PR DESCRIPTION

<img width="949" height="294" alt="image" src="https://github.com/user-attachments/assets/7ee2b0e7-6db7-4e81-9389-52101391cf09" />


## Summary

Adds opt-in cryptographic attestation of scan results, so a downstream consumer
can verify, tamper-evidently, that **a given repo was scanned by Trustabl and
produced this verdict**. Trustabl holds no keys and does no crypto itself: it
renders a deterministic predicate and shells out to the **cosign** CLI.

What gets attested is the **scanned repo's result** (subject = the canonical JSON
report); the **signer is whoever runs the scan**, never trustabl.dev. The release
binary's own build-provenance is unrelated and untouched.

## What's added

- **`internal/attest/`** — `BuildPredicate` (deterministic in-toto predicate, type
  `https://trustabl.dev/attestation/scan/v1`, derived only from `ScanResult`, **not**
  folded into `ScanID`) + a thin cosign exec wrapper (`attest-blob` /
  `verify-blob-attestation`) with typed errors.
- **`trustabl attest <report.json>`** — signs the report; writes a predicate + a
  sigstore bundle. Keyless by default, `--key` for offline/private signing,
  `--no-tlog` to skip the public Rekor log.
- **`trustabl verify <report.json>`** — consumer-side verification; keyless pins
  `--certificate-identity` + `--certificate-oidc-issuer`, or `--key` for key mode.
  Exit 0 = verified, 1 = failed, 2 = usage / cosign missing.
- **`scan --attest`** — convenience flag that signs the JSON report in one step
  (shares one `doAttest` core with the subcommand). Plain `scan` is unchanged and
  needs no cosign.
- **`scripts/attest-e2e.sh`** — hermetic key-mode e2e (scan → attest → verify →
  tamper → verify-fails, plus the `scan --attest` path).
- **CI** (`test.yml`): `attest-e2e` job (per-PR, key-mode, deterministic) +
  `attest-keyless` job (manual `workflow_dispatch`, real OIDC→Fulcio→Rekor).
- Unit tests (golden predicate, determinism, verdict gate, cosign arg
  construction, missing-cosign path); README / ARCHITECTURE / CHANGELOG updated.

## Key design decisions

- **Subject = the canonical scan-report JSON.** A repo has no single artifact
  digest; the report's sha256 + `ScanID` already pin the scanned state, and it
  reuses the existing byte-stable report — simpler and more reproducible than a
  source archive. (No commit field in v1; deferred.)
- **Shell out to cosign (Approach A), not embed the sigstore SDK.** Tiny code,
  free keyless OIDC in CI. Cost: cosign on PATH — auto-installed by the CI
  wrappers; a one-command install for raw-binary users; gated behind `--attest`.
- **Verify is its own command, never wired into `scan`** — it's a consumer-side
  action; auto-verifying a fresh signature proves nothing.
- Keyless writes to the **public Rekor transparency log** — documented; `--key`
  avoids it for private signing.
 
 ## Test Usage Example
**Prerequisite and setup:**
Install cosign **2.4.x** version

Add to target folder path:
`export PATH="<folder_path>:$PATH"`

Export and Generate Key Pair:
`export COSIGN_PASSWORD="" `
skip the passphrase prompt (omit for a real key)

`cosign generate-key-pair`
writes cosign.key (private) + cosign.pub (public)

Trustabl Scan and Attest:
`./trustabl.exe scan https://github.com/google/adk-samples --json-out report.json --attest --attest-key cosign.key --attest-bundle att.bundle.json --attest-no-tlog`

VERIFICATION
`./trustabl.exe verify report.json --key cosign.pub --bundle att.bundle.json --no-tlog`

## How to test

Local (key mode, fully offline — requires cosign):
```bash
bash scripts/attest-e2e.sh
