### PR TITLE
Licenses and secrets detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,10 @@ matching `--format` stdout output.
 dependencies the repo declares across every supported language — `requirements.txt`
 / `pyproject.toml` / `Pipfile` (pip), `package.json` (npm), `go.mod` (Go),
 `composer.json` (Composer), `*.csproj` (NuGet), `Cargo.toml` (Cargo). It is pure
-inventory of DECLARED direct deps and makes no network call.
+inventory of DECLARED direct deps and makes no network call. Where the manifest
+carries a `license` field (`package.json`, `Cargo.toml`, `composer.json`,
+`pyproject.toml`), the SPDX identifier is included in each component's
+`licenses[]` array in the BOM.
 
 `--vuln-scan` turns that BOM into a vulnerability verdict: it matches the repo's
 concretely-pinned dependencies against a pinned [OSV](https://osv.dev) snapshot
@@ -655,6 +658,17 @@ trustabl scan ./repo --bom-out sbom.json
 trustabl vulndb pull                              # pre-download OSV (optional; --vuln-scan auto-fetches)
 trustabl scan ./repo --vuln-scan                  # BOM inventory + CVE verdict in one pass
 trustabl scan ./repo --vuln-scan --bom-out bom.json  # CycloneDX BOM + VEX (vulnerabilities[]) in one file
+
+# License scan (opt-in): flag dependencies with copyleft licenses (GPL-2.0,
+# GPL-3.0, AGPL-3.0, LGPL-2.1, SSPL-1.0) as medium-severity findings.
+# License data is read from the manifest at parse time — no network call.
+trustabl scan ./repo --license-scan
+trustabl scan ./repo --license-scan --bom-out bom.json  # findings + BOM with licenses[]
+
+# Secret scan (opt-in): walk all text files in the repo for hardcoded
+# credential literals (SECRET-LIT-001, high) and scripts that read
+# credential environment variables (SECRET-ENV-001, medium).
+trustabl scan ./repo --secret-scan
 
 # JSON output for CI piping
 trustabl scan ./repo --format json

--- a/cmd/trustabl/scan.go
+++ b/cmd/trustabl/scan.go
@@ -42,6 +42,8 @@ type scanFlags struct {
 	sarifOut      string
 	bomOut        string
 	vulnScan      bool
+	licenseScan   bool
+	secretScan    bool
 	attest        bool
 	attestKey     string
 	attestBundle  string
@@ -139,6 +141,10 @@ Exit codes:
 		"also write a CycloneDX BOM of the repo's declared dependencies to this file")
 	cmd.Flags().BoolVar(&f.vulnScan, "vuln-scan", false,
 		"match dependencies against a pinned OSV snapshot and report known CVEs (off by default; fetches the OSV database on first use, then caches it)")
+	cmd.Flags().BoolVar(&f.licenseScan, "license-scan", false,
+		"flag dependencies with copyleft licenses (GPL-2.0, GPL-3.0, AGPL-3.0, LGPL-2.1, SSPL-1.0) as findings (opt-in)")
+	cmd.Flags().BoolVar(&f.secretScan, "secret-scan", false,
+		"scan all text files for hardcoded secret literals and credential reads (opt-in)")
 	cmd.Flags().BoolVar(&f.attest, "attest", false,
 		"after the scan, sign the JSON report into a cosign attestation (requires cosign on PATH; keyless by default — see 'trustabl attest')")
 	cmd.Flags().StringVar(&f.attestKey, "attest-key", "",
@@ -371,6 +377,8 @@ func resolveAndScan(cfg *scanner.Config, f scanFlags, rep progress.Reporter) (mo
 	cfg.RulesSchemaNewer = res.SchemaNewer
 	cfg.RulesOrigin = origin
 	cfg.VulnScan = f.vulnScan
+	cfg.LicenseScan = f.licenseScan
+	cfg.SecretScan = f.secretScan
 	cfg.VulnNoUpdate = f.noRulesUpdate // --no-rules-update is the offline switch for both rules and the OSV DB
 	cfg.Progress = rep
 

--- a/internal/analysis/deps.go
+++ b/internal/analysis/deps.go
@@ -80,6 +80,35 @@ func skipForDeps(name string) bool {
 	return false
 }
 
+// spdxAliases maps common non-canonical spellings to their SPDX 3.x identifiers.
+// Unknown strings pass through normalizeSPDX unchanged.
+var spdxAliases = map[string]string{
+	"Apache 2.0": "Apache-2.0", "Apache-2": "Apache-2.0", "Apache 2": "Apache-2.0",
+	"GPL-2.0": "GPL-2.0-only", "GPLv2": "GPL-2.0-only", "GNU GPL v2": "GPL-2.0-only",
+	"GPL-3.0": "GPL-3.0-only", "GPLv3": "GPL-3.0-only",
+	"AGPL-3.0": "AGPL-3.0-only", "AGPLv3": "AGPL-3.0-only",
+	"LGPL-2.1": "LGPL-2.1-only", "LGPLv2.1": "LGPL-2.1-only",
+	"LGPL-3.0": "LGPL-3.0-only", "LGPLv3": "LGPL-3.0-only",
+	"MIT": "MIT", "BSD-2-Clause": "BSD-2-Clause", "BSD-3-Clause": "BSD-3-Clause",
+	"ISC": "ISC", "MPL-2.0": "MPL-2.0", "CC0-1.0": "CC0-1.0", "SSPL-1.0": "SSPL-1.0",
+}
+
+func normalizeSPDX(s string) string {
+	s = strings.TrimSpace(s)
+	if c, ok := spdxAliases[s]; ok {
+		return c
+	}
+	return s
+}
+
+// stampLicense sets License on every dep in the slice and returns it.
+func stampLicense(deps []models.DepRef, lic string) []models.DepRef {
+	for i := range deps {
+		deps[i].License = lic
+	}
+	return deps
+}
+
 // requirementLineRe captures a PEP 508 requirement's distribution name (group 1)
 // and its optional version specifier (group 2, from the first operator char).
 var requirementLineRe = regexp.MustCompile(`^([A-Za-z0-9][A-Za-z0-9._-]*)\s*(?:\[[^\]]*\])?\s*([=<>!~][^;#]*)?`)
@@ -132,9 +161,13 @@ func parsePyproject(abs, source string) []models.DepRef {
 		Project struct {
 			Dependencies         []string            `toml:"dependencies"`
 			OptionalDependencies map[string][]string `toml:"optional-dependencies"`
+			License              struct {
+				Text string `toml:"text"`
+			} `toml:"license"`
 		} `toml:"project"`
 		Tool struct {
 			Poetry struct {
+				License         string         `toml:"license"`
 				Dependencies    map[string]any `toml:"dependencies"`
 				DevDependencies map[string]any `toml:"dev-dependencies"`
 				Group           map[string]struct {
@@ -145,6 +178,10 @@ func parsePyproject(abs, source string) []models.DepRef {
 	}
 	if err := toml.Unmarshal(content, &doc); err != nil {
 		return nil
+	}
+	lic := normalizeSPDX(doc.Project.License.Text)
+	if lic == "" {
+		lic = normalizeSPDX(doc.Tool.Poetry.License)
 	}
 	var out []models.DepRef
 	for _, spec := range doc.Project.Dependencies {
@@ -172,7 +209,11 @@ func parsePyproject(abs, source string) []models.DepRef {
 	for _, g := range doc.Tool.Poetry.Group {
 		addPoetry(g.Dependencies)
 	}
-	return withLines(out, content)
+	out = withLines(out, content)
+	if lic != "" {
+		out = stampLicense(out, lic)
+	}
+	return out
 }
 
 // parsePipfile extracts pip deps from a Pipfile ([packages] / [dev-packages]).
@@ -195,6 +236,7 @@ func parsePipfile(abs, source string) []models.DepRef {
 			if ver == "*" {
 				ver = ""
 			}
+			ver = strings.TrimPrefix(ver, "==")
 			out = append(out, models.DepRef{Name: name, Version: ver, Ecosystem: "pypi", Source: source})
 		}
 	}
@@ -205,17 +247,55 @@ func parsePipfile(abs, source string) []models.DepRef {
 
 // parseNpmPackageJSON extracts npm deps (runtime + dev) from a package.json.
 func parseNpmPackageJSON(abs, source string) []models.DepRef {
-	return parseJSONDepMaps(abs, source, "npm",
-		[]string{"dependencies", "devDependencies"}, nil)
+	deps := parseJSONDepMaps(abs, source, "npm", []string{"dependencies", "devDependencies"}, nil)
+	if lic := jsonTopLevelLicense(abs); lic != "" {
+		deps = stampLicense(deps, lic)
+	}
+	return deps
 }
 
 // parseComposerJSON extracts PHP deps from a composer.json (require + require-dev).
 // Platform/meta requirements (php, ext-*, anything without a vendor/name slash)
 // are skipped — they are not Packagist packages.
 func parseComposerJSON(abs, source string) []models.DepRef {
-	return parseJSONDepMaps(abs, source, "composer",
+	deps := parseJSONDepMaps(abs, source, "composer",
 		[]string{"require", "require-dev"},
 		func(name string) bool { return !strings.Contains(name, "/") })
+	if lic := jsonTopLevelLicense(abs); lic != "" {
+		deps = stampLicense(deps, lic)
+	}
+	return deps
+}
+
+// jsonTopLevelLicense reads the top-level "license" field from a JSON manifest.
+// The field may be a string (npm: "MIT") or an array of strings
+// (composer: ["MIT", "Apache-2.0"]); arrays are joined with " OR ".
+func jsonTopLevelLicense(abs string) string {
+	content, err := readCapped(abs, maxBundledScriptScanBytes)
+	if err != nil {
+		return ""
+	}
+	var doc struct {
+		License json.RawMessage `json:"license"`
+	}
+	if err := json.Unmarshal(content, &doc); err != nil || doc.License == nil {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(doc.License, &s); err == nil {
+		return normalizeSPDX(s)
+	}
+	var arr []string
+	if err := json.Unmarshal(doc.License, &arr); err == nil {
+		parts := make([]string, 0, len(arr))
+		for _, item := range arr {
+			if n := normalizeSPDX(item); n != "" {
+				parts = append(parts, n)
+			}
+		}
+		return strings.Join(parts, " OR ")
+	}
+	return ""
 }
 
 // parseJSONDepMaps reads the named top-level objects of a JSON manifest
@@ -297,6 +377,9 @@ func parseCargoToml(abs, source string) []models.DepRef {
 		return nil
 	}
 	var doc struct {
+		Package struct {
+			License string `toml:"license"`
+		} `toml:"package"`
 		Dependencies      map[string]any `toml:"dependencies"`
 		DevDependencies   map[string]any `toml:"dev-dependencies"`
 		BuildDependencies map[string]any `toml:"build-dependencies"`
@@ -304,10 +387,11 @@ func parseCargoToml(abs, source string) []models.DepRef {
 	if err := toml.Unmarshal(content, &doc); err != nil {
 		return nil
 	}
+	lic := normalizeSPDX(doc.Package.License)
 	var out []models.DepRef
 	add := func(m map[string]any) {
 		for name, v := range m {
-			out = append(out, models.DepRef{Name: name, Version: tomlVersion(v), Ecosystem: "cargo", Source: source})
+			out = append(out, models.DepRef{Name: name, Version: tomlVersion(v), Ecosystem: "cargo", Source: source, License: lic})
 		}
 	}
 	add(doc.Dependencies)

--- a/internal/analysis/deps_test.go
+++ b/internal/analysis/deps_test.go
@@ -74,7 +74,7 @@ func TestDiscoverDependencies_PoetryAndPipfile(t *testing.T) {
 	writeDep(t, root, "svc/Pipfile", "[packages]\nflask = \"*\"\nboto3 = \"==1.34.0\"\n[dev-packages]\nmypy = \"*\"\n")
 	got := depKeys(DiscoverDependencies(root))
 	want := []string{
-		"pypi:boto3@==1.34.0",
+		"pypi:boto3@1.34.0",
 		"pypi:flask@", // "*" normalized to empty
 		"pypi:mypy@",  // "*" normalized to empty
 		"pypi:pytest@^8.0",

--- a/internal/analysis/secrets.go
+++ b/internal/analysis/secrets.go
@@ -1,0 +1,89 @@
+package analysis
+
+import (
+	"bytes"
+	"io/fs"
+	"path/filepath"
+	"sort"
+
+	"github.com/trustabl/trustabl/internal/models"
+)
+
+// DiscoverSecrets walks the entire repository for hardcoded secret literals and
+// credential-reading scripts, returning one SecretMatch per detected occurrence.
+// It is the opt-in --secret-scan layer: it runs repo-wide (all text files) so
+// it catches secrets committed outside the .claude/ tree — in tool implementations,
+// CI helpers, test fixtures, or any other source file.
+//
+// Two rule IDs are emitted:
+//   - SECRET-LIT-001: a hardcoded credential literal committed in source (AWS key,
+//     GitHub PAT, Slack token, OpenAI key, Google API key, private-key block).
+//   - SECRET-ENV-001: a script that reads a credential from the environment at
+//     runtime (e.g. $ANTHROPIC_API_KEY, gh auth, printenv SECRET).
+//
+// No raw secret value is recorded. Only file, 1-indexed line, and rule ID.
+func DiscoverSecrets(repoRoot string) []models.SecretMatch {
+	var out []models.SecretMatch
+	_ = filepath.WalkDir(repoRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			if path != repoRoot && skipForDeps(d.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if classifyBundledFile(d.Name()) == "binary" {
+			return nil
+		}
+		content, rerr := readCapped(path, maxBundledScriptScanBytes)
+		if rerr != nil || len(content) == 0 {
+			return nil
+		}
+		rel, rerr := filepath.Rel(repoRoot, path)
+		if rerr != nil {
+			return nil
+		}
+		rel = filepath.ToSlash(rel)
+
+		if loc := bundledSecretLiteralRe.FindIndex(content); loc != nil {
+			out = append(out, models.SecretMatch{
+				File:   rel,
+				Line:   lineOf1(content, loc[0]),
+				RuleID: "SECRET-LIT-001",
+			})
+		}
+		if classifyBundledFile(d.Name()) == "script" {
+			code := bundledCommentRe.ReplaceAll(content, nil)
+			if loc := bundledSecretRe.FindIndex(code); loc != nil {
+				out = append(out, models.SecretMatch{
+					File:   rel,
+					Line:   lineOf1(content, loc[0]),
+					RuleID: "SECRET-ENV-001",
+				})
+			}
+		}
+		return nil
+	})
+	sort.Slice(out, func(i, j int) bool {
+		a, b := out[i], out[j]
+		if a.File != b.File {
+			return a.File < b.File
+		}
+		if a.Line != b.Line {
+			return a.Line < b.Line
+		}
+		return a.RuleID < b.RuleID
+	})
+	return out
+}
+
+// lineOf1 returns the 1-indexed line number of byte offset pos in content by
+// counting newlines before it.
+func lineOf1(content []byte, pos int) int {
+	if pos > len(content) {
+		pos = len(content)
+	}
+	return bytes.Count(content[:pos], []byte("\n")) + 1
+}

--- a/internal/analysis/secrets_test.go
+++ b/internal/analysis/secrets_test.go
@@ -1,0 +1,121 @@
+package analysis
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeSecret(t *testing.T, root, rel, content string) {
+	t.Helper()
+	abs := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestDiscoverSecrets_LiteralCredential proves a file containing a hardcoded
+// GitHub PAT fires SECRET-LIT-001, and the line number is correct.
+func TestDiscoverSecrets_LiteralCredential(t *testing.T) {
+	root := t.TempDir()
+	writeSecret(t, root, "src/tool.py", "# tool implementation\nTOKEN = \"ghp_abcdefghijklmnopqrstuvwxyz1234567890\"\n")
+	got := DiscoverSecrets(root)
+	if len(got) == 0 {
+		t.Fatal("expected SECRET-LIT-001 match, got none")
+	}
+	found := false
+	for _, m := range got {
+		if m.RuleID == "SECRET-LIT-001" && m.File == "src/tool.py" {
+			found = true
+			if m.Line != 2 {
+				t.Errorf("expected line 2, got %d", m.Line)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("no SECRET-LIT-001 for src/tool.py: %+v", got)
+	}
+}
+
+// TestDiscoverSecrets_ScriptReadsEnv proves a shell script that reads a known
+// credential environment variable fires SECRET-ENV-001.
+func TestDiscoverSecrets_ScriptReadsEnv(t *testing.T) {
+	root := t.TempDir()
+	writeSecret(t, root, "hooks/run.sh", "#!/bin/bash\necho $ANTHROPIC_API_KEY\n")
+	got := DiscoverSecrets(root)
+	if len(got) == 0 {
+		t.Fatal("expected SECRET-ENV-001 match, got none")
+	}
+	found := false
+	for _, m := range got {
+		if m.RuleID == "SECRET-ENV-001" && m.File == "hooks/run.sh" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("no SECRET-ENV-001 for hooks/run.sh: %+v", got)
+	}
+}
+
+// TestDiscoverSecrets_BinarySkipped proves a file with a binary extension is
+// not scanned even if it contains a matching pattern.
+func TestDiscoverSecrets_BinarySkipped(t *testing.T) {
+	root := t.TempDir()
+	// Write a .wasm file that would match the literal pattern.
+	writeSecret(t, root, "dist/app.wasm", "AKIA1234567890ABCDEF")
+	got := DiscoverSecrets(root)
+	for _, m := range got {
+		if m.File == "dist/app.wasm" {
+			t.Errorf("binary file was scanned: %+v", m)
+		}
+	}
+}
+
+// TestDiscoverSecrets_VendoredDirSkipped proves node_modules is not scanned.
+func TestDiscoverSecrets_VendoredDirSkipped(t *testing.T) {
+	root := t.TempDir()
+	writeSecret(t, root, "node_modules/evil/index.js", "const tok = \"ghp_abcdefghijklmnopqrstuvwxyz1234567890\";")
+	got := DiscoverSecrets(root)
+	for _, m := range got {
+		if m.File == "node_modules/evil/index.js" {
+			t.Errorf("vendored dir was scanned: %+v", m)
+		}
+	}
+}
+
+// TestDiscoverSecrets_CommentStrippedForEnvCheck proves that a shell env
+// variable reference inside a comment does NOT fire SECRET-ENV-001 (comments
+// are stripped before the behavioral check) but WOULD fire SECRET-LIT-001 only
+// if a real literal pattern is present.
+func TestDiscoverSecrets_CommentStrippedForEnvCheck(t *testing.T) {
+	root := t.TempDir()
+	// Comment-only reference to $ANTHROPIC_API_KEY — should not fire ENV-001.
+	writeSecret(t, root, "scripts/deploy.sh", "#!/bin/bash\n# export ANTHROPIC_API_KEY=...\necho hello\n")
+	got := DiscoverSecrets(root)
+	for _, m := range got {
+		if m.File == "scripts/deploy.sh" && m.RuleID == "SECRET-ENV-001" {
+			t.Errorf("comment-only env ref should not fire SECRET-ENV-001: %+v", m)
+		}
+	}
+}
+
+// TestDiscoverSecrets_Deterministic proves the result is byte-stable regardless
+// of which files are written first.
+func TestDiscoverSecrets_Deterministic(t *testing.T) {
+	root := t.TempDir()
+	writeSecret(t, root, "a/tool.py", "key = \"ghp_abcdefghijklmnopqrstuvwxyz1234567890\"\n")
+	writeSecret(t, root, "b/tool.py", "key = \"ghp_abcdefghijklmnopqrstuvwxyz1234567890\"\n")
+	first := DiscoverSecrets(root)
+	second := DiscoverSecrets(root)
+	if len(first) != len(second) {
+		t.Fatalf("non-deterministic result lengths: %d vs %d", len(first), len(second))
+	}
+	for i := range first {
+		if first[i] != second[i] {
+			t.Errorf("non-deterministic at index %d: %+v vs %+v", i, first[i], second[i])
+		}
+	}
+}

--- a/internal/cyclonedx/render.go
+++ b/internal/cyclonedx/render.go
@@ -45,12 +45,21 @@ type tool struct {
 }
 
 type component struct {
-	BOMRef     string     `json:"bom-ref"`
-	Type       string     `json:"type"`
-	Name       string     `json:"name"`
-	Version    string     `json:"version,omitempty"`
-	PURL       string     `json:"purl"`
-	Properties []property `json:"properties,omitempty"`
+	BOMRef     string          `json:"bom-ref"`
+	Type       string          `json:"type"`
+	Name       string          `json:"name"`
+	Version    string          `json:"version,omitempty"`
+	PURL       string          `json:"purl"`
+	Licenses   []licenseChoice `json:"licenses,omitempty"`
+	Properties []property      `json:"properties,omitempty"`
+}
+
+type licenseChoice struct {
+	License licenseID `json:"license"`
+}
+
+type licenseID struct {
+	ID string `json:"id"`
 }
 
 type property struct {
@@ -135,6 +144,9 @@ func Render(deps []models.DepRef, vulns []models.DepVuln, toolVersion string) []
 			Name:    d.Name,
 			Version: d.Version,
 			PURL:    base,
+		}
+		if d.License != "" {
+			c.Licenses = []licenseChoice{{License: licenseID{ID: d.License}}}
 		}
 		if d.Source != "" {
 			c.Properties = []property{{Name: "trustabl:source", Value: d.Source}}

--- a/internal/cyclonedx/render_test.go
+++ b/internal/cyclonedx/render_test.go
@@ -221,3 +221,40 @@ func TestRender_NoVulnsOmitsArray(t *testing.T) {
 		t.Errorf("inventory-only BOM must not contain a vulnerabilities array:\n%s", out)
 	}
 }
+
+// TestRender_License proves a dep with a License field emits a CycloneDX
+// licenses[] array and a dep without one omits it.
+func TestRender_License(t *testing.T) {
+	deps := []models.DepRef{
+		{Name: "requests", Version: "2.31.0", Ecosystem: "pypi", Source: "requirements.txt", License: "MIT"},
+		{Name: "flask", Version: "3.0.0", Ecosystem: "pypi", Source: "requirements.txt"},
+	}
+	out := string(Render(deps, nil, "1.0.0"))
+	// The licensed component must carry licenses[0].license.id.
+	if !strings.Contains(out, `"id": "MIT"`) {
+		t.Errorf("BOM missing license id MIT:\n%s", out)
+	}
+	// The unlicensed component must not carry a licenses key at all.
+	// Verify by parsing and checking per-component.
+	var doc struct {
+		Components []struct {
+			Name     string            `json:"name"`
+			Licenses []json.RawMessage `json:"licenses"`
+		} `json:"components"`
+	}
+	if err := json.Unmarshal([]byte(out), &doc); err != nil {
+		t.Fatalf("invalid CycloneDX JSON: %v\n%s", err, out)
+	}
+	for _, c := range doc.Components {
+		switch c.Name {
+		case "requests":
+			if len(c.Licenses) != 1 {
+				t.Errorf("requests: want 1 license entry, got %d", len(c.Licenses))
+			}
+		case "flask":
+			if len(c.Licenses) != 0 {
+				t.Errorf("flask: want no licenses array, got %d entries", len(c.Licenses))
+			}
+		}
+	}
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -347,8 +347,19 @@ type DepRef struct {
 	// StartLine/EndLine are the 1-indexed line of the dependency's declaration in
 	// Source. A declaration is a single manifest line, so EndLine == StartLine.
 	// Mirrors models.Location so a dependency attributes like any other entity.
-	StartLine int `json:"start_line"`
-	EndLine   int `json:"end_line"`
+	StartLine int    `json:"start_line"`
+	EndLine   int    `json:"end_line"`
+	License   string `json:"license,omitempty"`
+}
+
+// SecretMatch is one potential secret detected by the opt-in --secret-scan
+// layer: a hardcoded credential literal (SECRET-LIT-001) or a script that reads
+// credentials from the environment at runtime (SECRET-ENV-001). No raw secret
+// value is stored — only the file, 1-indexed line, and the rule ID that fired.
+type SecretMatch struct {
+	File   string `json:"file"`
+	Line   int    `json:"line"`
+	RuleID string `json:"rule_id"`
 }
 
 // DepVuln is one known vulnerability matched against a declared dependency by the
@@ -496,6 +507,7 @@ type ScanResult struct {
 	Skills              []SkillDef         `json:"skills"`
 	Dependencies        []DepRef           `json:"dependencies"`              // repo-wide declared-dependency BOM (TR-278); not folded into ScanID
 	Vulnerabilities     []DepVuln          `json:"vulnerabilities,omitempty"` // --vuln-scan OSV matches (TR-271); absent on the default path
+	Secrets             []SecretMatch      `json:"secrets,omitempty"`         // --secret-scan hardcoded-credential matches; absent on the default path
 	SlashCommands       []SlashCommandDef  `json:"slash_commands"`
 	PluginManifests     []PluginManifest   `json:"plugin_manifests"`
 	ClaudeSettings      []ClaudeSettings   `json:"claude_settings"`

--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -2115,6 +2115,7 @@ var policyRepoRuleCases = []policyRepoCase{
 		},
 		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKOpenAIAgents}},
 		false},
+
 }
 
 // optionsWithPermissionMode builds a ClaudeAgentOptionsDef whose captured

--- a/internal/rules/predicates.go
+++ b/internal/rules/predicates.go
@@ -1023,3 +1023,4 @@ func PredRepoClaudeOptionsPermissionModeIs(modes []string, inv models.RepoInvent
 	}
 	return false
 }
+

--- a/internal/scanner/license.go
+++ b/internal/scanner/license.go
@@ -1,0 +1,68 @@
+package scanner
+
+import (
+	"fmt"
+
+	"github.com/trustabl/trustabl/internal/models"
+)
+
+// copyleftEntry describes a copyleft license family for finding synthesis.
+type copyleftEntry struct {
+	family   string
+	severity models.Severity
+	ruleID   string
+}
+
+// copyleftLicenses maps SPDX identifiers to their finding metadata.
+// Severity is medium: license incompatibility is a legal/compliance risk,
+// not an active exploit — the same rationale as vuln findings at medium.
+var copyleftLicenses = map[string]copyleftEntry{
+	"GPL-2.0-only":     {"GPL-2.0", models.SeverityMedium, "LIC-GPL2"},
+	"GPL-2.0-or-later": {"GPL-2.0", models.SeverityMedium, "LIC-GPL2"},
+	"GPL-3.0-only":     {"GPL-3.0", models.SeverityMedium, "LIC-GPL3"},
+	"GPL-3.0-or-later": {"GPL-3.0", models.SeverityMedium, "LIC-GPL3"},
+	"AGPL-3.0-only":    {"AGPL-3.0", models.SeverityMedium, "LIC-AGPL3"},
+	"AGPL-3.0-or-later": {"AGPL-3.0", models.SeverityMedium, "LIC-AGPL3"},
+	"LGPL-2.1-only":    {"LGPL-2.1", models.SeverityMedium, "LIC-LGPL21"},
+	"LGPL-2.1-or-later": {"LGPL-2.1", models.SeverityMedium, "LIC-LGPL21"},
+	"SSPL-1.0":         {"SSPL-1.0", models.SeverityMedium, "LIC-SSPL1"},
+}
+
+// licenseFindings synthesizes one Finding per dependency that carries a
+// copyleft license, so license violations flow through the normal findings
+// pipeline — exit codes, SARIF, and the report. This is the --license-scan
+// analog of vulnFindings, not a YAML rule.
+func licenseFindings(deps []models.DepRef) []models.Finding {
+	var out []models.Finding
+	for _, d := range deps {
+		if d.License == "" {
+			continue
+		}
+		entry, ok := copyleftLicenses[d.License]
+		if !ok {
+			continue
+		}
+		out = append(out, models.Finding{
+			RuleID:    entry.ruleID,
+			Severity:  entry.severity,
+			FilePath:  d.Source,
+			StartLine: d.StartLine,
+			EndLine:   d.EndLine,
+			Title:     fmt.Sprintf("Copyleft dependency: %s (%s)", d.Name, d.License),
+			Explanation: fmt.Sprintf(
+				"%s declares the %s license (%s). Copyleft licenses impose "+
+					"redistribution obligations: if this dependency is linked into "+
+					"an agent or service distributed to third parties, the "+
+					"combined work may need to be released under the same license. "+
+					"Review your distribution model and confirm this is intentional.",
+				d.Name, entry.family, d.License),
+			SuggestedFix: fmt.Sprintf(
+				"Verify that your project's license is compatible with %s. "+
+					"If redistribution obligations are unacceptable, replace %s "+
+					"with a permissively licensed alternative (MIT, Apache-2.0, BSD).",
+				entry.family, d.Name),
+			Confidence: 0.9,
+		})
+	}
+	return out
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -64,6 +64,17 @@ type Config struct {
 	VulnNoUpdate bool
 	VulnCacheDir string
 
+	// LicenseScan opts into the copyleft license detection layer: flag any
+	// declared dependency whose SPDX license is GPL-2.0, GPL-3.0, AGPL-3.0,
+	// LGPL-2.1, or SSPL-1.0. Off by default.
+	LicenseScan bool
+
+	// SecretScan opts into the repo-wide secret-scanning layer: walk all text
+	// files in the repository and flag hardcoded credential literals
+	// (SECRET-LIT-001) and scripts that read credentials from the environment
+	// (SECRET-ENV-001). Off by default.
+	SecretScan bool
+
 	// Progress receives real-time phase events. Nil means no progress output.
 	Progress progress.Reporter
 
@@ -461,6 +472,21 @@ func Run(cfg Config) (models.ScanResult, error) {
 		log.Verbosef("vuln-scan: OSV snapshot %s · %d dependency vulnerabilities", vulnDBVersion, len(vulns))
 	}
 
+	if cfg.LicenseScan {
+		lf := licenseFindings(inventory.Dependencies)
+		findings = append(findings, lf...)
+		log.Verbosef("license-scan: %d copyleft findings", len(lf))
+	}
+
+	var secrets []models.SecretMatch
+	if cfg.SecretScan {
+		rep.StartPhase("secret-scan", "Scanning repository for secrets")
+		secrets = analysis.DiscoverSecrets(profile.Manifest.RepoRoot)
+		rep.EndPhase(fmt.Sprintf("%d potential secrets", len(secrets)))
+		findings = append(findings, secretFindings(secrets)...)
+		log.Verbosef("secret-scan: %d potential secrets", len(secrets))
+	}
+
 	// Step 5: scoring
 	surfaces, overall := analysis.Score(tools, inventory.Agents, inventory.Subagents, inventory.Skills, findings)
 	projected := analysis.Project(tools, inventory.Agents, inventory.Subagents, inventory.Skills, findings)
@@ -504,6 +530,7 @@ func Run(cfg Config) (models.ScanResult, error) {
 		Skills:              inventory.Skills,
 		Dependencies:        inventory.Dependencies,
 		Vulnerabilities:     vulns,
+		Secrets:             secrets,
 		SlashCommands:       inventory.SlashCommands,
 		PluginManifests:     inventory.PluginManifests,
 		ClaudeSettings:      inventory.ClaudeSettings,

--- a/internal/scanner/secrets.go
+++ b/internal/scanner/secrets.go
@@ -1,0 +1,65 @@
+package scanner
+
+import (
+	"fmt"
+
+	"github.com/trustabl/trustabl/internal/models"
+)
+
+// secretFindings synthesizes one Finding per SecretMatch so secrets flow
+// through the normal findings pipeline — exit codes, SARIF, and the report.
+// This is the --secret-scan analog of vulnFindings, not a YAML rule.
+func secretFindings(matches []models.SecretMatch) []models.Finding {
+	out := make([]models.Finding, 0, len(matches))
+	for _, m := range matches {
+		var sev models.Severity
+		var title, expl, fix string
+		switch m.RuleID {
+		case "SECRET-LIT-001":
+			sev = models.SeverityHigh
+			title = "Hardcoded credential literal"
+			expl = fmt.Sprintf(
+				"%s (line %d) contains a hardcoded credential literal — a "+
+					"provider-format token committed directly in source. "+
+					"If this file is pushed to a remote repository the credential "+
+					"is exposed to anyone with read access and will likely be "+
+					"harvested by secret-scanning bots within minutes.",
+				m.File, m.Line)
+			fix = "Revoke and rotate the credential immediately. " +
+				"Store secrets in environment variables, a secrets manager " +
+				"(e.g. AWS Secrets Manager, HashiCorp Vault, GitHub Actions secrets), " +
+				"or a .env file excluded from version control, and reference them " +
+				"at runtime instead of hardcoding them."
+		case "SECRET-ENV-001":
+			sev = models.SeverityMedium
+			title = "Script reads credentials from environment"
+			expl = fmt.Sprintf(
+				"%s (line %d) reads or prints a credential environment variable "+
+					"(e.g. $ANTHROPIC_API_KEY, $AWS_SECRET_ACCESS_KEY, gh auth). "+
+					"If this script is invoked by an agent it may leak credentials "+
+					"to the model's context window, tool output, or log files.",
+				m.File, m.Line)
+			fix = "Avoid passing raw credentials through scripts invoked by agents. " +
+				"Prefer SDKs that inject credentials transparently, " +
+				"scope the credential to the minimum required permissions, " +
+				"and ensure script output is not returned verbatim to the model."
+		default:
+			sev = models.SeverityMedium
+			title = "Potential secret detected"
+			expl = fmt.Sprintf("%s (line %d): pattern matched by %s.", m.File, m.Line, m.RuleID)
+			fix = "Review the flagged line and rotate the credential if it is real."
+		}
+		out = append(out, models.Finding{
+			RuleID:       m.RuleID,
+			Severity:     sev,
+			FilePath:     m.File,
+			StartLine:    m.Line,
+			EndLine:      m.Line,
+			Title:        title,
+			Explanation:  expl,
+			SuggestedFix: fix,
+			Confidence:   0.85,
+		})
+	}
+	return out
+}


### PR DESCRIPTION
**License extraction (always-on)**
Reads the license field from package.json, Cargo.toml, composer.json, and pyproject.toml at parse time and stores it as DepRef.License (SPDX-normalized). The CycloneDX BOM now includes a licenses[] array per component, so downstream SCA tools and procurement workflows get license data without a separate scan.

**--license-scan**
Flags dependencies carrying copyleft licenses as medium-severity findings — GPL-2.0, GPL-3.0, AGPL-3.0, LGPL-2.1, and SSPL-1.0. Implemented as hardcoded Go findings (same pattern as vulnFindings) rather than YAML rules, so no sync to trustabl-rules is required.

**--secret-scan**
Opt-in repo-wide scan of all text files. Flags:

**SECRET-LIT-001 (high)** — hardcoded credential literals: GitHub PATs, AWS access keys, Slack tokens, OpenAI keys, Google API keys, private key blocks
**SECRET-ENV-001 (medium)** — scripts that read credential environment variables at runtime, which can leak keys into an agent's context window or log files
_Skips binary files and vendored directories. Results flow through the normal findings pipeline — exit codes, SARIF, JSON output all work as expected._

Fix: Pipfile pinned-version parsing
parsePipfile was storing ==1.34.0 instead of 1.34.0, causing pinned Pipfile deps to be silently skipped by the vuln scanner's concrete-version check. One-line fix mirroring what pypiSpec already does.

**Test plan**
 CGO_ENABLED=1 go test -race ./... passes (excluding pre-existing TestSave_FilePermissions Windows permission issue on main)
 trustabl scan --license-scan <repo-with-gpl-dep> emits LIC-GPL3 findings
 trustabl scan --secret-scan <repo-with-secrets> emits SECRET-LIT-001 and SECRET-ENV-001 findings
 trustabl scan --bom-out bom.json <repo> includes licenses[] per component in CycloneDX output