### PR TITLE
docs: update Discord invite link in Community section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1068,7 +1068,7 @@ measurement.
 
 ## Community
 
-Join the [Trustabl Discord](https://discord.gg/maQ7QMPsB) to ask questions, share feedback, and follow development.
+Join the [Trustabl Discord](https://discord.gg/G6gM8nKxPg) to ask questions, share feedback, and follow development.
 
 ## License
 


### PR DESCRIPTION
## Summary
  
 - Updates the Discord invite link in the README Community section
 - Old link (`discord.gg/maQ7QMPsB`) replaced with the current invite
 (`discord.gg/G6gM8nKxPg`)
  
  ## Test plan
  
 - [ ] Verify the new link opens the correct Discord server