### PR TITLE
feat(claude_sdk): add CSDK-204, session sets no explicit max_turns limit

### DIFF
--- a/internal/rules/evaluator.go
+++ b/internal/rules/evaluator.go
@@ -111,6 +111,9 @@ func (e MatchExpr) EvaluateRepo(p models.RepoProfile, inv models.RepoInventory) 
 	if len(e.RepoClaudeOptionsPermissionModeIs) > 0 && !PredRepoClaudeOptionsPermissionModeIs(e.RepoClaudeOptionsPermissionModeIs, inv) {
 		return false
 	}
+	if e.RepoClaudeOptionsMaxTurnsMissing != nil && PredRepoClaudeOptionsMaxTurnsMissing(inv) != *e.RepoClaudeOptionsMaxTurnsMissing {
+		return false
+	}
 	return true
 }
 
@@ -377,6 +380,7 @@ var predicatesByScope = map[models.Scope]map[string]bool{
 		"repo_component_present": true, "repo_uses_default_tracing": true,
 		"repo_claude_default_mode_is":            true,
 		"repo_claude_options_permission_mode_is": true,
+		"repo_claude_options_max_turns_missing":  true,
 	},
 }
 
@@ -446,6 +450,7 @@ func (e MatchExpr) setPredicateNames() []string {
 	add(e.RepoUsesDefaultTracing != nil, "repo_uses_default_tracing")
 	add(len(e.RepoClaudeDefaultModeIs) > 0, "repo_claude_default_mode_is")
 	add(len(e.RepoClaudeOptionsPermissionModeIs) > 0, "repo_claude_options_permission_mode_is")
+	add(e.RepoClaudeOptionsMaxTurnsMissing != nil, "repo_claude_options_max_turns_missing")
 	return n
 }
 

--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -2101,6 +2101,52 @@ var policyRepoRuleCases = []policyRepoCase{
 		},
 		false},
 
+	// ─── CSDK-204 session max_turns missing (repo-scoped) ────────────────────
+	{"CSDK-204 fires when the only ClaudeAgentOptions sets no max_turns", "CSDK-204",
+		models.RepoProfile{},
+		models.RepoInventory{
+			SDKsDetected:       []models.SDK{models.SDKClaudeAgentSDK},
+			ClaudeAgentOptions: []models.ClaudeAgentOptionsDef{{}},
+		},
+		true},
+	{"CSDK-204 silent when max_turns is set", "CSDK-204",
+		models.RepoProfile{},
+		models.RepoInventory{
+			SDKsDetected:       []models.SDK{models.SDKClaudeAgentSDK},
+			ClaudeAgentOptions: []models.ClaudeAgentOptionsDef{optionsWithMaxTurns("10")},
+		},
+		false},
+	// One of several constructions sets max_turns: that's enough to silence
+	// the rule for the whole repo — this is an absence check across all
+	// constructions, not a per-call match.
+	{"CSDK-204 silent when at least one of several sets max_turns", "CSDK-204",
+		models.RepoProfile{},
+		models.RepoInventory{
+			SDKsDetected: []models.SDK{models.SDKClaudeAgentSDK},
+			ClaudeAgentOptions: []models.ClaudeAgentOptionsDef{
+				{}, optionsWithMaxTurns("10"),
+			},
+		},
+		false},
+	// No ClaudeAgentOptions construction anywhere: nothing to flag.
+	{"CSDK-204 silent when repo has no ClaudeAgentOptions", "CSDK-204",
+		models.RepoProfile{},
+		models.RepoInventory{
+			SDKsDetected:       []models.SDK{models.SDKClaudeAgentSDK},
+			ClaudeAgentOptions: nil,
+		},
+		false},
+	// The only construction is Opaque (built via ** unpacking): its kwarg set
+	// is untrustworthy, so its silence on max_turns isn't evidence of a
+	// missing cap.
+	{"CSDK-204 silent when the only ClaudeAgentOptions is opaque", "CSDK-204",
+		models.RepoProfile{},
+		models.RepoInventory{
+			SDKsDetected:       []models.SDK{models.SDKClaudeAgentSDK},
+			ClaudeAgentOptions: []models.ClaudeAgentOptionsDef{{Opaque: true}},
+		},
+		false},
+
 	// ─── CSDK-203 / ADK-201 / OAI-202 (team rules): SDK code but no agent doc ─
 	// repo_has_sdk_in_code reads inv.SDKsDetected; repo_component_present reads
 	// profile.Manifest.Components. Fire = SDK present AND neither an agents_md
@@ -2179,6 +2225,16 @@ func optionsWithPermissionMode(mode string) models.ClaudeAgentOptionsDef {
 		Kwargs: &models.KwargTree{
 			Children: map[string]*models.KwargTree{
 				"permission_mode": {Value: &models.Expr{Kind: models.ExprLiteralString, Text: `"` + mode + `"`}},
+			},
+		},
+	}
+}
+
+func optionsWithMaxTurns(v string) models.ClaudeAgentOptionsDef {
+	return models.ClaudeAgentOptionsDef{
+		Kwargs: &models.KwargTree{
+			Children: map[string]*models.KwargTree{
+				"max_turns": {Value: &models.Expr{Kind: models.ExprLiteralInt, Text: v}},
 			},
 		},
 	}

--- a/internal/rules/predicates.go
+++ b/internal/rules/predicates.go
@@ -1050,3 +1050,25 @@ func PredRepoClaudeOptionsPermissionModeIs(modes []string, inv models.RepoInvent
 	return false
 }
 
+// PredRepoClaudeOptionsMaxTurnsMissing fires when the repo constructs at least
+// one ClaudeAgentOptions(...) and NO such construction sets max_turns. This is
+// an absence check across every construction, not a per-call value match: a
+// single options object that sets an explicit cap silences the rule for the
+// repo. Constructions marked Opaque (built with ** unpacking) are skipped —
+// their kwarg set is untrustworthy, so their silence is not evidence of a
+// missing cap. A repo with no ClaudeAgentOptions at all never fires: there is
+// no session config to flag.
+func PredRepoClaudeOptionsMaxTurnsMissing(inv models.RepoInventory) bool {
+	concrete := 0
+	for _, opt := range inv.ClaudeAgentOptions {
+		if opt.Opaque {
+			continue
+		}
+		concrete++
+		if node := lookupKwargInTree(opt.Kwargs, "max_turns"); node != nil && node.Value != nil {
+			return false
+		}
+	}
+	return concrete > 0
+}
+

--- a/internal/rules/schema.go
+++ b/internal/rules/schema.go
@@ -108,6 +108,7 @@ type MatchExpr struct {
 	RepoUsesDefaultTracing            *bool    `yaml:"repo_uses_default_tracing,omitempty"`
 	RepoClaudeDefaultModeIs           []string `yaml:"repo_claude_default_mode_is,omitempty"`
 	RepoClaudeOptionsPermissionModeIs []string `yaml:"repo_claude_options_permission_mode_is,omitempty"`
+	RepoClaudeOptionsMaxTurnsMissing  *bool    `yaml:"repo_claude_options_max_turns_missing,omitempty"`
 }
 
 // ToolDecoratorKwargValueExpr matches a decorator kwarg to a specific value.

--- a/internal/rules/schema.yaml
+++ b/internal/rules/schema.yaml
@@ -435,3 +435,12 @@ rules:
 #       permission_mode to one of the listed modes. Reads
 #       RepoInventory.ClaudeAgentOptions[].Kwargs (permission_mode). The in-code,
 #       session-level analogue of repo_claude_default_mode_is. Used by CSDK-202.
+#   repo_claude_options_max_turns_missing: true | false
+#       Fires when the repo has at least one non-opaque ClaudeAgentOptions(...)
+#       construction and NONE of them set max_turns. Reads
+#       RepoInventory.ClaudeAgentOptions[].Kwargs (max_turns) via the same
+#       lookup as repo_claude_options_permission_mode_is. Constructions built
+#       with ** unpacking (Opaque: true) are skipped — their kwarg set is
+#       untrustworthy, so their silence isn't evidence of a missing cap. A repo
+#       with zero ClaudeAgentOptions constructions never fires. Used by
+#       CSDK-204.

--- a/internal/rules/schema_version.go
+++ b/internal/rules/schema_version.go
@@ -27,4 +27,4 @@ package rules
 // that rule (safe) instead of mis-evaluating a predicate whose meaning changed.
 // That rename discipline is what keeps lenient loading safe without a hard
 // version gate.
-const SupportedSchemaVersion = 13
+const SupportedSchemaVersion = 14

--- a/testdata/rules-fixture/claude_sdk/repo.yaml
+++ b/testdata/rules-fixture/claude_sdk/repo.yaml
@@ -57,3 +57,30 @@ rules:
       auto-approve only file edits while still gating shell and network access).
       Reserve bypassPermissions for disposable sandboxes, never code that runs
       on a developer's or user's machine.
+
+  - id: CSDK-204
+    title: Claude Agent SDK session sets no explicit max_turns limit
+    severity: low
+    confidence: 0.6
+    applies_to:
+      - claude_sdk
+    scope: repo
+    match:
+      repo_claude_options_max_turns_missing: true
+    explanation: >
+      No ClaudeAgentOptions(...) in this project sets max_turns, so the agent
+      loop runs to whatever ceiling the runtime applies by default rather than
+      to a bound sized for this task. A model that loops or oscillates —
+      retrying a failing tool, re-reading the same file, ping-ponging between
+      two steps — keeps consuming turns, tokens, and tool side effects until
+      that implicit ceiling is reached, and an implicit ceiling can shift
+      between SDK versions without any change on your side. An explicit cap
+      also turns a stuck run into a clean, observable stop instead of a slow
+      burn.
+    fix: >
+      Pass max_turns= to ClaudeAgentOptions(...), sized to the work the
+      session actually does — a handful of turns for a single-file edit, more
+      for a multi-step investigation. Treat hitting the cap as a signal to
+      surface and handle rather than to raise it: if a task legitimately
+      needs many turns, split it into bounded sub-sessions instead of
+      removing the bound.

--- a/testdata/rules-fixture/manifest.yaml
+++ b/testdata/rules-fixture/manifest.yaml
@@ -11,4 +11,4 @@
 #
 # This file is metadata, not a rule: the engine's loader skips manifest.yaml
 # when walking the pack for policy files.
-schema_version: 12
+schema_version: 14


### PR DESCRIPTION
Closes execution-limit coverage gap for Claude Agent SDK sessions — matches the pattern already shipped for LangChain (LC-102), Vercel AI (VAI-007), Google ADK (ADK-108), AutoGen (AG2-006), and CrewAI (CREW-110).

New predicate: repo_claude_options_max_turns_missing. Skips Opaque (**-unpacked) ClaudeAgentOptions constructions since their kwarg set is untrustworthy — only fires when at least one concrete construction exists and none set max_turns.

Also corrects a pre-existing schema_version drift in the fixture manifest (was 12, now matches engine's 14).

SupportedSchemaVersion bumped 13 -> 14.