### PR TITLE
TR-312 Derive OpenShell binaries[].path from the agent entrypoint

### DIFF
--- a/internal/acac/openshell.go
+++ b/internal/acac/openshell.go
@@ -63,7 +63,21 @@ type OpenShellNetworkPolicy struct {
 	Key       string // YAML key (identifier-sanitized tool name)
 	Name      string // policy name (slug)
 	Endpoints []OpenShellEndpoint
-	Binaries  []string // interpreter-path guesses (review marker)
+	// Binaries are the requesting-binary identities OpenShell matches egress
+	// against (/proc/<pid>/exe, ancestors, cmdline). A Derived entry comes from
+	// the agent's real entrypoint script (TR-312) and is emitted as-is; a
+	// non-derived entry is a language interpreter-path guess that still carries
+	// the "confirm the interpreter path" review marker.
+	Binaries []OpenShellBinary
+}
+
+// OpenShellBinary is one entry under a network policy's binaries: list. Path is
+// the absolute (or glob) identity matched against the requesting process;
+// Derived distinguishes a real entrypoint (from a discovered fact, no marker)
+// from an interpreter-path guess (marker retained until a human confirms it).
+type OpenShellBinary struct {
+	Path    string
+	Derived bool
 }
 
 // OpenShellEndpoint is one allowed endpoint, conservative by default.
@@ -130,6 +144,11 @@ func BuildOpenShellPolicy(result models.ScanResult, agent models.AgentDef) OpenS
 	for _, rw := range p.ReadWrite {
 		writeSet[rw] = true
 	}
+	// The requesting binary is the agent's process, shared by every tool it
+	// invokes, so the entrypoint identity is derived once from the agent and
+	// applied to all its network policies. When it is not derivable, each tool
+	// falls back to the per-language interpreter guess.
+	entrypoint := openShellEntrypointBinaries(agent)
 	aliases := newAliasSet()
 	for _, t := range tools {
 		// Filesystem: captured absolute write paths extend read_write; a
@@ -192,11 +211,15 @@ func BuildOpenShellPolicy(result models.ScanResult, agent models.AgentDef) OpenS
 		if len(endpoints) == 0 {
 			continue
 		}
+		bins := entrypoint
+		if len(bins) == 0 {
+			bins = guessedBinaries(t.Language)
+		}
 		np := OpenShellNetworkPolicy{
 			Key:       aliases.claim(t.Name),
 			Name:      dnsName(t.Name),
 			Endpoints: endpoints,
-			Binaries:  interpreterGuess(t.Language),
+			Binaries:  bins,
 		}
 		p.Network = append(p.Network, np)
 	}
@@ -315,6 +338,60 @@ func dnsName(name string) string {
 	return s
 }
 
+// openShellAppRoot is the conventional sandbox mount for application code:
+// OpenShell's restrictive_default_policy() ships /app as a read-only root, so a
+// repo-relative entrypoint script resolves to /app/<path> inside the sandbox.
+// A deployment that mounts its code elsewhere must adjust this.
+const openShellAppRoot = "/app"
+
+// openShellEntrypointBinaries derives the agent's real requesting-binary
+// identity (TR-312) from its entrypoint source file, mapped into the sandbox
+// app root. This is the cmdline/script identity OpenShell matches egress
+// against — emitted without a review marker because it comes from a discovered
+// fact rather than a language guess. Returns nil when the entrypoint is not
+// safely derivable (no file, or a path that escapes the app root), so the
+// caller falls back to the interpreter guess.
+func openShellEntrypointBinaries(agent models.AgentDef) []OpenShellBinary {
+	rel := normalizeEntrypointPath(agent.FilePath)
+	if rel == "" {
+		return nil
+	}
+	return []OpenShellBinary{{Path: openShellAppRoot + "/" + rel, Derived: true}}
+}
+
+// normalizeEntrypointPath turns a discovered repo-relative source path into a
+// clean sandbox-relative path: forward slashes, no leading "./" or "/". Returns
+// "" when the path is empty or contains a ".." segment (cannot be safely mapped
+// under the app root — such an entrypoint is treated as not derivable).
+func normalizeEntrypointPath(p string) string {
+	p = strings.ReplaceAll(p, "\\", "/")
+	p = strings.TrimPrefix(p, "./")
+	p = strings.TrimLeft(p, "/")
+	if p == "" {
+		return ""
+	}
+	for _, seg := range strings.Split(p, "/") {
+		if seg == ".." {
+			return ""
+		}
+	}
+	return p
+}
+
+// guessedBinaries wraps the per-language interpreter guess as non-derived
+// binaries (each keeps the review marker at emit time).
+func guessedBinaries(lang models.Language) []OpenShellBinary {
+	guesses := interpreterGuess(lang)
+	if len(guesses) == 0 {
+		return nil
+	}
+	out := make([]OpenShellBinary, 0, len(guesses))
+	for _, p := range guesses {
+		out = append(out, OpenShellBinary{Path: p, Derived: false})
+	}
+	return out
+}
+
 // interpreterGuess maps a tool's language to the conventional interpreter
 // path inside the sandbox. A guess by design — emitted with a review marker.
 func interpreterGuess(lang models.Language) []string {
@@ -426,7 +503,7 @@ func ValidateOpenShellPolicy(p OpenShellPolicy) error {
 			}
 		}
 		for _, b := range np.Binaries {
-			if err := checkPath(b, "binaries"); err != nil {
+			if err := checkPath(b.Path, "binaries"); err != nil {
 				return err
 			}
 		}

--- a/internal/acac/openshell_emit.go
+++ b/internal/acac/openshell_emit.go
@@ -108,8 +108,12 @@ func EmitOpenShellPolicy(p OpenShellPolicy) ([]byte, error) {
 		if len(np.Binaries) > 0 {
 			bins := seqNode()
 			for _, b := range np.Binaries {
-				pathVal := strNode(b)
-				pathVal.LineComment = MarkerReview + " — confirm the interpreter path inside the sandbox"
+				pathVal := strNode(b.Path)
+				// A derived entrypoint comes from a discovered fact and needs no
+				// confirmation; only the interpreter-path guess keeps the marker.
+				if !b.Derived {
+					pathVal.LineComment = MarkerReview + " — confirm the interpreter path inside the sandbox"
+				}
 				bins.Content = append(bins.Content, mappingNode(keyNode("path"), pathVal))
 			}
 			entry.Content = append(entry.Content, keyNode("binaries"), bins)

--- a/internal/acac/openshell_test.go
+++ b/internal/acac/openshell_test.go
@@ -67,8 +67,11 @@ func TestBuildOpenShellPolicy_Derivations(t *testing.T) {
 	if len(np.Endpoints) != 1 || np.Endpoints[0].Host != "status.example.com" || np.Endpoints[0].Port != 443 {
 		t.Errorf("endpoints = %+v", np.Endpoints)
 	}
-	if len(np.Binaries) != 1 || np.Binaries[0] != "/usr/bin/python3" {
-		t.Errorf("binaries = %v", np.Binaries)
+	// The agent entrypoint (main.py) is derivable, so binaries reflect the real
+	// requesting script mapped into the sandbox app root — not the interpreter
+	// guess — and carry no review marker.
+	if len(np.Binaries) != 1 || np.Binaries[0].Path != "/app/main.py" || !np.Binaries[0].Derived {
+		t.Errorf("binaries = %+v, want one derived /app/main.py", np.Binaries)
 	}
 
 	// internal_probe: the private 10.0.0.5 becomes a host-less allowed_ips
@@ -89,6 +92,69 @@ func TestBuildOpenShellPolicy_Derivations(t *testing.T) {
 
 	if err := ValidateOpenShellPolicy(p); err != nil {
 		t.Errorf("built policy must validate: %v", err)
+	}
+}
+
+func TestBuildOpenShellPolicy_EntrypointFallbackToGuess(t *testing.T) {
+	fetch := toolWithCaptures("fetch_status", "tools.py",
+		[]string{"status.example.com:443"}, nil, map[string]string{"http_call": "true"})
+	agent := agentWiring(&fetch)
+	agent.FilePath = "" // entrypoint not derivable → fall back to the guess
+
+	p := BuildOpenShellPolicy(models.ScanResult{}, agent)
+	if len(p.Network) != 1 {
+		t.Fatalf("network policies = %d, want 1", len(p.Network))
+	}
+	bins := p.Network[0].Binaries
+	if len(bins) != 1 || bins[0].Path != "/usr/bin/python3" || bins[0].Derived {
+		t.Errorf("binaries = %+v, want the non-derived interpreter guess /usr/bin/python3", bins)
+	}
+	if err := ValidateOpenShellPolicy(p); err != nil {
+		t.Errorf("policy must validate: %v", err)
+	}
+}
+
+func TestNormalizeEntrypointPath(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"main.py", "main.py"},
+		{"./main.py", "main.py"},
+		{"/abs/main.py", "abs/main.py"},
+		{"src\\agent\\main.py", "src/agent/main.py"},
+		{"pkg/../etc/passwd", ""}, // escapes the app root → not derivable
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := normalizeEntrypointPath(c.in); got != c.want {
+			t.Errorf("normalizeEntrypointPath(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestEmitOpenShell_BinaryMarkerOnlyWhenGuessed(t *testing.T) {
+	emit := func(b OpenShellBinary) string {
+		p := OpenShellPolicy{
+			ReadOnly:   []string{"/usr"},
+			ReadWrite:  []string{"/sandbox"},
+			RunAsUser:  "sandbox",
+			RunAsGroup: "sandbox",
+			Network: []OpenShellNetworkPolicy{{
+				Key: "t", Name: "t",
+				Endpoints: []OpenShellEndpoint{{Host: "api.example.com", Port: 443, Access: "read-only"}},
+				Binaries:  []OpenShellBinary{b},
+			}},
+		}
+		out, err := EmitOpenShellPolicy(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(out)
+	}
+	const marker = "confirm the interpreter path"
+	if got := emit(OpenShellBinary{Path: "/app/main.py", Derived: true}); strings.Contains(got, marker) {
+		t.Errorf("derived binary must not carry the interpreter marker:\n%s", got)
+	}
+	if got := emit(OpenShellBinary{Path: "/usr/bin/python3", Derived: false}); !strings.Contains(got, marker) {
+		t.Errorf("guessed binary must carry the interpreter marker:\n%s", got)
 	}
 }
 
@@ -195,7 +261,7 @@ func TestValidateOpenShellPolicy_RejectsEachConstraint(t *testing.T) {
 			Network: []OpenShellNetworkPolicy{{
 				Key: "t", Name: "t",
 				Endpoints: []OpenShellEndpoint{{Host: "api.example.com", Port: 443, Access: "read-only"}},
-				Binaries:  []string{"/usr/bin/python3"},
+				Binaries:  []OpenShellBinary{{Path: "/usr/bin/python3"}},
 			}},
 		}
 	}
@@ -244,7 +310,7 @@ func TestValidateOpenShellPolicy_RejectsEachConstraint(t *testing.T) {
 			p.Network[0].Endpoints[0].Port = 0
 		}, "out-of-range port"},
 		{"relative binary", func(p *OpenShellPolicy) {
-			p.Network[0].Binaries = []string{"python3"}
+			p.Network[0].Binaries = []OpenShellBinary{{Path: "python3"}}
 		}, "not absolute"},
 		{"path-count cap", func(p *OpenShellPolicy) {
 			for i := 0; i < 300; i++ {

--- a/internal/acac/testdata/acac-static-capture.openshell.yaml.golden
+++ b/internal/acac/testdata/acac-static-capture.openshell.yaml.golden
@@ -29,4 +29,4 @@ network_policies:
               method: GET
               path: /api/v1
     binaries:
-      - path: /usr/bin/python3 # trustabl: review — confirm the interpreter path inside the sandbox
+      - path: /app/main.py


### PR DESCRIPTION
## TR-312 — Story D (first slice)

Replaces the OpenShell exporter's interpreter-path guess (`/usr/bin/python3`) with the agent's **real entrypoint identity**, so the OpenShell prover's `BinaryRegistry` can match egress instead of falling to `get_or_unknown`.

> **Stacked PR.** Base is `cf/angry-curran-e89ee6`, not `main` — the `internal/acac` OpenShell exporter lives only on that (unmerged) branch. Merging the ACaC branch to `main` is a separate, larger decision.

### What changed
- New typed `OpenShellBinary{Path, Derived}`; `OpenShellNetworkPolicy.Binaries` is now `[]OpenShellBinary`.
- `BuildOpenShellPolicy` derives the requesting-binary identity once per agent from its entrypoint script (`AgentDef.FilePath` → `/app/<rel>`, via `openShellAppRoot`) and applies it to every tool's network policy; falls back to the per-language interpreter guess when the entrypoint isn't derivable.
- Emitter drops the "confirm the interpreter path" review marker for **derived** binaries; the guess keeps it (honors the ticket's "keep the review marker only when truly unknown").
- Golden `acac-static-capture.openshell.yaml.golden` regenerated: `/usr/bin/python3 # …guess` → `/app/main.py`.

### Tests
`TestBuildOpenShellPolicy_EntrypointFallbackToGuess`, `TestNormalizeEntrypointPath`, `TestEmitOpenShell_BinaryMarkerOnlyWhenGuessed`, plus updated `…_Derivations` and the validator case. `go build ./...`, `internal/acac`, `internal/analysis` all green.

### Design choices to confirm (review please)
1. **Entrypoint source** = the agent-declaring file (`AgentDef.FilePath`). Configured / non-`__main__` launch commands are not yet captured.
2. **Sandbox mount root** = `/app` (OpenShell `restrictive_default_policy` RO code mount). A deployment that mounts code elsewhere (e.g. the venv under `/sandbox` from the 0.0.59 live gate) needs `openShellAppRoot` adjusted.
3. Derived paths carry **no** review marker (per the ticket); the `/app` assumption is documented in code, not surfaced per-binary.

### Not in this slice
- A fuller `tool-entrypoint-binary` discovery fact for configured/non-file entrypoints and the in-sandbox interpreter (venv) identity.
- The live gate (egress from the named binary allowed, a different binary on the same endpoint denied) — needs a running OpenShell.