### PR TITLE
feat(predicates): add skill_body_has_text, skill_name_has_text, skill_description_has_text

### DIFF
--- a/internal/analysis/skills.go
+++ b/internal/analysis/skills.go
@@ -76,6 +76,7 @@ func DiscoverSkills(manifest models.ScanManifest) []models.SkillDef {
 			HasDynamicArgs:         hasDynamicArgs,
 			ReferencesSkills:       skillRefs,
 			BundledFiles:           bundledFiles(manifest.RepoRoot, p),
+			Body:                   string(body),
 			Location:               models.Location{FilePath: p, Line: startLine, EndLine: endLine},
 		})
 	}

--- a/internal/models/agent.go
+++ b/internal/models/agent.go
@@ -210,6 +210,7 @@ type SkillDef struct {
 	HasDynamicArgs         bool          `json:"has_dynamic_args,omitempty"`
 	ReferencesSkills       []string      `json:"references_skills,omitempty"`
 	BundledFiles           []BundledFile `json:"bundled_files,omitempty"`
+	Body                   string        `json:"-"` // raw SKILL.md body text; in-memory only, never serialized
 	Location                             // file_path = SKILL.md path
 }
 

--- a/internal/rules/evaluator.go
+++ b/internal/rules/evaluator.go
@@ -223,6 +223,15 @@ func (e MatchExpr) EvaluateSkill(s models.SkillDef, inv models.RepoInventory) bo
 	if e.SkillHasDuplicateToolRefs != nil && PredSkillHasDuplicateToolRefs(s) != *e.SkillHasDuplicateToolRefs {
 		return false
 	}
+	if len(e.SkillBodyHasText) > 0 && !PredSkillBodyHasText(e.SkillBodyHasText, s) {
+		return false
+	}
+	if len(e.SkillNameHasText) > 0 && !PredSkillNameHasText(e.SkillNameHasText, s) {
+		return false
+	}
+	if len(e.SkillDescriptionHasText) > 0 && !PredSkillDescriptionHasText(e.SkillDescriptionHasText, s) {
+		return false
+	}
 	return true
 }
 
@@ -374,6 +383,9 @@ var predicatesByScope = map[models.Scope]map[string]bool{
 		"skill_has_description":                         true,
 		"skill_is_agent_specific":                       true,
 		"skill_has_duplicate_tool_refs":                 true,
+		"skill_body_has_text":                           true,
+		"skill_name_has_text":                           true,
+		"skill_description_has_text":                    true,
 	},
 	models.ScopeRepo: {
 		"repo_has_sdk_in_code":   true,
@@ -440,10 +452,13 @@ func (e MatchExpr) setPredicateNames() []string {
 	add(e.SkillBundledScriptNetworkEgress != nil, "skill_bundled_script_network_egress")
 	add(e.SkillBundledScriptReadsSecrets != nil, "skill_bundled_script_reads_secrets")
 	add(e.SkillBundledFileHasHardcodedSecret != nil, "skill_bundled_file_has_hardcoded_secret")
-  add(e.SkillDescriptionToolMismatch != nil, "skill_description_tool_mismatch")
-  add(e.SkillHasDescription != nil, "skill_has_description")
-  add(e.SkillIsAgentSpecific != nil, "skill_is_agent_specific")
-  add(e.SkillHasDuplicateToolRefs != nil, "skill_has_duplicate_tool_refs")
+	add(e.SkillDescriptionToolMismatch != nil, "skill_description_tool_mismatch")
+	add(e.SkillHasDescription != nil, "skill_has_description")
+	add(e.SkillIsAgentSpecific != nil, "skill_is_agent_specific")
+	add(e.SkillHasDuplicateToolRefs != nil, "skill_has_duplicate_tool_refs")
+	add(len(e.SkillBodyHasText) > 0, "skill_body_has_text")
+	add(len(e.SkillNameHasText) > 0, "skill_name_has_text")
+	add(len(e.SkillDescriptionHasText) > 0, "skill_description_has_text")
 	// Repo scope
 	add(len(e.RepoHasSDKInCode) > 0, "repo_has_sdk_in_code")
 	add(len(e.RepoComponentPresent) > 0, "repo_component_present")

--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -2369,6 +2369,29 @@ var policySkillRuleCases = []policySkillCase{
 	{"CSKILL-071 silent when skill is agent-agnostic", "CSKILL-071",
 		models.SkillDef{Name: "generic-skill",
 			Location: models.Location{FilePath: ".claude/skills/generic-skill/SKILL.md"}}, models.RepoInventory{}, false},
+
+	{"CSKILL-062 fires when the body contains a TODO marker", "CSKILL-062",
+		models.SkillDef{Name: "helper",
+			Location: models.Location{FilePath: ".claude/skills/helper/SKILL.md"},
+			Body:     "# Helper\n\nTODO: finish the retry logic."}, models.RepoInventory{}, true},
+	{"CSKILL-062 silent when the body has no placeholder text", "CSKILL-062",
+		models.SkillDef{Name: "helper",
+			Location: models.Location{FilePath: ".claude/skills/helper/SKILL.md"},
+			Body:     "# Helper\n\nSummarises the current git diff."}, models.RepoInventory{}, false},
+
+	{"CSKILL-063 fires when the name contains a draft marker", "CSKILL-063",
+		models.SkillDef{Name: "deploy-draft",
+			Location: models.Location{FilePath: ".claude/skills/deploy-draft/SKILL.md"}}, models.RepoInventory{}, true},
+	{"CSKILL-063 silent when the name has no draft/test/wip marker", "CSKILL-063",
+		models.SkillDef{Name: "deploy",
+			Location: models.Location{FilePath: ".claude/skills/deploy/SKILL.md"}}, models.RepoInventory{}, false},
+
+	{"CSKILL-064 fires when the description flags internal-only use", "CSKILL-064",
+		models.SkillDef{Name: "helper", Description: "Internal use only — do not distribute outside the team.",
+			Location: models.Location{FilePath: ".claude/skills/helper/SKILL.md"}}, models.RepoInventory{}, true},
+	{"CSKILL-064 silent when the description has no such marker", "CSKILL-064",
+		models.SkillDef{Name: "helper", Description: "Summarises the current git diff.",
+			Location: models.Location{FilePath: ".claude/skills/helper/SKILL.md"}}, models.RepoInventory{}, false},
 }
 
 // policyAgentRuleCases covers agent-scoped rules.

--- a/internal/rules/predicates.go
+++ b/internal/rules/predicates.go
@@ -971,6 +971,43 @@ func PredSkillHasDuplicateToolRefs(s models.SkillDef) bool {
 	return false
 }
 
+// PredSkillBodyHasText reports whether the skill's raw SKILL.md body contains
+// any of needles (case-insensitive). Mirrors PredHasBodyText for the skill
+// scope — same last-resort substring-matching caveats apply.
+func PredSkillBodyHasText(needles []string, s models.SkillDef) bool {
+	body := strings.ToLower(s.Body)
+	for _, n := range needles {
+		if strings.Contains(body, strings.ToLower(n)) {
+			return true
+		}
+	}
+	return false
+}
+
+// PredSkillNameHasText reports whether the skill's name contains any of
+// needles (case-insensitive).
+func PredSkillNameHasText(needles []string, s models.SkillDef) bool {
+	name := strings.ToLower(s.Name)
+	for _, n := range needles {
+		if strings.Contains(name, strings.ToLower(n)) {
+			return true
+		}
+	}
+	return false
+}
+
+// PredSkillDescriptionHasText reports whether the skill's description
+// contains any of needles (case-insensitive).
+func PredSkillDescriptionHasText(needles []string, s models.SkillDef) bool {
+	desc := strings.ToLower(s.Description)
+	for _, n := range needles {
+		if strings.Contains(desc, strings.ToLower(n)) {
+			return true
+		}
+	}
+	return false
+}
+
 // ─── repo predicates ──────────────────────────────────────────────────────────
 
 func PredRepoHasSDKInCode(sdks []string, inv models.RepoInventory) bool {
@@ -1071,4 +1108,3 @@ func PredRepoClaudeOptionsMaxTurnsMissing(inv models.RepoInventory) bool {
 	}
 	return concrete > 0
 }
-

--- a/internal/rules/schema.go
+++ b/internal/rules/schema.go
@@ -101,6 +101,9 @@ type MatchExpr struct {
 	SkillHasDescription                     *bool    `yaml:"skill_has_description,omitempty"`
 	SkillIsAgentSpecific                    *bool    `yaml:"skill_is_agent_specific,omitempty"`
 	SkillHasDuplicateToolRefs               *bool    `yaml:"skill_has_duplicate_tool_refs,omitempty"`
+	SkillBodyHasText                        []string `yaml:"skill_body_has_text,omitempty"`
+	SkillNameHasText                        []string `yaml:"skill_name_has_text,omitempty"`
+	SkillDescriptionHasText                 []string `yaml:"skill_description_has_text,omitempty"`
 
 	// Repo-scope predicates
 	RepoHasSDKInCode                  []string `yaml:"repo_has_sdk_in_code,omitempty"`

--- a/internal/rules/schema.yaml
+++ b/internal/rules/schema.yaml
@@ -400,6 +400,23 @@ rules:
 #       more than once unnecessarily. Configuration-quality signal, not a
 #       security bug on its own. Bool predicate.
 #
+#   skill_body_has_text: [substring, substring, ...]
+#       Fires when the SKILL.md body (the raw markdown below the frontmatter)
+#       contains any listed substring, matched case-insensitively. Mirrors the
+#       tool-scope has_body_text — same DISCOURAGED-last-resort caveat: prefer
+#       a structured predicate (skill_body_has_dynamic_exec,
+#       skill_references_external_url, skill_body_has_injection_marker, ...)
+#       when one fits; reserve this for a known phrase with no structural
+#       signature.
+#
+#   skill_name_has_text: [substring, substring, ...]
+#       Fires when SkillDef.Name contains any listed substring, matched
+#       case-insensitively.
+#
+#   skill_description_has_text: [substring, substring, ...]
+#       Fires when SkillDef.Description contains any listed substring,
+#       matched case-insensitively.
+#
 #
 # ━━━ REPO-SCOPE PREDICATES ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # (used only in scope: repo rules; match runs once per scan)

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -492,6 +492,29 @@ func TestScan_SkillDuplicateToolRefs(t *testing.T) {
 	}
 }
 
+func TestScan_SkillNameMatch(t *testing.T) {
+	_, thisFile, _, _ := runtime.Caller(0)
+	target := filepath.Join(filepath.Dir(thisFile), "..", "..", "testdata", "corpus", "skill-name-match")
+	res, err := scanner.Run(scanner.Config{Target: target, RulesFS: rulesFixture(t)})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+
+	fired := map[string]bool{}
+	for _, f := range res.Findings {
+		fired[f.RuleID] = true
+	}
+	if !fired["CSKILL-063"] {
+		t.Errorf("expected CSKILL-063 to fire on skill-name-match; fired set: %v", fired)
+	}
+
+	for _, f := range res.Findings {
+		if strings.HasPrefix(f.RuleID, "CSKILL-") && f.RuleID != "CSKILL-063" {
+			t.Errorf("unexpected skill finding %s fired on skill-name-match", f.RuleID)
+		}
+	}
+}
+
 func TestScan_SkillAgentSpecific(t *testing.T) {
 	_, thisFile, _, _ := runtime.Caller(0)
 	target := filepath.Join(filepath.Dir(thisFile), "..", "..", "testdata", "corpus", "skill-agent-specific")

--- a/testdata/corpus/skill-name-match/.claude/skills/deploy-draft/SKILL.md
+++ b/testdata/corpus/skill-name-match/.claude/skills/deploy-draft/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: deploy-draft
+description: Summarises the deploy pipeline configuration for review
+allowed-tools: Read
+---
+
+# Deploy Draft (synthetic test fixture)
+
+This is a synthetic Trustabl test fixture used to exercise the
+skill_name_has_text predicate (CSKILL-063). Its frontmatter `name:` contains
+the "draft" marker on purpose. It only reads files the user points it at —
+no dynamic-context execution, no external URLs, no bundled scripts, no
+prompt-injection markers, no duplicate tool references, and it is not bound
+to a specific agent — so CSKILL-063 is the only skill-scope rule expected to
+fire.

--- a/testdata/rules-fixture/claude_skill/skill_safety.yaml
+++ b/testdata/rules-fixture/claude_skill/skill_safety.yaml
@@ -302,3 +302,74 @@ rules:
       agent-agnostic so it can be reused across agents and reviewed on its own
       tool grants rather than inheriting assumptions from one agent's
       configuration.
+
+  - id: CSKILL-062
+    title: Skill body references TODO/FIXME placeholder text
+    severity: low
+    confidence: 0.5
+    applies_to:
+      - claude_skill
+    scope: skill
+    match:
+      skill_body_has_text:
+        - "TODO"
+        - "FIXME"
+    explanation: >
+      This skill's body contains a TODO or FIXME placeholder. A skill checked
+      into a shared repository with unfinished instructions is a review gap —
+      the model executes whatever incomplete or provisional guidance the
+      placeholder marks, and a reviewer skimming the frontmatter has no signal
+      that the body is still a work in progress.
+    fix: >
+      Resolve the TODO/FIXME before shipping the skill, or remove it and file
+      the follow-up work as a tracked issue instead of leaving it inline in
+      instructions the model will act on.
+
+  - id: CSKILL-063
+    title: Skill name suggests it is a draft or test artifact
+    severity: low
+    confidence: 0.5
+    applies_to:
+      - claude_skill
+    scope: skill
+    match:
+      skill_name_has_text:
+        - "draft"
+        - "test"
+        - "wip"
+    explanation: >
+      This skill's name contains a marker like "draft", "test", or "wip"
+      (case-insensitive). A skill named this way is often a work-in-progress
+      or scratch artifact that was never intended to ship, but once it's
+      installed in .claude/skills it is discoverable and — unless
+      disable-model-invocation is set — invocable by the model like any other
+      skill.
+    fix: >
+      Rename the skill to reflect its real purpose before shipping it, or
+      delete it if it was scratch work. If it's intentionally a draft, keep
+      it out of any directory the scanner or Claude Code loads skills from
+      until it's ready.
+
+  - id: CSKILL-064
+    title: Skill description references an unreviewed or internal-only source
+    severity: low
+    confidence: 0.4
+    applies_to:
+      - claude_skill
+    scope: skill
+    match:
+      skill_description_has_text:
+        - "internal use only"
+        - "do not distribute"
+        - "unreviewed"
+    explanation: >
+      This skill's description flags itself as internal-only, unreviewed, or
+      not for distribution. That self-disclosure is a signal worth surfacing
+      at scan time — a skill carrying this language in a repository that gets
+      shared, forked, or published may be shipping further than its author
+      intended.
+    fix: >
+      Confirm the skill's actual distribution matches its stated intent:
+      either complete the review and update the description, or keep the
+      skill out of any repository or plugin that gets shared beyond its
+      intended audience.


### PR DESCRIPTION
## What this does
Adds 3 new skill-scope text-match predicates that check for 
keywords in a skill's body, name, and description fields. 
These unlock the next batch of 8 skill quality rules from 
the detection logic spreadsheet.

## Changes
- internal/models/agent.go — added SkillDef.Body string
  (json:"-", in-memory only, never serialized to output)
- internal/analysis/skills.go — populate Body from the
  already-parsed SKILL.md body during discovery
- internal/rules/schema.go — 3 new MatchExpr fields:
  SkillBodyHasText, SkillNameHasText, SkillDescriptionHasText
- internal/rules/predicates.go — PredSkillBodyHasText,
  PredSkillNameHasText, PredSkillDescriptionHasText
  (case-insensitive, mirrors PredHasBodyText pattern)
- internal/rules/evaluator.go — wired in EvaluateSkill,
  predicatesByScope[ScopeSkill], setPredicateNames()
- internal/rules/schema.yaml — documented all 3 predicates
- internal/rules/schema_version.go — bumped
  SupportedSchemaVersion 13 → 14
- testdata/rules-fixture/claude_skill/skill_safety.yaml —
  added CSKILL-062, CSKILL-063, CSKILL-064 test rules
- internal/rules/policies_test.go — FIRE + SILENT cases
  for all 3 new rules
- testdata/corpus/skill-name-match/ — corpus fixture for
  skill_name_has_text end-to-end coverage
- internal/scanner/scanner_test.go — TestScan_SkillNameMatch

## Note
Cross-repo sync (mirroring CSKILL-062/063/064 to trustabl-rules
and bumping manifest.yaml schema_version to 14) will follow
in a separate trustabl-rules PR once this is merged —
same pattern as the previous predicate batch.

## Testing
- go build ./... passes
- go test ./... passes
- TestPolicyRules_AllRulesCovered passes
- TestScan_SkillNameMatch passes
- TestScanExamples_NoCrash passes