### PR TITLE
feat(crewai): add CREW-110, no explicit max_iter limit

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -2406,6 +2406,17 @@ var policyAgentRuleCases = []policyAgentCase{
 			}}},
 		models.RepoInventory{}, false},
 
+	{"CREW-110 fires when Agent has no max_iter", "CREW-110",
+		models.AgentDef{SDK: models.SDKCrewAI, Class: "Agent", Language: models.LanguagePython},
+		models.RepoInventory{}, true},
+	{"CREW-110 silent when max_iter set", "CREW-110",
+		models.AgentDef{
+			SDK: models.SDKCrewAI, Class: "Agent", Language: models.LanguagePython,
+			Kwargs: &models.KwargTree{Children: map[string]*models.KwargTree{
+				"max_iter": {Value: &models.Expr{Kind: models.ExprLiteralInt, Text: "5"}},
+			}}},
+		models.RepoInventory{}, false},
+
 	{"CREW-106 fires when FileReadTool has no file_path", "CREW-106",
 		models.AgentDef{
 			SDK: models.SDKCrewAI, Class: "Agent", Language: models.LanguagePython,

--- a/testdata/rules-fixture/crewai/agent_safety.yaml
+++ b/testdata/rules-fixture/crewai/agent_safety.yaml
@@ -87,3 +87,30 @@ rules:
       If the crew must delegate, keep high-risk tools (code execution, file read,
       shell) off every agent reachable through delegation, and constrain each
       peer's tool set to the minimum its role requires.
+
+  - id: CREW-110
+    title: CrewAI agent has no explicit max_iter limit
+    severity: low
+    confidence: 0.6
+    language: python
+    applies_to:
+      - crewai_agent
+    scope: agent
+    match:
+      agent_kwarg_missing:
+        - max_iter
+    explanation: >
+      This Agent sets no explicit max_iter, so it falls back to CrewAI's default
+      iteration cap (documented as 20). That default prevents a true runaway, but
+      it is a generic ceiling rather than one sized to this agent's role: a model
+      that loops or oscillates still burns up to the full budget of tool
+      round-trips and LLM calls before CrewAI forces a final answer — a latency
+      and token cost the workflow may not tolerate. The implicit cap has also
+      changed across CrewAI releases, so a version bump can silently move the
+      bound this agent actually runs under.
+    fix: >
+      Pass max_iter= to the Agent constructor, sized to the role — a
+      single-lookup agent rarely needs more than a handful of iterations. Pair it
+      with max_execution_time= so a slow or stalled run is bounded in wall-clock
+      seconds as well as in iterations, and the agent cannot hold the crew open
+      indefinitely.


### PR DESCRIPTION
Closes execution-limit coverage gap for CrewAI — matches the existing pattern already shipped for LangChain (LC-102), Vercel AI (VAI-007), Google ADK (ADK-108), and AutoGen (AG2-006).

Rules-only change: reuses the existing agent_kwarg_missing predicate and CrewAI's generic kwarg capture. No engine files touched (predicates.go, schema.go, evaluator.go, crewai_agents.go all unmodified).