### PR TITLE
fix(scan): show an empty state instead of 100% when nothing is analyz…

### DIFF
--- a/cmd/trustabl/main_test.go
+++ b/cmd/trustabl/main_test.go
@@ -387,3 +387,27 @@ func TestValidateOutputFlags(t *testing.T) {
 		})
 	}
 }
+
+// TestExitCode_StrictFailsEmptyScan covers the case where a scan evaluated
+// nothing at all. Under --strict that must fail: a mistyped path or a moved
+// source tree would otherwise leave the gate permanently green, and a passing
+// build is never investigated. Without --strict it stays a pass, because
+// scanning a repo that legitimately has no agent code is not an error.
+func TestExitCode_StrictFailsEmptyScan(t *testing.T) {
+	empty := models.ScanResult{NoAgentSurfaces: true}
+
+	if got := exitCode(empty, true); got != 1 {
+		t.Errorf("exitCode(empty, strict=true) = %d, want 1", got)
+	}
+	if got := exitCode(empty, false); got != 0 {
+		t.Errorf("exitCode(empty, strict=false) = %d, want 0", got)
+	}
+
+	// A repo with surfaces and no findings must still pass under --strict.
+	clean := models.ScanResult{
+		Surfaces: []models.SurfaceReadiness{{Kind: models.ScopeTool, Name: "t", Score: 1}},
+	}
+	if got := exitCode(clean, true); got != 0 {
+		t.Errorf("exitCode(clean repo, strict=true) = %d, want 0", got)
+	}
+}

--- a/cmd/trustabl/scan.go
+++ b/cmd/trustabl/scan.go
@@ -777,6 +777,15 @@ func writeSideOutputs(result models.ScanResult, f scanFlags) error {
 }
 
 func exitCode(result models.ScanResult, strict bool) int {
+	// A scan that evaluated nothing is the worst thing to pass silently under
+	// --strict: a mistyped path or a moved source tree leaves the gate green
+	// forever, and nobody investigates a passing build. --strict means "I expect
+	// agent code here", so finding none is itself the failure. The default path
+	// is untouched: scanning a repo with no agents is not an error unless the
+	// caller asked for strictness.
+	if strict && result.NoAgentSurfaces {
+		return 1
+	}
 	for _, f := range result.Findings {
 		switch f.Severity {
 		case models.SeverityMedium, models.SeverityHigh, models.SeverityCritical:

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -524,6 +524,11 @@ type ScanResult struct {
 	RulesSkipped        []string           `json:"rules_skipped,omitempty"`        // rule IDs dropped as forward-incompatible (sorted, deduped)
 	RulesOrigin         RulesOrigin        `json:"rules_origin"`                   // provenance of the rules (signed channel / unsigned / custom)
 	Coverage            Coverage           `json:"coverage"`                       // how many source files parsed vs. were skipped
+	// NoAgentSurfaces marks a scan that found nothing to evaluate: no tools,
+	// agents, subagents or skills. Scoring an empty set yields 1.0, which reads
+	// as a perfect result when in fact nothing was checked, so consumers must be
+	// able to tell the two apart. OverallScore is left at 1.0 for compatibility.
+	NoAgentSurfaces bool `json:"no_agent_surfaces,omitempty"`
 }
 
 // EnrichedFinding extends Finding with AI-generated context and an optional

--- a/internal/review/diff.go
+++ b/internal/review/diff.go
@@ -161,7 +161,18 @@ func (r *Renderer) Render(result models.ScanResult) string {
 		}
 	}
 
-	fmt.Fprintf(&b, "  Overall score:      %s\n\n", scoreCell(result.OverallScore))
+	// Nothing to evaluate is not the same as everything passing. Scoring an
+	// empty surface set returns 1.0, so print an explicit empty state instead
+	// of a 100% that implies the repo was checked and found clean.
+	if result.NoAgentSurfaces {
+		fmt.Fprintf(&b, "  Overall score:      %s\n", styleDim.Render("n/a"))
+		fmt.Fprintf(&b, "  %s\n", styleMed.Render("No agent surfaces found - nothing was evaluated."))
+		fmt.Fprintf(&b, "      %s\n", styleDim.Render("Trustabl scores tools, agents, subagents and skills from the supported"))
+		fmt.Fprintf(&b, "      %s\n", styleDim.Render("SDKs. This repo has none, so there is no readiness score to report."))
+		fmt.Fprintf(&b, "      %s\n\n", styleDim.Render("Check the scanned path is correct and that your SDK is supported."))
+	} else {
+		fmt.Fprintf(&b, "  Overall score:      %s\n\n", scoreCell(result.OverallScore))
+	}
 
 	if len(result.Agents) > 0 {
 		b.WriteString(styleHeader.Render("Agents") + "\n")

--- a/internal/review/diff_test.go
+++ b/internal/review/diff_test.go
@@ -447,3 +447,49 @@ func TestRender_RulesSkippedShownAsDegraded(t *testing.T) {
 		t.Errorf("a clean scan must not show a skipped-rules line:\n%s", clean)
 	}
 }
+
+// TestRender_EmptyScanShowsEmptyState is the regression test for the bug where
+// scanning a repo with no agent surfaces reported "100%". Scoring an empty
+// surface set returns 1.0, so a repo containing no tools, agents, subagents or
+// skills rendered as a perfect result when in fact nothing had been evaluated.
+// The human format must say so rather than print a passing score.
+func TestRender_EmptyScanShowsEmptyState(t *testing.T) {
+	result := models.ScanResult{
+		Repo:            "./empty",
+		OverallScore:    1.0, // what scoring returns for an empty surface set
+		NoAgentSurfaces: true,
+	}
+
+	out := (&review.Renderer{NoColor: true}).Render(result)
+
+	if !strings.Contains(out, "No agent surfaces found") {
+		t.Errorf("empty scan must state that nothing was evaluated; got:\n%s", out)
+	}
+	if !strings.Contains(out, "Overall score:      n/a") {
+		t.Errorf("empty scan must not report a numeric score; got:\n%s", out)
+	}
+	if strings.Contains(out, "100%") {
+		t.Errorf("empty scan must never render 100%%; got:\n%s", out)
+	}
+}
+
+// A repo that does have surfaces must still render its score, so the empty
+// state cannot mask real results.
+func TestRender_NonEmptyScanStillShowsScore(t *testing.T) {
+	result := models.ScanResult{
+		Repo:         "./fixture",
+		OverallScore: 0.96,
+		Surfaces: []models.SurfaceReadiness{
+			{Kind: models.ScopeTool, Name: "search", FilePath: "tools.py", Score: 0.96},
+		},
+	}
+
+	out := (&review.Renderer{NoColor: true}).Render(result)
+
+	if strings.Contains(out, "No agent surfaces found") {
+		t.Errorf("a scan with surfaces must not show the empty state; got:\n%s", out)
+	}
+	if !strings.Contains(out, "96%") {
+		t.Errorf("a scan with surfaces must render its score; got:\n%s", out)
+	}
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -563,6 +563,9 @@ func Run(cfg Config) (models.ScanResult, error) {
 		RulesSkipped:        sortedUnique(rulesSkipped),
 		RulesOrigin:         cfg.RulesOrigin,
 		Coverage:            coverage,
+		// An empty surface set means nothing was evaluated. Flag it so a
+		// score of 1.0 is not mistaken for a clean bill of health.
+		NoAgentSurfaces: len(surfaces) == 0,
 	}, nil
 }
 


### PR DESCRIPTION
show an empty state instead of 100% when nothing is analyzable

Scoring an empty surface set returns 1.0, so scanning a repo with no tools, agents, subagents or skills reported a perfect score and a passing result when in fact nothing had been evaluated. A user pointed a scan at a repo containing no agent code and got back 100%, which reads as a clean bill of health.

The human report now prints an explicit empty state, and ScanResult carries NoAgentSurfaces so machine consumers can tell 'nothing found' apart from 'nothing wrong'.

OverallScore is deliberately left at 1.0: the CI plugins parse it and compute risk as 100 - score, so returning 0 would flip every empty scan from pass to fail and break those pipelines. The new flag is additive and omitempty, so no existing consumer changes behaviour.

<img width="688" height="356" alt="image" src="https://github.com/user-attachments/assets/876a1cf2-b762-404d-89bb-fc69cec60dc5" />
