### PR TITLE
TR-615 docs: update rule count badge (187 -> 193)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <a href="https://github.com/trustabl/trustabl/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/trustabl/trustabl/test.yml?branch=main&amp;label=tests" alt="Tests"></a>
   <a href="go.mod"><img src="https://img.shields.io/github/go-mod/go-version/trustabl/trustabl" alt="Go version"></a>
   <br>
-  <a href="https://github.com/trustabl/trustabl-rules"><img src="https://img.shields.io/badge/rules-187-brightgreen" alt="187 detection rules"></a>
+  <a href="https://github.com/trustabl/trustabl-rules"><img src="https://img.shields.io/badge/rules-193-brightgreen" alt="193 detection rules"></a>
   <a href="COVERAGE.md"><img src="https://img.shields.io/badge/SDKs-9-blue" alt="9 SDKs supported"></a>
   <a href="COVERAGE.md"><img src="https://img.shields.io/badge/languages-7-blue" alt="7 languages supported"></a>
   <a href="COVERAGE.md"><img src="https://img.shields.io/badge/scopes-5-blue" alt="5 detection scopes"></a>


### PR DESCRIPTION
Rule count badge was stale. Verified current count via:

  grep -rh "^\s*- id: " */*.yaml | wc -l

in trustabl-rules main → 193.