### PR TITLE
fix(attest): support cosign v3 for offline --no-tlog signing and keyless signin

### DIFF
--- a/.github/workflows/attestation.yml
+++ b/.github/workflows/attestation.yml
@@ -35,9 +35,17 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - uses: sigstore/cosign-installer@v3
-        with:
-          cosign-release: ${{ matrix.cosign }}
+      # Install the exact cosign under test by downloading the release binary
+      # directly. We do NOT use sigstore/cosign-installer here: its signature-
+      # verification step 404s on cosign v3 (v3 releases dropped the detached
+      # `.sig` asset that installer expects). This job is a functional e2e, not a
+      # cosign-provenance gate, so a direct download is the right tradeoff; the
+      # keyless job below still uses the installer.
+      - name: Install cosign ${{ matrix.cosign }}
+        run: |
+          sudo curl -sSfL "https://github.com/sigstore/cosign/releases/download/${{ matrix.cosign }}/cosign-linux-amd64" -o /usr/local/bin/cosign
+          sudo chmod +x /usr/local/bin/cosign
+          cosign version
 
       - name: Attestation e2e (key mode, cosign ${{ matrix.cosign }})
         run: bash scripts/attest-e2e.sh

--- a/.github/workflows/attestation.yml
+++ b/.github/workflows/attestation.yml
@@ -18,6 +18,14 @@ jobs:
     # verify -> tamper -> verify-fails, plus the scan --attest path. No OIDC, no
     # Rekor — deterministic assurance that the cosign integration is wired right.
     # This is the spike that cannot run on a dev box without cosign installed.
+    #
+    # Run against BOTH cosign majors: v2 (the --tlog-upload=false no-tlog path) and
+    # v3 (which removed that flag — no-tlog goes through a no-Rekor --signing-config).
+    # A single pinned version silently missed the v3 breakage.
+    strategy:
+      fail-fast: false
+      matrix:
+        cosign: ["v2.4.3", "v3.1.1"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -28,8 +36,10 @@ jobs:
           cache: true
 
       - uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: ${{ matrix.cosign }}
 
-      - name: Attestation e2e (key mode)
+      - name: Attestation e2e (key mode, cosign ${{ matrix.cosign }})
         run: bash scripts/attest-e2e.sh
 
   attest-keyless:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ to follow Semantic Versioning once it reaches 1.0.
   is now part of a scan's identity by design; baselines pinned to old IDs must
   be re-captured once.
 
+### Fixed
+
+- **Attestation now works with cosign v3.** cosign v3 removed the
+  `--tlog-upload` flag (it defaults `--use-signing-config=true`), which broke the
+  offline `--no-tlog` signing path (`--tlog-upload=false is not supported with
+  --signing-config`). Trustabl now detects the cosign major version and, on v3+,
+  signs against a generated no-Rekor `--signing-config`; v2 keeps
+  `--tlog-upload=false`. Verification is unchanged. CI runs the attestation e2e
+  against both cosign v2 and v3 so this cannot regress.
+
 ### Added
 
 - **Scan attestation (opt-in).** New `internal/attest` package plus `trustabl

--- a/README.md
+++ b/README.md
@@ -479,6 +479,24 @@ writes cosign.key (private) + cosign.pub (public)
 ##### VERIFICATION
 `./trustabl.exe verify report.json --key cosign.pub --bundle att.bundle.json --no-tlog`
 
+#### Keyless (CI / no key to manage)
+
+Keyless signs with your ambient **OIDC identity** instead of a key pair — nothing
+to generate or store. In CI (GitHub Actions) the runner's identity is used
+automatically; **on a laptop it opens a browser to log in**. Either way the
+signing event is recorded in the **public Rekor transparency log** — so use key
+mode above if that visibility is unacceptable. No `--no-tlog` here (keyless *is*
+the transparency-log path), so the cosign v2/v3 difference does not apply.
+
+##### Scan and Attest (keyless):
+`./trustabl.exe scan https://github.com/google/adk-python --json-out report.json --attest --attest-bundle att.bundle.json`
+
+##### VERIFICATION (keyless — you must pin who signed and the issuer):
+`./trustabl.exe verify report.json --bundle att.bundle.json --certificate-identity "<signer-identity>" --certificate-oidc-issuer "https://token.actions.githubusercontent.com"`
+
+In GitHub Actions the identity is the workflow ref, e.g.
+`https://github.com/OWNER/REPO/.github/workflows/scan.yml@refs/heads/main`.
+
 ### cosign (optional — only for scan attestation)
 
 Trustabl's `attest` / `verify` commands and `scan --attest` shell out to the

--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ gh attestation verify <archive> --repo trustabl/trustabl
 ## Attestation
 ### Test Usage Example
 #### **Prerequisite and setup:**
-Install cosign **2.4.x** version
+Install cosign (any **2.x or 3.x** — Trustabl adapts to the installed version)
 
 ##### Add to target folder path:
 `export PATH="<folder_path>:$PATH"`
@@ -501,10 +501,15 @@ component add `sigstore/cosign-installer` for you.
 Key mode signs with a local key pair and skips the public transparency log — no
 browser, no network, ideal for a laptop or air-gapped run.
 
-> **cosign version:** the `--no-tlog` flag needs cosign **2.4.x**. cosign 2.5+
-> removed the underlying `--tlog-upload` flag, so the command errors there — pin
-> 2.4.3 if you hit that. On a PATH install the command is `trustabl`; for a local
+> **cosign version:** works with cosign **2.x and 3.x** — Trustabl selects the
+> right no-transparency-log mechanism per version automatically
+> (`--tlog-upload=false` on v2; a no-Rekor `--signing-config` on v3+, which
+> removed that flag). On a PATH install the command is `trustabl`; for a local
 > Windows build it is `.\trustabl.exe`.
+
+> **Attestation tiers:** this is the **free-tier basic attestation** — it signs
+> scan *provenance* (scan ID, rules version, reliability score, verdict, severity
+> counts). Behavioral and policy-aware attestations are on the paid roadmap.
 
 **Step 0 — install cosign** (see the commands above for your OS).
 

--- a/internal/attest/cosign.go
+++ b/internal/attest/cosign.go
@@ -33,6 +33,10 @@ type AttestOptions struct {
 	Bundle    string // output path for the signed sigstore bundle
 	KeyRef    string // cosign private-key reference; empty selects keyless (ambient OIDC)
 	NoTLog    bool   // do not upload the signature to the public Rekor transparency log
+	// SigningConfig is the path to a no-Rekor signing config. It is set internally
+	// by Attest on cosign v3+ (which removed --tlog-upload) to realize NoTLog; when
+	// empty and NoTLog is set, the pre-v3 --tlog-upload=false flag is used instead.
+	SigningConfig string
 }
 
 // attestArgs builds the cosign argv (without the binary name). Pure and
@@ -49,7 +53,13 @@ func attestArgs(o AttestOptions) []string {
 		args = append(args, "--key", o.KeyRef)
 	}
 	if o.NoTLog {
-		args = append(args, "--tlog-upload=false")
+		if o.SigningConfig != "" {
+			// cosign v3+: sign against a no-Rekor signing config (no transparency log).
+			args = append(args, "--signing-config", o.SigningConfig)
+		} else {
+			// cosign v2: the direct flag (removed in v3).
+			args = append(args, "--tlog-upload=false")
+		}
 	}
 	// The subject blob is the trailing positional argument.
 	return append(args, o.Blob)
@@ -61,11 +71,50 @@ func attestArgs(o AttestOptions) []string {
 // ErrCosignNotFound when cosign is absent, or a wrapped error when cosign runs
 // but fails (e.g. keyless with no OIDC identity available).
 func Attest(ctx context.Context, o AttestOptions) error {
+	if o.NoTLog {
+		// cosign v3 removed --tlog-upload (it defaults --use-signing-config=true, a
+		// Rekor-bearing config, so the old flag conflicts). Realize NoTLog on v3+ via
+		// an explicit no-Rekor signing config; pre-v3 keeps --tlog-upload=false. If the
+		// version can't be determined, fall back to the pre-v3 flag (best effort).
+		if major, verr := cosignMajor(ctx); verr == nil && major >= 3 {
+			cfg, cleanup, cerr := writeNoTLogSigningConfig(ctx)
+			if cerr != nil {
+				return cerr
+			}
+			defer cleanup()
+			o.SigningConfig = cfg
+		}
+	}
 	err := run(ctx, attestArgs(o))
 	if err == nil || errors.Is(err, ErrCosignNotFound) {
 		return err
 	}
 	return fmt.Errorf("attest: cosign signing failed: %w", err)
+}
+
+// writeNoTLogSigningConfig generates a Sigstore signing config with no Rekor, TSA,
+// OIDC, or Fulcio services — i.e. one that signs without contacting or recording
+// to any transparency log. cosign v3 needs this for offline signing because it
+// defaults --use-signing-config=true. Returns the temp-file path and a cleanup
+// func the caller must defer.
+func writeNoTLogSigningConfig(ctx context.Context) (path string, cleanup func(), err error) {
+	f, err := os.CreateTemp("", "trustabl-signingconfig-*.json")
+	if err != nil {
+		return "", func() {}, err
+	}
+	name := f.Name()
+	f.Close()
+	cleanup = func() { os.Remove(name) }
+	if e := run(ctx, []string{
+		"signing-config", "create",
+		"--no-default-rekor", "--no-default-tsa",
+		"--no-default-oidc", "--no-default-fulcio",
+		"--out", name,
+	}); e != nil {
+		cleanup()
+		return "", func() {}, fmt.Errorf("attest: building no-tlog signing config: %w", e)
+	}
+	return name, cleanup, nil
 }
 
 // VerifyOptions configures a single `cosign verify-blob-attestation` invocation.

--- a/internal/attest/cosign_test.go
+++ b/internal/attest/cosign_test.go
@@ -28,6 +28,16 @@ func TestAttestArgs(t *testing.T) {
 			t.Errorf("attestArgs key = %v, want %v", got, want)
 		}
 	})
+	t.Run("key + no-tlog on cosign v3 (signing-config)", func(t *testing.T) {
+		got := attestArgs(AttestOptions{Predicate: "p.json", Bundle: "b.json", Blob: "report.json", KeyRef: "k.key", NoTLog: true, SigningConfig: "sc.json"})
+		want := []string{
+			"attest-blob", "--predicate", "p.json", "--type", PredicateType,
+			"--bundle", "b.json", "--yes", "--key", "k.key", "--signing-config", "sc.json", "report.json",
+		}
+		if !slices.Equal(got, want) {
+			t.Errorf("attestArgs v3 no-tlog = %v, want %v", got, want)
+		}
+	})
 }
 
 func TestVerifyArgs(t *testing.T) {
@@ -76,5 +86,23 @@ func TestVerify_CosignMissing(t *testing.T) {
 	err := Verify(context.Background(), VerifyOptions{Blob: "report.json", Bundle: "b.json", KeyRef: "k.pub"})
 	if !errors.Is(err, ErrCosignNotFound) {
 		t.Fatalf("Verify err = %v, want ErrCosignNotFound", err)
+	}
+}
+
+func TestCosignVersionRE(t *testing.T) {
+	cases := map[string]string{
+		"GitVersion:    v3.1.1\n": "3",
+		"GitVersion: v2.4.3":      "2",
+		"GitVersion:\t2.5.0":      "2",
+	}
+	for in, want := range cases {
+		m := cosignVersionRE.FindStringSubmatch(in)
+		if m == nil {
+			t.Errorf("parse %q: no match", in)
+			continue
+		}
+		if m[1] != want {
+			t.Errorf("parse %q major = %s, want %s", in, m[1], want)
+		}
 	}
 }

--- a/internal/attest/version.go
+++ b/internal/attest/version.go
@@ -1,0 +1,30 @@
+package attest
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+)
+
+// cosignVersionRE pulls the major version out of `cosign version` output, whose
+// relevant line looks like `GitVersion:    v3.1.1`.
+var cosignVersionRE = regexp.MustCompile(`GitVersion:\s*v?(\d+)\.`)
+
+// cosignMajor returns cosign's major version number. cosign v3 removed the
+// --tlog-upload flag (it defaults --use-signing-config=true, which conflicts with
+// it), so no-tlog signing on v3+ must instead pass an explicit no-Rekor
+// --signing-config. Callers use this to pick the right flag; on any error they
+// fall back to the pre-v3 behavior.
+func cosignMajor(ctx context.Context) (int, error) {
+	out, err := exec.CommandContext(ctx, cosignBinary, "version").CombinedOutput()
+	if err != nil {
+		return 0, err
+	}
+	m := cosignVersionRE.FindSubmatch(out)
+	if m == nil {
+		return 0, fmt.Errorf("attest: cannot parse cosign version from %q", out)
+	}
+	return strconv.Atoi(string(m[1]))
+}


### PR DESCRIPTION
Detect the cosign major version and, on v3+, sign against a generated no-Rekor signing config (cosign signing-config create --no-default-*); v2 keeps --tlog-upload=false. Verify is unchanged (--insecure-ignore-tlog still exists on v3). CI attest-e2e now runs a cosign v2+v3 matrix so this can't regress. Docs: relax the README version note, add a tiers note, changelog entry.

Keyless:
`./trustabl.exe scan https://github.com/google/adk-python --json-out report.json --attest`

Step 1: Scan and Attest Keyless
<img width="1001" height="560" alt="image" src="https://github.com/user-attachments/assets/d9df4ec4-a650-4a3d-beb4-7c317ff32c45" />

Step 2: Integrate in Sigstore
<img width="1148" height="368" alt="image" src="https://github.com/user-attachments/assets/7c3ba8e9-2134-4319-9781-ed050f71e671" />

Step 3: Sign-in
<img width="994" height="473" alt="image" src="https://github.com/user-attachments/assets/f4bd3c90-174a-459b-a5e7-dc4fd2195b36" />
<img width="1105" height="419" alt="image" src="https://github.com/user-attachments/assets/f1dac76b-78a6-4c0d-9955-0cf034867e3b" />

Step 4: Token Received, Successfully Attest using Keyless via Sigstore 
<img width="845" height="235" alt="image" src="https://github.com/user-attachments/assets/6f0c880a-0428-4b66-a7ec-2f86211e319a" />

