### PR TITLE
validate/correct generated fixes + custom LLM provider support

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2204,6 +2204,29 @@ The LLM client calls the active provider's model (from `llm.Load()`) and parses
 a JSON array response — one `enrichResult` per finding. A `salvagePartialJSON`
 fallback recovers partial objects if the response is truncated.
 
+**Replacement validation and targeted correction**
+(`internal/enrichment/validate.go` + `Pipeline.validateAndCorrect` in
+`internal/enrichment/pipeline.go`). Every non-empty `Replacement` is spliced
+into the file and syntax-checked in-process before it can reach `--apply` or
+the JSON output: `validateSyntax` reuses `internal/analysis/astutil`'s
+existing tree-sitter parsers (Python, Go, TS/TSX, C#, PHP, Rust —
+`HasError()` on the parsed root; an extension with no grammar here is skipped,
+not failed closed). A replacement that fails the check gets up to
+`maxCorrectionAttempts-1` (currently 1) targeted correction calls —
+`llmEnricher.reviseResult`, a small single-issue prompt scoped to just that
+finding's prior bad replacement and the parse error, never a re-run of the
+whole batch. The correction call returns ONLY the fixed code: it merges into
+the existing `enrichResult`, replacing `Replacement` alone —
+`Explanation`/`Fix`/`Original`/`FalsePositive` and the line range stay exactly
+as the original generation produced them, since the syntax check only proved
+the code was wrong, not the rest of the result. If correction is exhausted
+without a clean parse, the finding falls back to the same "no code change"
+shape the LLM itself can produce: `Replacement`/`LineStart`/`LineEnd` cleared,
+`Explanation` kept. This keeps
+`enrich`'s own non-determinism (LLM output) from ever writing unparseable code
+to disk, while leaving `trustabl scan`'s byte-stable/`ScanID` contract
+untouched — `enrich` is a separate command outside the scan pipeline.
+
 **Optional runtime trace grounding (`--langsmith`,
 [internal/langsmith/](internal/langsmith/)).** With `--langsmith`, tool-scope
 findings gain a third context layer: recent executions of each flagged tool are
@@ -2328,7 +2351,15 @@ take it absent a concrete distribution requirement.
   (switches active provider, auto-creates entry with a per-provider default
   model), `ValidateKey`, and `MaskKey`. A `defaultModels` map supplies
   fast/cheap defaults per known provider (`anthropic → claude-haiku-4-5`,
-  `openai → gpt-4.1-nano`, `google → gemini-2.5-flash-lite`).
+  `openai → gpt-4.1-nano`, `google → gemini-2.5-flash-lite`, `custom → ""`).
+  `custom` is a fourth known provider for a self-hosted OpenAI-compatible
+  endpoint (e.g. a local model server): `Load()` activates it whenever
+  `OPENAI_BASE_URL` is set, ahead of the plain `OPENAI_API_KEY` branch, has no
+  fixed default model (`TRUSTABL_LLM_MODEL` is required), and — unlike every
+  other provider — does not require a key, since such endpoints often don't
+  check one. `newLLMClient` (`internal/enrichment/llm.go`) wires its `BaseURL`
+  into the OpenAI SDK client via `option.WithBaseURL`; wire-compatible with
+  the `openai` case otherwise.
   `trustabl enrich` (§8.2) reads this config to call the active LLM provider with BYOK.
   The scan pipeline itself makes no LLM call — rule-based detection is the
   entire scan, with or without a key configured.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2346,8 +2346,8 @@ take it absent a concrete distribution requirement.
 
 - **LLM enrichment is a separate post-scan step.** `internal/llm/` owns key storage
   (`~/.config/trustabl/keys.json`, mode 0600) and is managed via
-  `trustabl llm` (list / key set|get|delete / model set / provider set|list).
-  The package exposes `Load`/`Save` (atomic write, mode 0600), `SetActive`
+  `trustabl llm` (list / key set|get|delete / model set / base-url set /
+  provider set|list). The package exposes `Load`/`Save` (atomic write, mode 0600), `SetActive`
   (switches active provider, auto-creates entry with a per-provider default
   model), `ValidateKey`, and `MaskKey`. A `defaultModels` map supplies
   fast/cheap defaults per known provider (`anthropic → claude-haiku-4-5`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ to follow Semantic Versioning once it reaches 1.0.
 
 ### Added
 
+- **`custom` LLM provider for self-hosted / local model servers.** `trustabl
+  enrich` can now target any OpenAI-compatible endpoint (LiteLLM, vLLM, a local
+  model server, etc.) instead of a hosted provider. Set `OPENAI_BASE_URL` to
+  activate it — it takes priority over a plain `OPENAI_API_KEY`, and unlike
+  every other provider, `custom` does not require a key at all, since
+  self-hosted endpoints often don't check one. `TRUSTABL_LLM_MODEL` is
+  required (`custom` has no default model).
 - **Scan attestation (opt-in).** New `internal/attest` package plus `trustabl
   attest` / `trustabl verify` subcommands and a `scan --attest` flag. Trustabl
   renders a deterministic in-toto predicate (type

--- a/README.md
+++ b/README.md
@@ -818,16 +818,25 @@ trustabl llm key set sk-ant-api03-...      # set key non-interactively
 trustabl llm key get                       # show masked key for active provider
 trustabl llm key delete                    # delete key with confirmation prompt
 trustabl llm model set claude-sonnet-4-6   # change model for active provider
+trustabl llm base-url set http://host:4000 # set API base URL (only meaningful for "custom")
 trustabl llm provider set openai           # switch active provider (auto-creates entry)
 trustabl llm provider list                 # list configured providers
 
 # Self-hosted / local model server (any OpenAI-compatible endpoint, e.g. a
-# LiteLLM or vLLM gateway). OPENAI_BASE_URL alone activates "custom" — it
-# takes priority over a plain OPENAI_API_KEY. No default model, so
-# TRUSTABL_LLM_MODEL is required. OPENAI_API_KEY is optional: only set it if
-# the endpoint actually checks it.
+# LiteLLM or vLLM gateway). Two ways to configure it:
+#
+# 1. Env vars — no persistent config, works in CI:
+#    OPENAI_BASE_URL alone activates "custom", ahead of a plain OPENAI_API_KEY.
+#    No default model, so TRUSTABL_LLM_MODEL is required. OPENAI_API_KEY is
+#    optional: only set it if the endpoint actually checks it.
 export OPENAI_BASE_URL=http://localhost:4000
 export TRUSTABL_LLM_MODEL=qwen-32b
+#
+# 2. Persistent config — same three fields, saved to ~/.config/trustabl/keys.json:
+trustabl llm provider set custom
+trustabl llm base-url set http://localhost:4000
+trustabl llm model set qwen-32b
+# trustabl llm key set is optional — skip it if the endpoint needs no key
 
 # Enrich a scan result (requires any configured LLM provider — a custom
 # endpoint may not need a key, every other provider does)

--- a/README.md
+++ b/README.md
@@ -821,7 +821,16 @@ trustabl llm model set claude-sonnet-4-6   # change model for active provider
 trustabl llm provider set openai           # switch active provider (auto-creates entry)
 trustabl llm provider list                 # list configured providers
 
-# Enrich a scan result (requires any configured LLM provider with a key set)
+# Self-hosted / local model server (any OpenAI-compatible endpoint, e.g. a
+# LiteLLM or vLLM gateway). OPENAI_BASE_URL alone activates "custom" — it
+# takes priority over a plain OPENAI_API_KEY. No default model, so
+# TRUSTABL_LLM_MODEL is required. OPENAI_API_KEY is optional: only set it if
+# the endpoint actually checks it.
+export OPENAI_BASE_URL=http://localhost:4000
+export TRUSTABL_LLM_MODEL=qwen-32b
+
+# Enrich a scan result (requires any configured LLM provider — a custom
+# endpoint may not need a key, every other provider does)
 trustabl scan ./myrepo --format json | trustabl enrich --repo ./myrepo        # pipe scan into enrich (stdout)
 trustabl enrich --input scan.json --repo ./myrepo --output enriched.json      # file in, file out
 trustabl enrich --input scan.json --repo ./myrepo --diff                      # preview proposed fixes as a unified diff (stderr)

--- a/cmd/trustabl/enrich.go
+++ b/cmd/trustabl/enrich.go
@@ -87,10 +87,11 @@ func runEnrich(cmd *cobra.Command, f enrichFlags) error {
 		return fmt.Errorf("enrich: load llm config: %w", err)
 	}
 	key := cfg.ActiveProvider().Key
-	if key == "" {
+	if key == "" && cfg.Active != "custom" {
 		return fmt.Errorf("enrich: no LLM key configured, run: trustabl llm key set")
 	}
 	model := cfg.ActiveProvider().Model
+	baseURL := cfg.ActiveProvider().BaseURL
 
 	result, err := readScanResult(f.inputFile)
 	if err != nil {
@@ -101,6 +102,7 @@ func runEnrich(cmd *cobra.Command, f enrichFlags) error {
 		LLMProvider:  cfg.Active,
 		LLMKey:       key,
 		LLMModel:     model,
+		LLMBaseURL:   baseURL,
 		RepoRoot:     f.repoRoot,
 		RuleFilter:   f.rules,
 		Apply:        f.apply,

--- a/cmd/trustabl/llm.go
+++ b/cmd/trustabl/llm.go
@@ -32,6 +32,7 @@ today, with or without a key configured.`,
 	cmd.AddCommand(newLLMListCommand())
 	cmd.AddCommand(newLLMKeyCommand())
 	cmd.AddCommand(newLLMModelCommand())
+	cmd.AddCommand(newLLMBaseURLCommand())
 	cmd.AddCommand(newLLMProviderCommand())
 	return cmd
 }
@@ -63,7 +64,7 @@ func runLLMList(cmd *cobra.Command) error {
 		return err
 	}
 	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 3, ' ', 0)
-	fmt.Fprintln(w, "PROVIDER\tMODEL\tKEY")
+	fmt.Fprintln(w, "PROVIDER\tMODEL\tBASE URL\tKEY")
 	names := make([]string, 0, len(cfg.Providers))
 	for name := range cfg.Providers {
 		names = append(names, name)
@@ -75,7 +76,11 @@ func runLLMList(cmd *cobra.Command) error {
 		if name == cfg.Active {
 			active = " *"
 		}
-		fmt.Fprintf(w, "%s%s\t%s\t%s\n", name, active, p.Model, llm.MaskKey(p.Key))
+		baseURL := p.BaseURL
+		if baseURL == "" {
+			baseURL = "-"
+		}
+		fmt.Fprintf(w, "%s%s\t%s\t%s\t%s\n", name, active, p.Model, baseURL, llm.MaskKey(p.Key))
 	}
 	return w.Flush()
 }
@@ -249,6 +254,52 @@ func runLLMModelSet(cmd *cobra.Command, model string) error {
 		return err
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "Model for %s set to %s.\n", cfg.Active, model)
+	return nil
+}
+
+// ── base-url ──────────────────────────────────────────────────────────────────
+
+func newLLMBaseURLCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "base-url",
+		Short: "Manage the API base URL for the active provider",
+		Long: `Manage a custom API base URL for the active provider. Only meaningful for
+"custom" — a self-hosted OpenAI-compatible endpoint (e.g. LiteLLM, vLLM, a
+local model server). Other providers ignore it and use their default hosted
+API.`,
+		Example: "  trustabl llm provider set custom\n  trustabl llm base-url set http://localhost:4000\n  trustabl llm model set qwen-32b",
+	}
+	cmd.AddCommand(newLLMBaseURLSetCommand())
+	return cmd
+}
+
+func newLLMBaseURLSetCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:     "set <url>",
+		Short:   "Set the API base URL for the active provider",
+		Long:    "Set the API base URL for the active provider. The value is stored as-is and\nis not validated as a reachable endpoint.",
+		Example: "  trustabl llm base-url set http://localhost:4000",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runLLMBaseURLSet(cmd, args[0])
+		},
+	}
+}
+
+func runLLMBaseURLSet(cmd *cobra.Command, baseURL string) error {
+	cfg, err := llm.Load()
+	if err != nil {
+		return err
+	}
+	cfg.SetBaseURL(baseURL)
+	if err := cfg.Save(); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Base URL for %s set to %s.\n", cfg.Active, baseURL)
+	if cfg.Active != "custom" {
+		fmt.Fprintf(cmd.OutOrStdout(),
+			"Note: only the \"custom\" provider uses a base URL — %s will ignore this.\n", cfg.Active)
+	}
 	return nil
 }
 

--- a/cmd/trustabl/llm_test.go
+++ b/cmd/trustabl/llm_test.go
@@ -305,6 +305,57 @@ func TestLLMModelSet(t *testing.T) {
 	}
 }
 
+func TestLLMBaseURLSet(t *testing.T) {
+	setLLMConfigDir(t, t.TempDir())
+
+	// Active provider a real one (custom) so no "will be ignored" note fires.
+	provCmd := newLLMProviderSetCommand()
+	provCmd.SetArgs([]string{"custom"})
+	if err := provCmd.Execute(); err != nil {
+		t.Fatalf("provider set setup: unexpected error: %v", err)
+	}
+
+	cmd := newLLMBaseURLSetCommand()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"http://localhost:4000"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "http://localhost:4000") {
+		t.Errorf("output %q missing base URL", buf.String())
+	}
+	if strings.Contains(buf.String(), "will ignore") {
+		t.Errorf("output %q should not warn for custom provider", buf.String())
+	}
+
+	cfg, err := llm.Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.ActiveProvider().BaseURL != "http://localhost:4000" {
+		t.Errorf("BaseURL = %q, want http://localhost:4000", cfg.ActiveProvider().BaseURL)
+	}
+}
+
+func TestLLMBaseURLSet_WarnsForNonCustomProvider(t *testing.T) {
+	setLLMConfigDir(t, t.TempDir())
+	// Default active provider is anthropic — base-url is meaningless there.
+
+	cmd := newLLMBaseURLSetCommand()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"http://localhost:4000"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "will ignore") {
+		t.Errorf("output %q should warn that anthropic ignores base-url", buf.String())
+	}
+}
+
 func TestLLMProviderSet_New(t *testing.T) {
 	setLLMConfigDir(t, t.TempDir())
 

--- a/internal/enrichment/correction_test.go
+++ b/internal/enrichment/correction_test.go
@@ -1,0 +1,150 @@
+package enrichment
+
+import (
+	"context"
+	"testing"
+
+	"github.com/trustabl/trustabl/internal/models"
+)
+
+// TestPipeline_InvalidReplacement_CorrectedOnRetry: the LLM's first replacement
+// doesn't parse; one reviseResult call fixes it. The corrected CODE replaces
+// the broken one, but the original explanation/fix survive untouched — the
+// correction call's only job is fixing the syntax, not re-explaining the finding.
+func TestPipeline_InvalidReplacement_CorrectedOnRetry(t *testing.T) {
+	dir := t.TempDir()
+	writeTempFile(t, dir, "agent.py", "def run():\n    agent = Agent()\n    return agent\n")
+
+	result := &models.ScanResult{
+		Findings: []models.Finding{
+			{RuleID: "CSDK-010", FilePath: "agent.py", StartLine: 2, EndLine: 2, Title: "No guardrail"},
+		},
+	}
+
+	mock := &mockLLM{
+		results: []enrichResult{
+			{Explanation: "bad", Fix: "add a guardrail", LineStart: 2, LineEnd: 2, Replacement: "    agent = Agent(input_guardrails=[g]"}, // missing ')' — invalid
+		},
+		reviseResults: []string{
+			"    agent = Agent(input_guardrails=[g])", // just the corrected code
+		},
+	}
+
+	p := &Pipeline{RepoRoot: dir, llm: mock}
+	enriched, err := p.Run(context.Background(), result)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	if mock.reviseCalls.Load() != 1 {
+		t.Errorf("reviseCalls = %d, want 1", mock.reviseCalls.Load())
+	}
+	f := enriched.Findings[0]
+	if f.Replacement != "    agent = Agent(input_guardrails=[g])" {
+		t.Errorf("Replacement = %q, want the corrected replacement", f.Replacement)
+	}
+	if f.AIExplanation != "bad" {
+		t.Errorf("AIExplanation = %q, want the ORIGINAL explanation preserved (correction only fixes code)", f.AIExplanation)
+	}
+	if f.AIFix != "add a guardrail" {
+		t.Errorf("AIFix = %q, want the ORIGINAL fix text preserved", f.AIFix)
+	}
+}
+
+// TestPipeline_ExhaustedCorrections: every attempt (original + 1 correction)
+// stays invalid. The finding must fall back to the "no code change" shape —
+// Replacement/LineStart/LineEnd cleared, but Explanation preserved — rather
+// than ever surface unparseable code.
+func TestPipeline_ExhaustedCorrections(t *testing.T) {
+	dir := t.TempDir()
+	writeTempFile(t, dir, "agent.py", "def run():\n    agent = Agent()\n    return agent\n")
+
+	result := &models.ScanResult{
+		Findings: []models.Finding{
+			{RuleID: "CSDK-010", FilePath: "agent.py", StartLine: 2, EndLine: 2, Title: "No guardrail"},
+		},
+	}
+
+	mock := &mockLLM{
+		results: []enrichResult{
+			{Explanation: "bad", LineStart: 2, LineEnd: 2, Replacement: "    agent = Agent(input_guardrails=[g]"}, // invalid
+		},
+		reviseResults: []string{
+			"    agent = Agent(input_guardrails=[g]", // still invalid
+		},
+	}
+
+	p := &Pipeline{RepoRoot: dir, llm: mock}
+	enriched, err := p.Run(context.Background(), result)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	if mock.reviseCalls.Load() != 1 {
+		t.Errorf("reviseCalls = %d, want 1 (maxCorrectionAttempts-1, not the whole batch re-run)", mock.reviseCalls.Load())
+	}
+	f := enriched.Findings[0]
+	if f.Replacement != "" {
+		t.Errorf("Replacement = %q, want empty after exhausting corrections", f.Replacement)
+	}
+	if f.LineStart != 0 || f.LineEnd != 0 {
+		t.Errorf("LineStart/LineEnd = %d/%d, want 0/0 after exhausting corrections", f.LineStart, f.LineEnd)
+	}
+	if f.AIExplanation != "bad" {
+		t.Errorf("AIExplanation = %q, want the original explanation preserved even when the replacement is dropped", f.AIExplanation)
+	}
+}
+
+// TestPipeline_BatchIsolation: 3 findings in one file, only the middle one's
+// replacement is invalid. Correction must be scoped to that single finding —
+// the other two must never trigger a reviseResult call.
+func TestPipeline_BatchIsolation(t *testing.T) {
+	dir := t.TempDir()
+	writeTempFile(t, dir, "vals.py", "def run():\n    a = 1\n    b = 2\n    c = 3\n    return a, b, c\n")
+
+	result := &models.ScanResult{
+		Findings: []models.Finding{
+			{RuleID: "R1", FilePath: "vals.py", StartLine: 2, EndLine: 2, Title: "F1"},
+			{RuleID: "R2", FilePath: "vals.py", StartLine: 3, EndLine: 3, Title: "F2"},
+			{RuleID: "R3", FilePath: "vals.py", StartLine: 4, EndLine: 4, Title: "F3"},
+		},
+	}
+
+	mock := &mockLLM{
+		results: []enrichResult{
+			{Explanation: "e1", LineStart: 2, LineEnd: 2, Replacement: "    a = 10"},  // valid
+			{Explanation: "e2", LineStart: 3, LineEnd: 3, Replacement: "    b = (20"}, // invalid — missing ')'
+			{Explanation: "e3", LineStart: 4, LineEnd: 4, Replacement: "    c = 30"},  // valid
+		},
+		reviseResults: []string{
+			"    b = 20",
+		},
+	}
+
+	p := &Pipeline{RepoRoot: dir, llm: mock}
+	enriched, err := p.Run(context.Background(), result)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	if mock.reviseCalls.Load() != 1 {
+		t.Errorf("reviseCalls = %d, want 1 (only the invalid finding, not the valid ones)", mock.reviseCalls.Load())
+	}
+
+	byRule := map[string]models.EnrichedFinding{}
+	for _, f := range enriched.Findings {
+		byRule[f.RuleID] = f
+	}
+	if byRule["R1"].Replacement != "    a = 10" {
+		t.Errorf("R1 Replacement = %q, want untouched original", byRule["R1"].Replacement)
+	}
+	if byRule["R2"].Replacement != "    b = 20" {
+		t.Errorf("R2 Replacement = %q, want the corrected replacement", byRule["R2"].Replacement)
+	}
+	if byRule["R2"].AIExplanation != "e2" {
+		t.Errorf("R2 AIExplanation = %q, want the original e2 preserved", byRule["R2"].AIExplanation)
+	}
+	if byRule["R3"].Replacement != "    c = 30" {
+		t.Errorf("R3 Replacement = %q, want untouched original", byRule["R3"].Replacement)
+	}
+}

--- a/internal/enrichment/llm.go
+++ b/internal/enrichment/llm.go
@@ -27,9 +27,14 @@ Respond with a JSON array only, one object per issue in the same order:
 [{"explanation":"...","fix":"...","line_start":N,"line_end":N,"original":"...","replacement":"...","false_positive":false},...]
 - explanation: 2-3 sentences specific to the actual code at that line (not generic)
 - fix: human-readable description of what was changed and why
-- line_start / line_end: MUST include the flagged line number. Only expand the range if adjacent lines must also change.
+- line_start / line_end: MUST include the flagged line number. Keep this the SMALLEST range that contains the
+  change — do not pull in an import, decorator, comment, or unrelated statement above or below it unless that
+  exact line is itself changing.
 - original: the current lines line_start..line_end copied VERBATIM (identical text, indentation, and order). It is used to verify the file is unchanged before applying your fix; if you cannot copy them exactly, set line_start and line_end to 0.
-- replacement: the exact new lines in the correct language (preserve original indentation, no trailing newline)
+- replacement: the exact new lines in the correct language (preserve original indentation, no trailing newline).
+  Copy every line in the range you are not changing VERBATIM — never repeat/duplicate an existing line or
+  argument instead of editing it, and never drop a line the rest of the file still relies on (an import, a
+  constant, a helper) just because it fell inside line_start..line_end.
 If no code change is needed set line_start, line_end to 0 and replacement to "".
 Do not wrap in markdown code fences.`
 
@@ -37,6 +42,50 @@ Do not wrap in markdown code fences.`
 // The real implementation is llmClient; tests inject a mock.
 type llmEnricher interface {
 	enrichFile(ctx context.Context, filePath string, issues []issueContext) ([]enrichResult, error)
+	// reviseResult asks for a corrected REPLACEMENT ONLY, after the prior one
+	// failed a syntax check (see validateSyntax). Deliberately narrow: the
+	// syntax check only proved the code was wrong, not the explanation/fix
+	// text, so this call's job is fixing the code — the caller keeps the rest
+	// of the original enrichResult untouched rather than risking drift (or a
+	// silently re-flipped false_positive) from a full re-generation. Not a
+	// threaded/multi-turn call either — a fresh, small, single-issue prompt is
+	// simpler across three provider SDKs and cheaper than re-running the batch.
+	reviseResult(ctx context.Context, filePath string, issue issueContext, priorReplacement, parseErr string) (string, error)
+}
+
+const reviseSystemPrompt = `Your previous suggested code replacement for this issue failed a syntax check.
+Return ONLY the corrected code as a single JSON object:
+{"replacement":"..."}
+Fix the syntax error while preserving the same intent, content, and line range as your original
+replacement (preserve original indentation, no trailing newline). Copy every line you are not
+specifically fixing VERBATIM from your previous replacement — do not duplicate a line or argument
+instead of correcting it, and do not drop an import or other line the rest of the file depends on.
+Do not wrap in markdown code fences.`
+
+// revisionResponse is the correction call's response shape: just the fixed
+// code, nothing else — see the llmEnricher.reviseResult doc comment for why.
+type revisionResponse struct {
+	Replacement string `json:"replacement"`
+}
+
+// buildRevisePrompt formats the user message for a single-issue correction
+// call: what failed, what it looked like, and why it didn't parse.
+func buildRevisePrompt(filePath string, issue issueContext, priorReplacement, parseErr string) string {
+	return fmt.Sprintf(
+		"File: %s\nIssue: %s\nYour previous replacement:\n%s\n\nParse error: %s\n\nReturn the corrected JSON object.",
+		filePath, issue.title, priorReplacement, parseErr,
+	)
+}
+
+// parseReviseResponse strips a markdown fence if present and decodes the
+// corrected-code JSON object, returning just its replacement field.
+func parseReviseResponse(raw string) (string, error) {
+	raw = stripFence(strings.TrimSpace(raw))
+	var r revisionResponse
+	if err := json.Unmarshal([]byte(raw), &r); err != nil {
+		return "", fmt.Errorf("parse revision response: %w", err)
+	}
+	return r.Replacement, nil
 }
 
 type enrichResult struct {
@@ -67,7 +116,7 @@ type llmClient struct {
 	model  anthropic.Model
 }
 
-func newLLMClient(ctx context.Context, provider, apiKey, model string) (llmEnricher, error) {
+func newLLMClient(ctx context.Context, provider, apiKey, model, baseURL string) (llmEnricher, error) {
 	switch provider {
 	case "anthropic":
 		return &llmClient{
@@ -82,6 +131,18 @@ func newLLMClient(ctx context.Context, provider, apiKey, model string) (llmEnric
 			client: openai.NewClient(openaiopt.WithAPIKey(apiKey)),
 			model:  model,
 		}, nil
+	case "custom":
+		// Self-hosted OpenAI-compatible endpoint (e.g. a local model server).
+		// Wire-compatible with the "openai" case above, just pointed elsewhere
+		// — apiKey may legitimately be "" here, such endpoints often don't
+		// require one.
+		if baseURL == "" {
+			return nil, fmt.Errorf("custom provider requires a base URL (OPENAI_BASE_URL)")
+		}
+		return &openaiClient{
+			client: openai.NewClient(openaiopt.WithAPIKey(apiKey), openaiopt.WithBaseURL(baseURL)),
+			model:  model,
+		}, nil
 	case "google":
 		c, err := genai.NewClient(ctx, &genai.ClientConfig{APIKey: apiKey})
 		if err != nil {
@@ -89,7 +150,7 @@ func newLLMClient(ctx context.Context, provider, apiKey, model string) (llmEnric
 		}
 		return &googleClient{client: c, model: model}, nil
 	default:
-		return nil, fmt.Errorf("unsupported LLM provider %q (known: anthropic, openai, google)", provider)
+		return nil, fmt.Errorf("unsupported LLM provider %q (known: anthropic, openai, google, custom)", provider)
 	}
 }
 
@@ -135,6 +196,23 @@ func (c *llmClient) enrichFile(ctx context.Context, filePath string, issues []is
 	return results, nil
 }
 
+func (c *llmClient) reviseResult(ctx context.Context, filePath string, issue issueContext, priorReplacement, parseErr string) (string, error) {
+	user := buildRevisePrompt(filePath, issue, priorReplacement, parseErr)
+	msg, err := c.client.Messages.New(ctx, anthropic.MessageNewParams{
+		Model:     c.model,
+		MaxTokens: 512, // just the code, not a full object — narrower than enrichFile's 2048
+		System:    []anthropic.TextBlockParam{{Text: reviseSystemPrompt}},
+		Messages:  []anthropic.MessageParam{anthropic.NewUserMessage(anthropic.NewTextBlock(user))},
+	})
+	if err != nil {
+		return "", fmt.Errorf("claude api: %w", err)
+	}
+	if len(msg.Content) == 0 {
+		return "", fmt.Errorf("claude api: empty response")
+	}
+	return parseReviseResponse(msg.Content[0].Text)
+}
+
 type openaiClient struct {
 	client openai.Client
 	model  string
@@ -173,6 +251,25 @@ func (c *openaiClient) enrichFile(ctx context.Context, filePath string, issues [
 	return results, nil
 }
 
+func (c *openaiClient) reviseResult(ctx context.Context, filePath string, issue issueContext, priorReplacement, parseErr string) (string, error) {
+	user := buildRevisePrompt(filePath, issue, priorReplacement, parseErr)
+	resp, err := c.client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
+		Model: c.model,
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			openai.SystemMessage(reviseSystemPrompt),
+			openai.UserMessage(user),
+		},
+		MaxTokens: openai.Int(512),
+	})
+	if err != nil {
+		return "", fmt.Errorf("openai api: %w", err)
+	}
+	if len(resp.Choices) == 0 {
+		return "", fmt.Errorf("openai api: empty response")
+	}
+	return parseReviseResponse(resp.Choices[0].Message.Content)
+}
+
 type googleClient struct {
 	client *genai.Client
 	model  string
@@ -202,6 +299,18 @@ func (c *googleClient) enrichFile(ctx context.Context, filePath string, issues [
 		}
 	}
 	return results, nil
+}
+
+func (c *googleClient) reviseResult(ctx context.Context, filePath string, issue issueContext, priorReplacement, parseErr string) (string, error) {
+	prompt := reviseSystemPrompt + "\n\n" + buildRevisePrompt(filePath, issue, priorReplacement, parseErr)
+	resp, err := c.client.Models.GenerateContent(ctx, c.model, genai.Text(prompt), nil)
+	if err != nil {
+		return "", fmt.Errorf("google api: %w", err)
+	}
+	if resp == nil || len(resp.Candidates) == 0 {
+		return "", fmt.Errorf("google api: empty response")
+	}
+	return parseReviseResponse(resp.Text())
 }
 
 // buildIssueList formats the issue list portion of the LLM prompt.

--- a/internal/enrichment/llm_test.go
+++ b/internal/enrichment/llm_test.go
@@ -71,12 +71,32 @@ func TestIndentBlock(t *testing.T) {
 }
 
 func TestNewLLMClient_UnknownProvider(t *testing.T) {
-	_, err := newLLMClient(context.Background(), "unknown", "key", "model")
+	_, err := newLLMClient(context.Background(), "unknown", "key", "model", "")
 	if err == nil {
 		t.Fatal("newLLMClient with unknown provider: expected error, got nil")
 	}
 	if !strings.Contains(err.Error(), "unsupported") {
 		t.Errorf("error %q should contain \"unsupported\"", err.Error())
+	}
+}
+
+func TestNewLLMClient_CustomRequiresBaseURL(t *testing.T) {
+	_, err := newLLMClient(context.Background(), "custom", "", "model", "")
+	if err == nil {
+		t.Fatal("newLLMClient with custom provider and no base URL: expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "base URL") {
+		t.Errorf("error %q should mention the missing base URL", err.Error())
+	}
+}
+
+func TestNewLLMClient_CustomWithBaseURL(t *testing.T) {
+	client, err := newLLMClient(context.Background(), "custom", "", "model", "http://localhost:4000")
+	if err != nil {
+		t.Fatalf("newLLMClient with custom provider and base URL: unexpected error: %v", err)
+	}
+	if client == nil {
+		t.Fatal("newLLMClient with custom provider and base URL: expected a client, got nil")
 	}
 }
 

--- a/internal/enrichment/pipeline.go
+++ b/internal/enrichment/pipeline.go
@@ -20,9 +20,10 @@ func init() {
 
 // Pipeline orchestrates enrichment of a ScanResult.
 type Pipeline struct {
-	LLMProvider  string   // "anthropic" | "openai" | "google"
-	LLMKey       string   // API key from llm.Load()
+	LLMProvider  string   // "anthropic" | "openai" | "google" | "custom"
+	LLMKey       string   // API key from llm.Load(); may be "" for "custom"
 	LLMModel     string   // model name from llm.Load(), e.g. "claude-haiku-4-5"
+	LLMBaseURL   string   // API base URL override; only used by "custom"
 	RepoRoot     string   // root of the scanned repo; source files are read relative to this
 	RuleFilter   []string // if non-empty, only enrich findings whose RuleID is in this list
 	Apply        bool     // write AI-generated replacements to disk
@@ -65,11 +66,13 @@ func (p *Pipeline) shouldEnrich(f models.Finding) bool {
 func (p *Pipeline) Run(ctx context.Context, result *models.ScanResult) (*models.EnrichmentResult, error) {
 	client := p.llm
 	if client == nil {
-		if p.LLMKey == "" {
+		// "custom" (a self-hosted OpenAI-compatible endpoint) may legitimately
+		// have no key — every other provider requires one.
+		if p.LLMKey == "" && p.LLMProvider != "custom" {
 			return nil, fmt.Errorf("enrichment: no LLM key configured, run: trustabl llm key set")
 		}
 		var clientErr error
-		client, clientErr = newLLMClient(ctx, p.LLMProvider, p.LLMKey, p.LLMModel)
+		client, clientErr = newLLMClient(ctx, p.LLMProvider, p.LLMKey, p.LLMModel, p.LLMBaseURL)
 		if clientErr != nil {
 			return nil, clientErr
 		}
@@ -210,6 +213,7 @@ func (p *Pipeline) enrichFile(ctx context.Context, client llmEnricher, filePath 
 			break
 		}
 		r := results[i]
+		r = p.validateAndCorrect(ctx, client, filePath, string(fileContent), issues[i], r)
 		out[i].AIExplanation = r.Explanation
 		out[i].AIFix = r.Fix
 		out[i].LineStart = r.LineStart
@@ -295,6 +299,61 @@ func (p *Pipeline) traceEvidenceFor(ctx context.Context, f models.Finding) strin
 		return "" // no traces recorded for this tool, nothing to say
 	}
 	return formatTraceEvidence(stats)
+}
+
+// maxCorrectionAttempts bounds how many times validateAndCorrect will retry a
+// single result: the original generation plus up to this many corrective
+// calls before giving up on that finding's replacement. Kept small — each
+// attempt beyond the first is a real LLM call paid out of the user's own
+// BYOK budget for what should be a narrow fix, not a full re-generation.
+const maxCorrectionAttempts = 2
+
+// validateAndCorrect checks r's replacement (if any) against a syntax parse
+// of the file with that replacement spliced in, and asks the LLM for up to
+// maxCorrectionAttempts-1 targeted corrections — scoped to this ONE finding,
+// never the whole batch — before giving up. A correction only ever replaces
+// r.Replacement; Explanation/Fix/Original/FalsePositive and the line range
+// are the original generation's and are never re-asked for — the syntax
+// check only proved the code was wrong, not the rest of the result. A
+// replacement that never validates falls back to the same "no code change"
+// shape the LLM itself can produce: Replacement/LineStart/LineEnd cleared,
+// Explanation kept.
+func (p *Pipeline) validateAndCorrect(ctx context.Context, client llmEnricher, filePath, fileContent string, issue issueContext, r enrichResult) enrichResult {
+	if r.Replacement == "" {
+		return r
+	}
+
+	for attempt := 0; attempt < maxCorrectionAttempts; attempt++ {
+		spliced, perr := applyPatches(fileContent, []filePatch{
+			{lineStart: r.LineStart, lineEnd: r.LineEnd, replacement: r.Replacement},
+		})
+		if perr != nil {
+			// Can't even splice it (bad line range) — a validity check has
+			// nothing to check; leave r as-is for --apply's own anchor check
+			// to handle.
+			return r
+		}
+
+		verr := validateSyntax(ctx, filePath, spliced)
+		if verr == nil {
+			return r // valid — keep r as-is
+		}
+
+		if attempt == maxCorrectionAttempts-1 {
+			log.Printf("warn: %s: replacement still invalid after %d correction(s): %v", filePath, attempt, verr)
+			r.Replacement, r.LineStart, r.LineEnd = "", 0, 0
+			return r
+		}
+
+		revised, rerr := client.reviseResult(ctx, filePath, issue, r.Replacement, verr.Error())
+		if rerr != nil {
+			log.Printf("warn: %s: correction call failed: %v", filePath, rerr)
+			r.Replacement, r.LineStart, r.LineEnd = "", 0, 0
+			return r
+		}
+		r.Replacement = revised
+	}
+	return r
 }
 
 // formatTraceEvidence renders ToolTraceStats as the prose block fed to the LLM

--- a/internal/enrichment/pipeline_test.go
+++ b/internal/enrichment/pipeline_test.go
@@ -16,6 +16,12 @@ type mockLLM struct {
 	results []enrichResult
 	err     error
 	calls   atomic.Int32
+
+	// reviseResults are the corrected-code strings returned in order, one per
+	// call to reviseResult. reviseErr, if set, is returned instead on every call.
+	reviseResults []string
+	reviseErr     error
+	reviseCalls   atomic.Int32
 }
 
 func (m *mockLLM) enrichFile(_ context.Context, _ string, issues []issueContext) ([]enrichResult, error) {
@@ -31,6 +37,17 @@ func (m *mockLLM) enrichFile(_ context.Context, _ string, issues []issueContext)
 		}
 	}
 	return out, nil
+}
+
+func (m *mockLLM) reviseResult(_ context.Context, _ string, _ issueContext, _, _ string) (string, error) {
+	i := m.reviseCalls.Add(1) - 1
+	if m.reviseErr != nil {
+		return "", m.reviseErr
+	}
+	if int(i) < len(m.reviseResults) {
+		return m.reviseResults[i], nil
+	}
+	return "", nil
 }
 
 func writeTempFile(t *testing.T, dir, name, content string) string {

--- a/internal/enrichment/trace_test.go
+++ b/internal/enrichment/trace_test.go
@@ -31,6 +31,10 @@ func (m *captureLLM) enrichFile(_ context.Context, _ string, issues []issueConte
 	return out, nil
 }
 
+func (m *captureLLM) reviseResult(_ context.Context, _ string, _ issueContext, priorReplacement, _ string) (string, error) {
+	return priorReplacement, nil
+}
+
 // fakeTraces returns canned stats and records which tools were looked up.
 type fakeTraces struct {
 	mu    sync.Mutex

--- a/internal/enrichment/validate.go
+++ b/internal/enrichment/validate.go
@@ -1,0 +1,90 @@
+package enrichment
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/trustabl/trustabl/internal/analysis/astutil"
+)
+
+// validateSyntax reports whether content parses cleanly as the language
+// implied by filePath's extension. An extension with no check at all returns
+// nil (skip, don't fail closed) rather than rejecting a language this check
+// can't judge.
+func validateSyntax(ctx context.Context, filePath, content string) error {
+	if strings.ToLower(filepath.Ext(filePath)) == ".py" {
+		// tree-sitter's grammar has no rule against a call repeating a
+		// keyword argument — that's a CPython compile-time check, not a
+		// parse-tree shape, so HasError() misses it (a real generated fix
+		// duplicated an entire argument list instead of adding one keyword
+		// and tree-sitter waved it through). compile() is a strict superset
+		// of what the grammar checks, so where it's available it replaces
+		// tree-sitter for Python rather than supplementing it. Same
+		// technique as trustabl-service's ApplyEnrichment syntax check
+		// (pr.go's runPyCompile).
+		if err, ok := validatePythonCompile(ctx, content); ok {
+			return err
+		}
+		// No python interpreter on PATH — fall back to tree-sitter below
+		// rather than skipping validation for Python entirely.
+	}
+
+	var parser *sitter.Parser
+	switch strings.ToLower(filepath.Ext(filePath)) {
+	case ".py":
+		parser = astutil.NewPyParser()
+	case ".go":
+		parser = astutil.NewGoParser()
+	case ".ts":
+		parser = astutil.NewTSParser()
+	case ".tsx":
+		parser = astutil.NewTSXParser()
+	case ".cs":
+		parser = astutil.NewCSharpParser()
+	case ".php":
+		parser = astutil.NewPHPParser()
+	case ".rs":
+		parser = astutil.NewRustParser()
+	default:
+		return nil
+	}
+
+	tree, err := astutil.ParseCtxTimeout(ctx, parser, []byte(content))
+	if err != nil {
+		return fmt.Errorf("parse failed: %w", err)
+	}
+	if tree.RootNode().HasError() {
+		return fmt.Errorf("generated replacement does not parse as valid %s", filepath.Ext(filePath))
+	}
+	return nil
+}
+
+// validatePythonCompile compiles content with a real Python interpreter's
+// compile() builtin — in-memory only, no file written to disk. ok is false
+// when no python3/python interpreter is on PATH, telling the caller to fall
+// back to the tree-sitter check instead; ok is true otherwise, with err
+// giving the actual verdict (nil = valid).
+func validatePythonCompile(ctx context.Context, content string) (err error, ok bool) {
+	pythonBin := "python3"
+	if _, lookErr := exec.LookPath(pythonBin); lookErr != nil {
+		pythonBin = "python"
+		if _, lookErr := exec.LookPath(pythonBin); lookErr != nil {
+			return nil, false
+		}
+	}
+
+	var stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, pythonBin, "-c",
+		"import sys\ncompile(sys.stdin.read(), '<enrichment>', 'exec')\n")
+	cmd.Stdin = strings.NewReader(content)
+	cmd.Stderr = &stderr
+	if runErr := cmd.Run(); runErr != nil {
+		return fmt.Errorf("generated replacement is not valid Python: %s", strings.TrimSpace(stderr.String())), true
+	}
+	return nil, true
+}

--- a/internal/enrichment/validate_test.go
+++ b/internal/enrichment/validate_test.go
@@ -1,0 +1,58 @@
+package enrichment
+
+import (
+	"context"
+	"testing"
+)
+
+func TestValidateSyntax_ValidGo(t *testing.T) {
+	src := "package main\n\nfunc main() {\n\tprintln(\"hi\")\n}\n"
+	if err := validateSyntax(context.Background(), "main.go", src); err != nil {
+		t.Errorf("validateSyntax() = %v, want nil for valid Go", err)
+	}
+}
+
+func TestValidateSyntax_InvalidGo(t *testing.T) {
+	src := "package main\n\nfunc main() {\n\tprintln(\"hi\"\n" // missing closing paren and brace
+	if err := validateSyntax(context.Background(), "main.go", src); err == nil {
+		t.Error("validateSyntax() = nil, want error for invalid Go")
+	}
+}
+
+func TestValidateSyntax_ValidPython(t *testing.T) {
+	src := "def run():\n    agent = Agent(input_guardrails=[g])\n    return agent\n"
+	if err := validateSyntax(context.Background(), "agent.py", src); err != nil {
+		t.Errorf("validateSyntax() = %v, want nil for valid Python", err)
+	}
+}
+
+func TestValidateSyntax_InvalidPython(t *testing.T) {
+	src := "def run(:\n    agent = Agent(\n    return agent\n" // unmatched parens
+	if err := validateSyntax(context.Background(), "agent.py", src); err == nil {
+		t.Error("validateSyntax() = nil, want error for invalid Python")
+	}
+}
+
+// TestValidateSyntax_InvalidPython_DuplicateKeywordArgument reproduces a real
+// enrichment PR: the LLM duplicated an entire call's keyword arguments
+// instead of adding one new one. tree-sitter's grammar has no rule against
+// repeating a keyword argument — that's a CPython compile-time check, not a
+// parse-tree shape — so HasError() misses it. python3's own compile() does
+// not: it raises "SyntaxError: keyword argument repeated: name".
+func TestValidateSyntax_InvalidPython_DuplicateKeywordArgument(t *testing.T) {
+	src := "agent = Agent(\n" +
+		"    name=\"x\",\n" +
+		"    name=\"x\",\n" +
+		")\n"
+	if err := validateSyntax(context.Background(), "agent.py", src); err == nil {
+		t.Error("validateSyntax() = nil, want error for Python with a repeated keyword argument")
+	}
+}
+
+func TestValidateSyntax_UnsupportedExtension(t *testing.T) {
+	// No grammar for .rb — must skip (nil), not fail closed.
+	src := "def run\n  agent = Agent.new(\nend\n" // deliberately broken Ruby
+	if err := validateSyntax(context.Background(), "agent.rb", src); err != nil {
+		t.Errorf("validateSyntax() = %v, want nil (unsupported extension skips validation)", err)
+	}
+}

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -19,6 +19,11 @@ var defaultModels = map[string]string{
 	"anthropic": "claude-haiku-4-5",
 	"openai":    "gpt-4.1-nano",
 	"google":    "gemini-2.5-flash-lite",
+	// "custom" (a self-hosted OpenAI-compatible endpoint) has no fixed
+	// default — the model name is meaningless without knowing what the
+	// endpoint serves, so it must always be set explicitly (TRUSTABL_LLM_MODEL
+	// or `trustabl llm model set`).
+	"custom": "",
 }
 
 // IsKnownProvider reports whether Trustabl ships a default model for provider
@@ -52,6 +57,9 @@ type Config struct {
 type Provider struct {
 	Model string `json:"model"`
 	Key   string `json:"key"`
+	// BaseURL overrides the API endpoint. Only meaningful for "custom" (a
+	// self-hosted OpenAI-compatible server); other providers ignore it.
+	BaseURL string `json:"base_url,omitempty"`
 }
 
 // ActiveProvider returns the Provider entry for the active provider name.
@@ -89,6 +97,17 @@ func (c *Config) SetModel(model string) {
 	c.Providers[c.Active] = p
 }
 
+// SetBaseURL sets the API base URL for the active provider. Only meaningful
+// for "custom" — points a self-hosted OpenAI-compatible server.
+func (c *Config) SetBaseURL(baseURL string) {
+	if c.Providers == nil {
+		c.Providers = make(map[string]Provider)
+	}
+	p := c.Providers[c.Active]
+	p.BaseURL = baseURL
+	c.Providers[c.Active] = p
+}
+
 // SetActive sets the active provider, auto-creating its entry with a default
 // model if it does not already exist. Existing entries are never overwritten.
 func (c *Config) SetActive(provider string) {
@@ -107,6 +126,20 @@ func Load() (*Config, error) {
 	if key := os.Getenv("ANTHROPIC_API_KEY"); key != "" {
 		cfg := defaults()
 		cfg.SetKey(key)
+		if m := os.Getenv("TRUSTABL_LLM_MODEL"); m != "" {
+			cfg.SetModel(m)
+		}
+		return cfg, nil
+	}
+	// A custom OpenAI-compatible endpoint (self-hosted or local model server)
+	// is signaled by OPENAI_BASE_URL alone — checked ahead of the plain
+	// OPENAI_API_KEY branch below because such endpoints often need no key at
+	// all, so this must not gate on OPENAI_API_KEY being set.
+	if baseURL := os.Getenv("OPENAI_BASE_URL"); baseURL != "" {
+		cfg := defaults()
+		cfg.SetActive("custom")
+		cfg.SetKey(os.Getenv("OPENAI_API_KEY"))
+		cfg.SetBaseURL(baseURL)
 		if m := os.Getenv("TRUSTABL_LLM_MODEL"); m != "" {
 			cfg.SetModel(m)
 		}

--- a/internal/llm/llm_test.go
+++ b/internal/llm/llm_test.go
@@ -343,7 +343,7 @@ func TestIsKnownProvider(t *testing.T) {
 
 func TestKnownProviders_SortedAndComplete(t *testing.T) {
 	got := llm.KnownProviders()
-	want := []string{"anthropic", "google", "openai"}
+	want := []string{"anthropic", "custom", "google", "openai"}
 	if len(got) != len(want) {
 		t.Fatalf("KnownProviders() = %v, want %v", got, want)
 	}
@@ -411,6 +411,71 @@ func TestLoad_EnvVarKey_Google(t *testing.T) {
 	}
 	if p.Model != "gemini-2.5-flash-lite" {
 		t.Errorf("Model = %q, want gemini-2.5-flash-lite", p.Model)
+	}
+}
+
+func TestLoad_EnvVarBaseURL_Custom(t *testing.T) {
+	setConfigDir(t, t.TempDir())
+	t.Setenv("OPENAI_BASE_URL", "http://10.8.0.1:4000")
+	t.Setenv("OPENAI_API_KEY", "sk-local-AAAAAAAAAAAAAAAAAAAAAA")
+	t.Setenv("TRUSTABL_LLM_MODEL", "qwen-32b")
+
+	cfg, err := llm.Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.Active != "custom" {
+		t.Errorf("Active = %q, want custom", cfg.Active)
+	}
+	p := cfg.ActiveProvider()
+	if p.Key != "sk-local-AAAAAAAAAAAAAAAAAAAAAA" {
+		t.Errorf("Key = %q, want sk-local-AAAAAAAAAAAAAAAAAAAAAA", p.Key)
+	}
+	if p.BaseURL != "http://10.8.0.1:4000" {
+		t.Errorf("BaseURL = %q, want http://10.8.0.1:4000", p.BaseURL)
+	}
+	if p.Model != "qwen-32b" {
+		t.Errorf("Model = %q, want qwen-32b", p.Model)
+	}
+}
+
+// A self-hosted endpoint often needs no key at all — this must not be
+// mistaken for "not configured" (see the OPENAI_API_KEY != "" branch below).
+func TestLoad_EnvVarBaseURL_CustomNoKey(t *testing.T) {
+	setConfigDir(t, t.TempDir())
+	t.Setenv("OPENAI_BASE_URL", "http://10.8.0.1:4000")
+	t.Setenv("TRUSTABL_LLM_MODEL", "qwen-32b")
+
+	cfg, err := llm.Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.Active != "custom" {
+		t.Errorf("Active = %q, want custom", cfg.Active)
+	}
+	p := cfg.ActiveProvider()
+	if p.Key != "" {
+		t.Errorf("Key = %q, want empty", p.Key)
+	}
+	if p.BaseURL != "http://10.8.0.1:4000" {
+		t.Errorf("BaseURL = %q, want http://10.8.0.1:4000", p.BaseURL)
+	}
+}
+
+// OPENAI_BASE_URL is the unambiguous signal for "custom" — it must win over
+// the plain OPENAI_API_KEY branch even when both are set, or a custom
+// endpoint would silently fall back to hosted OpenAI.
+func TestLoad_EnvVarBaseURL_TakesPriorityOverPlainOpenAI(t *testing.T) {
+	setConfigDir(t, t.TempDir())
+	t.Setenv("OPENAI_API_KEY", "sk-proj-AAAAAAAAAAAAAAAAAAAAAA")
+	t.Setenv("OPENAI_BASE_URL", "http://10.8.0.1:4000")
+
+	cfg, err := llm.Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.Active != "custom" {
+		t.Errorf("Active = %q, want custom", cfg.Active)
 	}
 }
 


### PR DESCRIPTION
## Summary

  Two changes riding together on this branch:

  ### 1. Validate & correct generated fixes (internal/enrichment/validate.go, correction_test.go, pipeline.go)
  Enrichment now syntax-checks the LLM's generated replacement before treating
  it as usable, and asks the LLM for one correction pass if that check fails,
  instead of surfacing the broken patch straight to the user. *(Pre-existing
  work on this branch.

  ### 2. Custom LLM provider support (internal/llm, internal/enrichment/llm.go, cmd/trustabl/enrich.go, cmd/trustabl/llm.go)
  `trustabl enrich` can now target any self-hosted OpenAI-compatible endpoint
  (LiteLLM, vLLM, a local model server) as a fourth provider, `custom`

  - `OPENAI_BASE_URL` env var activates `custom`, ahead of a plain
    `OPENAI_API_KEY` — no key required, since self-hosted endpoints often don't
    check one.
  - New `trustabl llm base-url set <url>` command persists the same to
    `~/.config/trustabl/keys.json`, alongside the existing `key set`/`model set`.
    `trustabl llm list` shows the new BASE URL column.
  - `newLLMClient` wires the URL into the OpenAI SDK via `option.WithBaseURL`.

  ## Testing
  - Full `go build` / `go vet` / `go test ./...` clean.
  - New unit coverage: `Load()` env-var priority (`OPENAI_BASE_URL` over plain
    `OPENAI_API_KEY`, no-key case), `newLLMClient` custom-provider construction,
    `base-url set` command (including the non-custom-provider warning path).
  - Verified against a real compiled binary and a real local endpoint
    (qwen-32b on a self-hosted box) through the Trustabl web app's Integrations
    settings - enrichment completed successfully end-to-end.

  ## Docs
  README.md, ARCHITECTURE.md §10, CHANGELOG.md updated per this repo's
  docs-are-part-of-the-change rule.