### PR TITLE
feat(predicates): add tool description quality checks (Queens paper)

### DIFF
--- a/internal/rules/evaluator.go
+++ b/internal/rules/evaluator.go
@@ -318,6 +318,14 @@ func (e MatchExpr) EvaluateTool(t models.ToolDef, pf analysis.ParsedFile) bool {
 	if len(e.HasBodyText) > 0 && !PredHasBodyText(e.HasBodyText, t, pf) {
 		return false
 	}
+	if len(e.HasDescriptionText) > 0 && !PredHasDescriptionText(e.HasDescriptionText, t) {
+		return false
+	}
+
+	// Int predicates
+	if e.DescriptionLengthLt != nil && !PredDescriptionLengthLt(t, *e.DescriptionLengthLt) {
+		return false
+	}
 
 	// Nested struct predicates
 	if e.ParamNameMatches != nil && !PredParamNameMatches(*e.ParamNameMatches, t) {
@@ -353,6 +361,7 @@ var predicatesByScope = map[models.Scope]map[string]bool{
 		"has_write_call": true, "has_dynamic_url_call": true,
 		"has_http_call_without_timeout": true,
 		"name_in":                       true, "name_has_prefix": true, "has_body_text": true,
+		"has_description_text": true, "description_length_lt": true,
 		"param_name_matches": true, "call_without_kwarg": true,
 		"call_uses_unnormalized_path_param": true,
 		"tool_decorator_kwarg_value":        true, "tool_decorator_kwarg_present": true,
@@ -422,6 +431,8 @@ func (e MatchExpr) setPredicateNames() []string {
 	add(len(e.NameIn) > 0, "name_in")
 	add(len(e.NameHasPrefix) > 0, "name_has_prefix")
 	add(len(e.HasBodyText) > 0, "has_body_text")
+	add(len(e.HasDescriptionText) > 0, "has_description_text")
+	add(e.DescriptionLengthLt != nil, "description_length_lt")
 	add(e.ParamNameMatches != nil, "param_name_matches")
 	add(e.CallWithoutKwarg != nil, "call_without_kwarg")
 	add(e.CallUsesUnnormalizedPathParam != nil, "call_uses_unnormalized_path_param")

--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -1953,6 +1953,39 @@ def calc(expr: str) -> int:
 			"  return { content: [{ type: \"text\", text: id }] };\n" +
 			"});\n",
 	},
+
+	// ─── CSDK-017 placeholder tool description ─────────────────────────────
+	{name: "CSDK-017 fires on TODO placeholder description", ruleID: "CSDK-017", kind: models.KindClaudeSDKTool, src: `
+def fetch_data(x: str) -> dict:
+    """TODO: describe this tool."""
+    return {}
+`,
+		toolConfig: nil, wantFires: true},
+	{name: "CSDK-017 silent with a real description", ruleID: "CSDK-017", kind: models.KindClaudeSDKTool, src: `
+def fetch_data(x: str) -> dict:
+    """Fetch the current account balance for the given customer ID."""
+    return {}
+`,
+		toolConfig: nil, wantFires: false},
+
+	// ─── CSDK-018 description too short to guide selection ─────────────────
+	{name: "CSDK-018 fires on a stub description", ruleID: "CSDK-018", kind: models.KindClaudeSDKTool, src: `
+def fetch_data(x: str) -> dict:
+    """Gets data."""
+    return {}
+`,
+		toolConfig: nil, wantFires: true},
+	{name: "CSDK-018 silent with a description over the length threshold", ruleID: "CSDK-018", kind: models.KindClaudeSDKTool, src: `
+def fetch_data(x: str) -> dict:
+    """Fetch the current account balance for the given customer ID."""
+    return {}
+`,
+		toolConfig: nil, wantFires: false},
+	{name: "CSDK-018 silent with no description at all", ruleID: "CSDK-018", kind: models.KindClaudeSDKTool, src: `
+def fetch_data(x: str) -> dict:
+    return {}
+`,
+		toolConfig: nil, wantFires: false},
 }
 
 // policyRepoRuleCases covers repo-scoped rules.

--- a/internal/rules/predicates.go
+++ b/internal/rules/predicates.go
@@ -311,6 +311,30 @@ func bodyTextFromSpan(src []byte, start, end int) string {
 	return strings.Join(lines[start-1:end], "\n")
 }
 
+// PredHasDescriptionText reports whether the tool's description contains any
+// of the listed substrings, case-insensitively. Unlike PredHasBodyText (which
+// matches case-sensitively against the function body), this lowers both sides
+// because placeholder markers in descriptions appear inconsistently cased
+// ("TODO", "todo", "Todo").
+func PredHasDescriptionText(needles []string, t models.ToolDef) bool {
+	description := strings.ToLower(t.Description)
+	for _, n := range needles {
+		if strings.Contains(description, strings.ToLower(n)) {
+			return true
+		}
+	}
+	return false
+}
+
+// ─── int predicates ───────────────────────────────────────────────────────────
+
+// PredDescriptionLengthLt reports whether the tool's trimmed description is
+// shorter than n characters — a stub description too short to give the model
+// a usable selection signal.
+func PredDescriptionLengthLt(t models.ToolDef, n int) bool {
+	return len(strings.TrimSpace(t.Description)) < n
+}
+
 func PredParamNameMatches(expr ParamNameMatchExpr, t models.ToolDef) bool {
 	for _, p := range t.ParamNames {
 		lower := strings.ToLower(p)

--- a/internal/rules/schema.go
+++ b/internal/rules/schema.go
@@ -57,9 +57,14 @@ type MatchExpr struct {
 	Always                    *bool `yaml:"always,omitempty"`
 
 	// String-list predicates
-	NameIn        []string `yaml:"name_in,omitempty"`
-	NameHasPrefix []string `yaml:"name_has_prefix,omitempty"`
-	HasBodyText   []string `yaml:"has_body_text,omitempty"`
+	NameIn             []string `yaml:"name_in,omitempty"`
+	NameHasPrefix      []string `yaml:"name_has_prefix,omitempty"`
+	HasBodyText        []string `yaml:"has_body_text,omitempty"`
+	HasDescriptionText []string `yaml:"has_description_text,omitempty"`
+
+	// Int predicates (tool scope) — pointer distinguishes "0" from "absent",
+	// mirroring the *bool tri-state pattern above.
+	DescriptionLengthLt *int `yaml:"description_length_lt,omitempty"`
 
 	// Nested struct predicates (tool scope)
 	ParamNameMatches              *ParamNameMatchExpr                `yaml:"param_name_matches,omitempty"`

--- a/internal/rules/schema.yaml
+++ b/internal/rules/schema.yaml
@@ -203,6 +203,28 @@ rules:
 #       Reserve new uses for a known constant that has no structural
 #       signature.
 #
+#   has_description_text: [substring, substring, ...]
+#       The tool's description (docstring for Python, the explicit
+#       description argument for TypeScript) contains any listed substring.
+#       Matching is CASE-INSENSITIVE (unlike has_body_text above) — placeholder
+#       markers show up as "TODO", "todo", "Todo" interchangeably, and lowering
+#       both sides avoids authoring a rule per casing. Reads ToolDef.Description,
+#       not the function body — use has_body_text for body content.
+#       Intended use: catch placeholder descriptions (todo, tbd, fixme,
+#       placeholder, "no description") that pass has_docstring but give the
+#       model no real selection signal.
+#
+#
+# ━━━ INT PREDICATES ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+#
+#   description_length_lt: N
+#       Fires when the tool's description, trimmed of leading/trailing
+#       whitespace, is shorter than N characters. Pair with
+#       `has_docstring: true` (via `all:`) so this doesn't double-report
+#       against a rule that already flags a missing description — an empty
+#       description is length 0, which is also < N, but that case belongs to
+#       has_docstring, not this predicate.
+#
 #
 # ━━━ NESTED STRUCT PREDICATES ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 #

--- a/testdata/rules-fixture/claude_sdk/tool_definition.yaml
+++ b/testdata/rules-fixture/claude_sdk/tool_definition.yaml
@@ -131,3 +131,55 @@ rules:
       Pass a clear one-line description as the second argument to
       `tool(name, description, schema, handler)`, stating what the tool does,
       what it returns, and when the model should reach for it.
+
+  - id: CSDK-017
+    title: Tool description is a placeholder
+    severity: low
+    confidence: 0.85
+    language: python
+    applies_to:
+      - claude_sdk_tool
+    scope: tool
+    match:
+      has_description_text:
+        - todo
+        - tbd
+        - fixme
+        - placeholder
+        - no description
+        - does stuff
+    explanation: >
+      The description passes the has-docstring check but carries a
+      placeholder marker instead of real content. The Claude Agent SDK
+      forwards this text to the model verbatim as the tool's selection
+      signal, so a stub like "TODO: describe this tool" is functionally
+      indistinguishable from no description at all — the model still has to
+      guess from the function name, causing mis-selection under ambiguous
+      prompts.
+    fix: >
+      Replace the placeholder with a real one-paragraph description covering
+      what the tool does, what it returns, and when the model should call it.
+
+  - id: CSDK-018
+    title: Tool description is too short to guide model selection
+    severity: low
+    confidence: 0.8
+    language: python
+    applies_to:
+      - claude_sdk_tool
+    scope: tool
+    match:
+      all:
+        - has_docstring: true
+        - description_length_lt: 40
+    explanation: >
+      A description under 40 characters is rarely enough to convey what a
+      tool does, what it returns, and when to call it versus a similarly
+      named neighbor. The Claude Agent SDK passes this text to the model as
+      its only selection signal, so a stub like "Gets data." leaves the
+      model to guess at scope and preconditions, which causes mis-selection
+      or missed calls under ambiguous prompts.
+    fix: >
+      Expand the description to at least a full sentence covering inputs,
+      outputs, and the situation in which this tool should be used over
+      alternatives.


### PR DESCRIPTION
## What this does
Adds 2 new tool-scope predicates based on the Queens paper 
findings on tool description quality — closing the gap between 
"description exists" (already covered by has_docstring/CSDK-001) 
and "description is actually useful."

## Predicates added
- has_description_text: [substrings] — case-insensitive match 
  against ToolDef.Description, catches placeholder markers 
  (TODO, TBD, FIXME, "no description")
- description_length_lt: N — flags descriptions shorter than N 
  characters (first int-typed predicate in the engine)

## Rules added
- CSDK-017: Placeholder tool description
- CSDK-018: Description too short to guide model selection 
  (guarded by has_docstring: true to avoid double-firing with 
  CSDK-001)

## Out of scope (follow-up, flagged to Ian separately)
- Mirroring CSDK-017/018 to trustabl-rules and rulebook — adds 
  one more file to the existing check-rules-sync.sh failure, 
  which already has pre-existing drift in 6+ files unrelated 
  to this change
- Fixture/production manifest version mismatch (both currently 
  say different things at "14") — pre-existing sync issue

## Testing
- go build ./... passes
- go test ./... passes (all packages)
- TestSchemaYAML_DocumentsEveryPredicate, 
  TestPredicatesByScope_MirrorsStruct, 
  TestSetPredicateNames_MirrorsStruct pass untouched — confirms 
  reflection-driven machinery handles the new *int field 
  automatically
- TestPolicyRules_AllRulesCovered passes