### PR TITLE
TR-325 Flip default rules source to the signed production channel

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -141,10 +141,11 @@ never leaves a partial pack and the recorded SHA always matches the content
 (see `internal/rulesource/git.go`).
 
 Resolution sits behind a `rulesource.Source` interface with two
-implementations. The default `gitSource` is the git path described above.
-`releaseSource` (opt-in via `--rules-source <name>`, or its deprecated alias
-`--channel <name>`) resolves rules from a
-**signature-verified release channel**: it verifies a signed channel statement
+implementations. `gitSource` is the unsigned git path described above (after the
+cutover it is the explicit opt-out, reached via `--rules-source git` or a
+`--rules-repo` / `--rules-ref` override). `releaseSource` (the **default**, and
+any `--rules-source <name>` / deprecated alias `--channel <name>`) resolves rules
+from a **signature-verified release channel**: it verifies a signed channel statement
 against an embedded Ed25519 trust keyring (`internal/rulesign`), fetches the
 bundle the statement commits to from GitHub Releases, re-derives the bundle's
 canonical digest and matches it to the statement, then installs it to a
@@ -163,8 +164,9 @@ on `ScanResult.RulesStale` and as a louder "rules may be out of date" stderr
 warning). The
 provenance of the rules (`models.RulesOrigin`: signed channel / unsigned
 custom / unsigned default) is surfaced as a report watermark and folded into
-`ScanID`. The default scan is unchanged — `gitSource` stays the default until
-the signed-production cutover. The CLI maps flags to a source in one place:
+`ScanID`. After the signed-production cutover, the `production` channel via `releaseSource`
+is the default; `gitSource` is the explicit opt-out (`--rules-source git`, or any
+`--rules-repo` / `--rules-ref`). The CLI maps flags to a source in one place:
 `effectiveRules` (`cmd/trustabl/scan.go`) derives BOTH the `rulesource.Config`
 and the `RulesOrigin` from a single decision (default in `defaultRulesSource`),
 so the resolved source and its reported provenance cannot disagree; a

--- a/README.md
+++ b/README.md
@@ -638,16 +638,20 @@ populates it; each subsequent scan checks for an update first (unless
 `--no-rules-update`), falling back to the cached rules if the fetch
 fails.
 
-**Signed rules channels (opt-in).** `--rules-source <name>` resolves rules from a
-signature-verified release channel instead of cloning git: Trustabl verifies a
+**Signed rules channels (default).** A plain `trustabl scan` resolves rules from
+the signature-verified **production** release channel: Trustabl verifies a
 signed channel statement against an embedded trust keyring, fetches the bundle
 it commits to, and refuses (exit `2`) on any verification failure rather than
 running unverified rules. `--rules-source git` selects the unsigned git path
 explicitly, and `--rules-repo` / `--rules-ref` imply it; a non-default channel
 can still be pointed at a fork with `--rules-source <name> --rules-repo <fork>`
 to test a signed fork. (`--channel <name>` is a deprecated alias for
-`--rules-source <name>`.) The **default scan is unchanged** — it still uses the
-git source until the signed-production cutover. A scan that did not use blessed
+`--rules-source <name>`.) The **default scan now uses the signed production
+channel**; set `TRUSTABL_REQUIRE_SIGNED=1` (or `--require-signed`) to forbid the
+unsigned git fallback entirely in CI. Already-shipped pre-cutover binaries are
+unaffected (the default and keyring are compiled in); upgrading shifts `ScanID`
+once as the origin tag and git-SHA become the channel's bundle digest. A scan
+that did not use blessed
 production rules (a pre-release channel, or a custom `--rules-repo` source) is
 watermarked in the report and in the JSON `rules_origin` field, and its
 provenance is folded into `ScanID`. This build embeds the rule-signing public

--- a/cmd/trustabl/rulesconfig_test.go
+++ b/cmd/trustabl/rulesconfig_test.go
@@ -8,23 +8,23 @@ import (
 
 // TestEffectiveRules covers the source-selection precedence that drives BOTH the
 // rulesource.Config and the RulesOrigin, so the resolved source and its reported
-// provenance can never disagree. The default is still git this phase; the flip to
-// production is a one-line change to defaultRulesSource (ENG-6).
+// provenance can never disagree. After the ENG-6 cutover the default is the signed
+// production channel; the unsigned git path is the explicit opt-out.
 func TestEffectiveRules(t *testing.T) {
 	// Neutralize any ambient override so cases are hermetic.
 	t.Setenv("TRUSTABL_RULES_REPO", "")
 	t.Setenv("TRUSTABL_REQUIRE_SIGNED", "")
 
-	t.Run("default is unsigned git", func(t *testing.T) {
+	t.Run("default is the signed production channel", func(t *testing.T) {
 		cfg, origin, err := effectiveRules(scanFlags{})
 		if err != nil {
 			t.Fatal(err)
 		}
-		if cfg.Channel != "" {
-			t.Errorf("Channel = %q, want git path (empty)", cfg.Channel)
+		if cfg.Channel != "production" {
+			t.Errorf("Channel = %q, want production (the post-cutover default)", cfg.Channel)
 		}
-		if origin.Signed || origin.Custom {
-			t.Errorf("origin = %+v, want unsigned default", origin)
+		if !origin.Signed || origin.Channel != "production" || origin.Custom {
+			t.Errorf("origin = %+v, want signed production default", origin)
 		}
 	})
 
@@ -159,14 +159,19 @@ func TestEffectiveRules(t *testing.T) {
 }
 
 // TestEffectiveRules_RequireSigned locks the signed-only gate: --require-signed
-// (or TRUSTABL_REQUIRE_SIGNED=1) refuses the unsigned git path and allows a
-// signed channel.
+// (or TRUSTABL_REQUIRE_SIGNED=1) refuses the unsigned git path (now the explicit
+// opt-out) and allows a signed channel — including the post-cutover default.
 func TestEffectiveRules_RequireSigned(t *testing.T) {
 	t.Setenv("TRUSTABL_RULES_REPO", "")
 	t.Setenv("TRUSTABL_REQUIRE_SIGNED", "")
 
-	if _, _, err := effectiveRules(scanFlags{requireSigned: true}); err == nil {
-		t.Fatal("--require-signed must refuse the unsigned git default")
+	// The default is now the signed production channel, so --require-signed is
+	// satisfied by the default; it only refuses when git is explicitly selected.
+	if _, _, err := effectiveRules(scanFlags{requireSigned: true}); err != nil {
+		t.Fatalf("--require-signed must allow the signed production default: %v", err)
+	}
+	if _, _, err := effectiveRules(scanFlags{requireSigned: true, rulesSource: "git"}); err == nil {
+		t.Fatal("--require-signed must refuse the explicit unsigned git path")
 	}
 	cfg, origin, err := effectiveRules(scanFlags{requireSigned: true, rulesSource: "production"})
 	if err != nil {
@@ -177,15 +182,15 @@ func TestEffectiveRules_RequireSigned(t *testing.T) {
 	}
 
 	t.Setenv("TRUSTABL_REQUIRE_SIGNED", "1")
-	if _, _, err := effectiveRules(scanFlags{}); err == nil {
-		t.Fatal("TRUSTABL_REQUIRE_SIGNED=1 must refuse the unsigned git default")
+	if _, _, err := effectiveRules(scanFlags{rulesSource: "git"}); err == nil {
+		t.Fatal("TRUSTABL_REQUIRE_SIGNED=1 must refuse the explicit unsigned git path")
 	}
 }
 
-// TestDefaultRulesSource_CutoverHasGenesisFloor is the cutover guard: the moment
-// the default flips from "git" to a signed channel (ENG-6), that channel MUST
-// ship with a non-zero genesis floor, or first contact has anti-rollback
-// disabled. While the default is still "git" this is a no-op.
+// TestDefaultRulesSource_CutoverHasGenesisFloor is the cutover guard: once the
+// default is a signed channel (ENG-6), that channel MUST ship with a non-zero
+// genesis floor, or first contact has anti-rollback disabled. (A "git" default
+// would make this a no-op.)
 func TestDefaultRulesSource_CutoverHasGenesisFloor(t *testing.T) {
 	if defaultRulesSource == "git" {
 		return // pre-cutover: unsigned git default, nothing to enforce yet

--- a/cmd/trustabl/scan.go
+++ b/cmd/trustabl/scan.go
@@ -401,7 +401,8 @@ func finishScan(result models.ScanResult, jobErr error, f scanFlags, log *logx.L
 			fmt.Fprintln(os.Stderr,
 				"No usable rules found: none cached locally and none could be fetched.")
 			fmt.Fprintln(os.Stderr,
-				`Run "trustabl rules pull" to download the rule packs.`)
+				`Run "trustabl rules pull" to pre-warm the signed channel cache for offline use, `+
+					`or pass --rules-source git to resolve from the unsigned git source.`)
 			return exitCodeError{2}
 		}
 		if errors.Is(jobErr, rules.ErrNoRulesInPack) {
@@ -413,11 +414,12 @@ func finishScan(result models.ScanResult, jobErr error, f scanFlags, log *logx.L
 		}
 		if errors.Is(jobErr, rulesource.ErrNoTrustKeys) {
 			fmt.Fprintln(os.Stderr,
-				"This build of Trustabl embeds no rule-signing keys, so a signed rules "+
-					"channel cannot be verified.")
+				"This build of Trustabl embeds no rule-signing keys, so the signed rules "+
+					"channel cannot be verified. A released binary always embeds them, so an "+
+					"empty keyring indicates a broken or custom build.")
 			fmt.Fprintln(os.Stderr,
-				"Use --rules-source git (or pass --rules-repo / --rules-ref) to resolve "+
-					"rules from the unsigned git source instead.")
+				"As a workaround, use --rules-source git (or pass --rules-repo / --rules-ref) "+
+					"to resolve rules from the unsigned git source instead.")
 			return exitCodeError{2}
 		}
 		if isRuleSignFailure(jobErr) {
@@ -647,14 +649,15 @@ func exitCode(result models.ScanResult, strict bool) int {
 	return 0
 }
 
-// defaultRulesSource is the rules source used when the operator selects none. It
-// stays "git" (the unsigned clone of the default branch) until the signed-
-// production cutover (ENG-6) flips it to "production". Keeping the default in one
-// place means the cutover is a one-line change, and effectiveRules already routes
-// the git opt-out (--rules-repo / --rules-ref / TRUSTABL_RULES_REPO) to the git
-// path for either default — so after the flip, "git only via --rules-ref/--rules-repo"
-// holds without further wiring.
-const defaultRulesSource = "git"
+// defaultRulesSource is the rules source used when the operator selects none.
+// The signed-production cutover (ENG-6) flipped it from "git" to "production": a
+// plain `trustabl scan` now resolves the signature-verified production channel,
+// and the unsigned git path is the explicit opt-out (--rules-source git, or any
+// --rules-repo / --rules-ref / TRUSTABL_RULES_REPO, which effectiveRules already
+// routes to git). The flip is safe only because the embedded keyring is populated
+// and channel-production has a published, floor-pinned statement — the
+// TestDefaultRulesSource_CutoverHasGenesisFloor guard fails the build otherwise.
+const defaultRulesSource = "production"
 
 // effectiveRules resolves the scan's rules source from flags into BOTH a
 // rulesource.Config and a models.RulesOrigin. Deriving them from one decision is


### PR DESCRIPTION
## TR-325 — the signed-rules cutover (ENG-6)

Flips `defaultRulesSource` from `git` to `production`, so a plain `trustabl scan` now resolves the signature-verified production channel by default. The unsigned git path becomes the explicit opt-out.

Safe to ship: PR #73 (merged) armed `genesisFloors["production"] = 1781639780`, the embedded keyring is populated, and `channel-production` has a published, floor-pinned statement. `TestDefaultRulesSource_CutoverHasGenesisFloor` fails the build if a signed default ever ships without a floor.

### Changes
- `cmd/trustabl/scan.go`: `const defaultRulesSource = "production"`. `effectiveRules` already routes `--rules-source git` / `--rules-repo` / `--rules-ref` to the unsigned git path, so the opt-out needs no new wiring. `trustabl rules pull` (no args) reuses `effectiveRules`, so it now pre-warms the production bundle cache by default (offline-first).
- Reworded the `ErrNoTrustKeys` message (an empty keyring is now a build-defect indicator) and the cold-cache `ErrNoRules` message (suggests `trustabl rules pull` + `--rules-source git`).
- `README.md` / `ARCHITECTURE.md`: signed channel is the default; git is the opt-out; noted the one-time `ScanID` shift and the `TRUSTABL_REQUIRE_SIGNED` CI lock.
- Updated `TestEffectiveRules` (default is now signed production) and `TestEffectiveRules_RequireSigned` (refusal now keys off the explicit `--rules-source git`).

### Verification
- `go build ./...`, `go vet`, and `cmd/trustabl` + `rulesource` + `scanner` + `review` suites all green.
- Already-shipped (pre-cutover) binaries are unaffected — the default and keyring are compiled in. Only a new release picks up the flip.

### Follow-up (after merge)
- Cut release **v0.1.6** (embeds the floor + the flipped default).
- Release notes should call out the one-time `ScanID` shift (origin tag + git-SHA → bundle digest).