### PR TITLE
Trustabl Forge Provenance Tracking

### DIFF
--- a/cmd/trustabl/forge.go
+++ b/cmd/trustabl/forge.go
@@ -93,6 +93,8 @@ section per detected SDK, with rules ordered by severity.`,
 	cmd.Flags().StringVar(&rulesRef, "rules-ref", "",
 		"pin the trustabl-rules branch or tag (default: latest cached)")
 
+	cmd.AddCommand(newForgeCheckCommand())
+
 	return cmd
 }
 
@@ -134,14 +136,10 @@ func runForge(cmd *cobra.Command, target string, explicit []models.DetectorCateg
 	}
 
 	// Step 4: build stamp (passive watermark)
-	sha := res.SHA
-	if len(sha) > 7 {
-		sha = sha[:7]
-	}
-	stamp := forge.Stamp{
+	stamp := forge.PolicyStamp{
 		Date:          time.Now().Format("2006-01-02"),
-		RulesSHA:      sha,
-		SchemaVersion: rules.SupportedSchemaVersion,
+		RulesSHA:      res.SHA,
+		SchemaVersion: res.SchemaVersion,
 		Categories:    categories,
 	}
 

--- a/cmd/trustabl/forge_check.go
+++ b/cmd/trustabl/forge_check.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/trustabl/trustabl/internal/forge"
+	"github.com/trustabl/trustabl/internal/rules"
+	"github.com/trustabl/trustabl/internal/rulesource"
+)
+
+func newForgeCheckCommand() *cobra.Command {
+	var rulesRef string
+
+	cmd := &cobra.Command{
+		Use:   "check [file]",
+		Short: "Check whether a forge-generated SKILL.md is current with the latest rules",
+		Long: `Check whether a forge-generated SKILL.md is current with the latest rules.
+
+Reads the provenance stamp embedded in the file by "trustabl forge", resolves
+the current rules SHA, and reports whether they match.
+
+Exit codes:
+  0  — stamp found and SHA matches current rules (file is current)
+  1  — stale (SHA mismatch), unstamped, or file not found (user action needed)
+  2  — error resolving rules or reading the file (operator/environment fault)`,
+		Args:         cobra.MaximumNArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path := "SKILL.md"
+			isDefault := len(args) == 0
+			if len(args) == 1 {
+				path = args[0]
+			}
+			return runForgeCheck(cmd, path, rulesRef, isDefault)
+		},
+	}
+
+	cmd.Flags().StringVar(&rulesRef, "rules-ref", "",
+		"pin the trustabl-rules branch or tag (default: latest cached)")
+
+	return cmd
+}
+
+func runForgeCheck(cmd *cobra.Command, path, rulesRef string, isDefault bool) error {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			if isDefault {
+				fmt.Fprintf(cmd.ErrOrStderr(),
+					"trustabl forge check: no SKILL.md found in current directory; "+
+						"pass an explicit path or run: trustabl forge --output SKILL.md\n")
+			} else {
+				fmt.Fprintf(cmd.ErrOrStderr(),
+					"trustabl forge check: %s: file not found\n", path)
+			}
+			return exitCodeError{code: 1}
+		}
+		fmt.Fprintf(cmd.ErrOrStderr(), "trustabl forge check: read %s: %v\n", path, err)
+		return exitCodeError{code: 2}
+	}
+
+	stamp, ok := forge.ParseStamp(string(raw))
+	if !ok {
+		fmt.Fprintf(cmd.ErrOrStderr(),
+			"trustabl forge check: no forge stamp found in %s; "+
+				"regenerate with: trustabl forge --output %s\n", path, path)
+		return exitCodeError{code: 1}
+	}
+
+	res, err := rulesource.Resolve(
+		rulesource.Config{Ref: rulesRef},
+		rules.SupportedSchemaVersion,
+	)
+	if err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "trustabl forge check: rules: %v\n", err)
+		return exitCodeError{code: 2}
+	}
+
+	if stamp.SHA == res.SHA {
+		fmt.Fprintf(cmd.OutOrStdout(),
+			"up to date (rules: %s, generated: %s)\n",
+			shortSHA(stamp.SHA), stamp.Date)
+		return nil
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(),
+		"outdated: generated from %s, current rules are %s\nregenerate: trustabl forge --output %s\n",
+		shortSHA(stamp.SHA), shortSHA(res.SHA), path)
+	return exitCodeError{code: 1}
+}
+
+// shortSHA returns the first 7 characters of a SHA for display, or the full
+// string when it is shorter than 7 characters.
+func shortSHA(sha string) string {
+	if len(sha) > 7 {
+		return sha[:7]
+	}
+	return sha
+}

--- a/cmd/trustabl/forge_test.go
+++ b/cmd/trustabl/forge_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -91,5 +93,86 @@ func TestForgeCommand_MaxOnePositionalArg(t *testing.T) {
 	err := cmd.Args(cmd, []string{"arg1", "arg2"})
 	if err == nil {
 		t.Error("expected error for two positional args")
+	}
+}
+
+func TestForgeCheckCommand_Registered(t *testing.T) {
+	cmd := newForgeCommand(nil)
+	var found bool
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == "check" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("forge check subcommand not registered")
+	}
+}
+
+func TestForgeCheckCommand_Flags(t *testing.T) {
+	cmd := newForgeCommand(nil)
+	var checkCmd *cobra.Command
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == "check" {
+			checkCmd = sub
+			break
+		}
+	}
+	if checkCmd == nil {
+		t.Fatal("forge check subcommand not found")
+	}
+	if checkCmd.Flags().Lookup("rules-ref") == nil {
+		t.Error("forge check: --rules-ref flag not registered")
+	}
+}
+
+func TestForgeCheckCommand_TooManyArgs(t *testing.T) {
+	root := &cobra.Command{Use: "trustabl", SilenceUsage: true, SilenceErrors: true}
+	root.AddCommand(newForgeCommand(nil))
+	root.SetArgs([]string{"forge", "check", "file1.md", "file2.md"})
+	buf := &bytes.Buffer{}
+	root.SetErr(buf)
+	if err := root.Execute(); err == nil {
+		t.Error("expected error for two positional args")
+	}
+}
+
+func TestForgeCheckCommand_FileNotFound_DefaultPath(t *testing.T) {
+	tmp := t.TempDir()
+	orig, _ := os.Getwd()
+	defer os.Chdir(orig)
+	os.Chdir(tmp)
+
+	root := &cobra.Command{Use: "trustabl", SilenceUsage: true, SilenceErrors: true}
+	root.AddCommand(newForgeCommand(nil))
+	root.SetArgs([]string{"forge", "check"})
+	errBuf := &bytes.Buffer{}
+	root.SetErr(errBuf)
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected non-nil error for missing SKILL.md")
+	}
+	if !strings.Contains(errBuf.String(), "SKILL.md") {
+		t.Errorf("stderr should mention SKILL.md, got: %s", errBuf.String())
+	}
+}
+
+func TestForgeCheckCommand_NoStamp_Exit1(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "skill.md")
+	os.WriteFile(path, []byte("# Some Skill\n\nNo stamp here.\n"), 0o644)
+
+	root := &cobra.Command{Use: "trustabl", SilenceUsage: true, SilenceErrors: true}
+	root.AddCommand(newForgeCommand(nil))
+	root.SetArgs([]string{"forge", "check", path})
+	errBuf := &bytes.Buffer{}
+	root.SetErr(errBuf)
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected non-nil error for unstamped file")
+	}
+	if !strings.Contains(errBuf.String(), "no forge stamp") {
+		t.Errorf("stderr should mention 'no forge stamp', got: %s", errBuf.String())
 	}
 }

--- a/internal/forge/gen.go
+++ b/internal/forge/gen.go
@@ -97,8 +97,8 @@ func matchCondition(expr rules.MatchExpr) string {
 	return "When the condition described by this rule is met."
 }
 
-// Stamp is the passive watermark embedded in a GenerateCombined output.
-type Stamp struct {
+// PolicyStamp is the passive watermark embedded in a GenerateCombined output.
+type PolicyStamp struct {
 	Date          string                    // YYYY-MM-DD
 	RulesSHA      string                    // short (7-char) or full SHA
 	SchemaVersion int
@@ -164,7 +164,7 @@ func emitRuleSection(b *strings.Builder, heading string, rs []rules.RuleDef, sco
 // Output is byte-stable: categories are iterated in stamp.Categories order;
 // within each section rules are sorted by severity (critical first) then rule
 // ID ascending.
-func GenerateCombined(categories []models.DetectorCategory, policies []rules.PolicyFile, stamp Stamp) string {
+func GenerateCombined(categories []models.DetectorCategory, policies []rules.PolicyFile, stamp PolicyStamp) string {
 	// build category set for O(1) membership check
 	catSet := make(map[models.DetectorCategory]bool, len(categories))
 	for _, c := range categories {
@@ -272,7 +272,8 @@ func sanitizeEmittedText(s string) string {
 // Only rules already filtered to scope==skill should be passed; Generate does
 // not re-filter. Output is byte-stable: rules are sorted by severity rank
 // (critical first), then by rule ID ascending within each rank.
-func Generate(meta rules.PolicyMeta, skillRules []rules.RuleDef) string {
+// When stamp.SHA is non-empty, a provenance comment is embedded after the header.
+func Generate(meta rules.PolicyMeta, skillRules []rules.RuleDef, stamp Stamp) string {
 	sorted := make([]rules.RuleDef, len(skillRules))
 	copy(sorted, skillRules)
 	sort.Slice(sorted, func(i, j int) bool {
@@ -301,6 +302,10 @@ func Generate(meta rules.PolicyMeta, skillRules []rules.RuleDef) string {
 	// --- Header ---
 	fmt.Fprintf(&b, "# Trustabl Pre-Coding: %s\n", meta.Name)
 	fmt.Fprintf(&b, "\n")
+	if line := stamp.Line(); line != "" {
+		fmt.Fprintf(&b, "%s\n", line)
+		fmt.Fprintf(&b, "\n")
+	}
 	fmt.Fprintf(&b, "Before writing any SKILL.md, you MUST apply every constraint below. Rules are\n")
 	fmt.Fprintf(&b, "ordered by severity. A violation here will fire the corresponding finding\n")
 	fmt.Fprintf(&b, "in post-build scan — prevent it now.\n")

--- a/internal/forge/gen_test.go
+++ b/internal/forge/gen_test.go
@@ -140,7 +140,12 @@ func TestGenerate_GoldenFile(t *testing.T) {
 		t.Fatal("no skill-scoped rules found in fixture")
 	}
 
-	got := Generate(pf.Policy, skillRules)
+	got := Generate(pf.Policy, skillRules, Stamp{
+		Date:   "2026-01-01",
+		SHA:    "0000000000000000000000000000000000000000",
+		Schema: 1,
+		SDKs:   []string{"claude_skill"},
+	})
 
 	goldenPath := filepath.Join("..", "..", "testdata", "forge", "claude_skill", "expected", "SKILL.md")
 	if *update {
@@ -179,8 +184,8 @@ func TestGenerate_Deterministic(t *testing.T) {
 			skillRules = append(skillRules, r)
 		}
 	}
-	a := Generate(pf.Policy, skillRules)
-	b := Generate(pf.Policy, skillRules)
+	a := Generate(pf.Policy, skillRules, Stamp{})
+	b := Generate(pf.Policy, skillRules, Stamp{})
 	if a != b {
 		t.Error("Generate is not deterministic: two calls with same input produced different output")
 	}
@@ -189,7 +194,7 @@ func TestGenerate_Deterministic(t *testing.T) {
 	shuffled := make([]rules.RuleDef, len(skillRules))
 	copy(shuffled, skillRules)
 	rand.Shuffle(len(shuffled), func(i, j int) { shuffled[i], shuffled[j] = shuffled[j], shuffled[i] })
-	c := Generate(pf.Policy, shuffled)
+	c := Generate(pf.Policy, shuffled, Stamp{})
 	if a != c {
 		t.Error("Generate is not order-independent: shuffled input produced different output")
 	}
@@ -201,7 +206,7 @@ func TestGenerate_EmptyRules(t *testing.T) {
 		Name:        "Test Policy",
 		Description: "A test policy. Second sentence.",
 	}
-	got := Generate(meta, nil)
+	got := Generate(meta, nil, Stamp{})
 	if !strings.Contains(got, "name: test-policy") {
 		t.Errorf("expected name: test-policy in output, got:\n%s", got)
 	}
@@ -227,7 +232,7 @@ func TestGenerate_SkillCompliant(t *testing.T) {
 			skillRules = append(skillRules, r)
 		}
 	}
-	got := Generate(pf.Policy, skillRules)
+	got := Generate(pf.Policy, skillRules, Stamp{})
 
 	// The generated skill must itself be CSKILL-compliant.
 	if strings.Contains(got, "allowed-tools: Bash") {
@@ -301,7 +306,7 @@ func TestGenerateCombined_GoldenFile(t *testing.T) {
 		t.Fatal("no policies loaded from fixture")
 	}
 
-	stamp := Stamp{
+	stamp := PolicyStamp{
 		Date:          "2026-01-01",
 		RulesSHA:      "abc1234",
 		SchemaVersion: 13,
@@ -338,7 +343,7 @@ func TestGenerateCombined_Deterministic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load fixture rules: %v", err)
 	}
-	stamp := Stamp{
+	stamp := PolicyStamp{
 		Date:          "2026-01-01",
 		RulesSHA:      "abc1234",
 		SchemaVersion: 13,
@@ -358,7 +363,7 @@ func TestGenerateCombined_UnknownCategorySkipped(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load fixture rules: %v", err)
 	}
-	stamp := Stamp{
+	stamp := PolicyStamp{
 		Date:          "2026-01-01",
 		RulesSHA:      "abc1234",
 		SchemaVersion: 13,

--- a/internal/forge/stamp.go
+++ b/internal/forge/stamp.go
@@ -1,0 +1,78 @@
+package forge
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Stamp holds provenance metadata embedded in a forge-generated SKILL.md.
+type Stamp struct {
+	Date   string   // YYYY-MM-DD
+	SHA    string   // resolved rules commit SHA
+	Schema int      // pack manifest schema_version
+	SDKs   []string // sorted detected SDK IDs
+}
+
+// Line renders the stamp as an HTML comment. Returns empty string when SHA is
+// empty so a zero-value Stamp silently omits the comment.
+func (s Stamp) Line() string {
+	if s.SHA == "" {
+		return ""
+	}
+	return fmt.Sprintf(
+		"<!-- generated: %s | rules: %s | schema: %d | sdks: %s -->",
+		s.Date, s.SHA, s.Schema, strings.Join(s.SDKs, ", "),
+	)
+}
+
+// ParseStamp scans content for a forge stamp HTML comment and parses its
+// fields. Returns (Stamp{}, false) when no stamp is found or the comment is
+// malformed.
+func ParseStamp(content string) (Stamp, bool) {
+	const prefix = "<!-- generated: "
+	const suffix = " -->"
+
+	idx := strings.Index(content, prefix)
+	if idx < 0 {
+		return Stamp{}, false
+	}
+	rest := content[idx+len(prefix):]
+	end := strings.Index(rest, suffix)
+	if end < 0 {
+		return Stamp{}, false
+	}
+	body := rest[:end]
+
+	// body: "2026-08-11 | rules: abc123 | schema: 13 | sdks: claude_sdk, mcp"
+	parts := strings.SplitN(body, " | ", 4)
+	if len(parts) != 4 {
+		return Stamp{}, false
+	}
+
+	date := parts[0]
+
+	rulesVal := strings.TrimPrefix(parts[1], "rules: ")
+	if rulesVal == parts[1] { // prefix not found
+		return Stamp{}, false
+	}
+
+	schemaStr := strings.TrimPrefix(parts[2], "schema: ")
+	if schemaStr == parts[2] {
+		return Stamp{}, false
+	}
+	schema, err := strconv.Atoi(schemaStr)
+	if err != nil {
+		return Stamp{}, false
+	}
+
+	sdksStr := strings.TrimPrefix(parts[3], "sdks: ")
+	var sdks []string
+	for _, s := range strings.Split(sdksStr, ", ") {
+		if s = strings.TrimSpace(s); s != "" {
+			sdks = append(sdks, s)
+		}
+	}
+
+	return Stamp{Date: date, SHA: rulesVal, Schema: schema, SDKs: sdks}, true
+}

--- a/internal/forge/stamp_test.go
+++ b/internal/forge/stamp_test.go
@@ -1,0 +1,81 @@
+package forge
+
+import (
+	"testing"
+)
+
+func TestStamp_Line_WithSHA(t *testing.T) {
+	s := Stamp{Date: "2026-08-11", SHA: "abc1234", Schema: 13, SDKs: []string{"claude_sdk", "mcp"}}
+	want := "<!-- generated: 2026-08-11 | rules: abc1234 | schema: 13 | sdks: claude_sdk, mcp -->"
+	if got := s.Line(); got != want {
+		t.Errorf("Line() = %q, want %q", got, want)
+	}
+}
+
+func TestStamp_Line_EmptySHA(t *testing.T) {
+	s := Stamp{Date: "2026-08-11", Schema: 13, SDKs: []string{"claude_sdk"}}
+	if got := s.Line(); got != "" {
+		t.Errorf("Line() with empty SHA = %q, want empty string", got)
+	}
+}
+
+func TestStamp_Line_NoSDKs(t *testing.T) {
+	s := Stamp{Date: "2026-08-11", SHA: "abc1234", Schema: 13}
+	want := "<!-- generated: 2026-08-11 | rules: abc1234 | schema: 13 | sdks:  -->"
+	if got := s.Line(); got != want {
+		t.Errorf("Line() with nil SDKs = %q, want %q", got, want)
+	}
+}
+
+func TestParseStamp_RoundTrip(t *testing.T) {
+	orig := Stamp{
+		Date:   "2026-08-11",
+		SHA:    "abc1234def5678",
+		Schema: 13,
+		SDKs:   []string{"claude_sdk", "mcp"},
+	}
+	content := "# Header\n\n" + orig.Line() + "\n\nsome body text"
+	got, ok := ParseStamp(content)
+	if !ok {
+		t.Fatal("ParseStamp returned false for valid stamp")
+	}
+	if got.Date != orig.Date {
+		t.Errorf("Date: got %q, want %q", got.Date, orig.Date)
+	}
+	if got.SHA != orig.SHA {
+		t.Errorf("SHA: got %q, want %q", got.SHA, orig.SHA)
+	}
+	if got.Schema != orig.Schema {
+		t.Errorf("Schema: got %d, want %d", got.Schema, orig.Schema)
+	}
+	if len(got.SDKs) != len(orig.SDKs) {
+		t.Errorf("SDKs: got %v, want %v", got.SDKs, orig.SDKs)
+	}
+}
+
+func TestParseStamp_NoStamp(t *testing.T) {
+	cases := []string{
+		"",
+		"# Just a regular markdown file\n\nNo stamp here.",
+		"<!-- some other comment -->",
+		"<!-- generated: bad | format -->",
+	}
+	for _, c := range cases {
+		if _, ok := ParseStamp(c); ok {
+			t.Errorf("ParseStamp(%q) returned true, want false", c)
+		}
+	}
+}
+
+func TestParseStamp_MidFile(t *testing.T) {
+	// Stamp can appear anywhere in the content, not just the first line.
+	s := Stamp{Date: "2026-01-01", SHA: "deadbeef", Schema: 1, SDKs: []string{"openai_sdk"}}
+	content := "lots of content before\n\n" + s.Line() + "\n\nlots of content after"
+	got, ok := ParseStamp(content)
+	if !ok {
+		t.Fatal("ParseStamp returned false")
+	}
+	if got.SHA != s.SHA {
+		t.Errorf("SHA: got %q, want %q", got.SHA, s.SHA)
+	}
+}

--- a/testdata/forge/claude_skill/expected/SKILL.md
+++ b/testdata/forge/claude_skill/expected/SKILL.md
@@ -8,6 +8,8 @@ disable-model-invocation: false
 
 # Trustabl Pre-Coding: Claude Agent Skill safety
 
+<!-- generated: 2026-01-01 | rules: 0000000000000000000000000000000000000000 | schema: 1 | sdks: claude_skill -->
+
 Before writing any SKILL.md, you MUST apply every constraint below. Rules are
 ordered by severity. A violation here will fire the corresponding finding
 in post-build scan — prevent it now.


### PR DESCRIPTION
Every forge-generated SKILL.md now embeds a provenance stamp as an HTML comment recording the rules SHA, schema version, detected SDKs, and generation date:

  <!-- generated: 2026-08-11 | rules: <sha> | schema: 13 | sdks: claude_skill -->

New `trustabl forge check [file]` subcommand reads the stamp, resolves the current rules SHA, and exits 0 (current), 1 (stale/unstamped/not found), or 2 (rules fetch failure) — suitable for use in CI.

Files:
- internal/forge/stamp.go: Stamp struct, Line(), ParseStamp()
- internal/forge/stamp_test.go: round-trip and parse tests
- internal/forge/gen.go: PolicyStamp rename; Generate() accepts Stamp
- cmd/trustabl/forge_check.go: forge check subcommand
- cmd/trustabl/forge.go: build Stamp from resolved rules, register check
- testdata/forge/claude_skill/expected/SKILL.md: golden file updated