### PR TITLE
feat(analysis): add agent execution-limit discovery for OpenAI/Pydantic AI

### DIFF
--- a/internal/analysis/agent_run_calls.go
+++ b/internal/analysis/agent_run_calls.go
@@ -1,0 +1,177 @@
+package analysis
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/trustabl/trustabl/internal/analysis/astutil"
+	"github.com/trustabl/trustabl/internal/models"
+)
+
+// Agent execution-call discovery: OpenAI Agents SDK and Pydantic AI.
+//
+// Execution limits (max_turns for OpenAI Agents SDK, usage_limits for
+// Pydantic AI) are set on the call that RUNS an agent, not on the agent's
+// constructor — Runner.run(agent, ..., max_turns=N) / agent.run(...,
+// usage_limits=UsageLimits(...)). Neither is visible to DiscoverAgents /
+// DiscoverPydanticAIAgents, which only capture the constructor call. This
+// file adds a second, independent discovery pass over the same call-node
+// shape so agent-scope rules can correlate a specific AgentDef to the call
+// that executes it (by same-file VarName), mirroring how
+// DiscoverClaudeAgentOptions captures ClaudeAgentOptions(...) constructions
+// separately from agent discovery.
+//
+// The two SDKs need different discriminators:
+//
+//   - OpenAI Agents SDK: Runner is a fixed class (imported from `agents`),
+//     so the callee is matched by requiring the attribute's object be
+//     exactly "Runner" or end in ".Runner" (e.g. `agents.Runner.run(...)`).
+//     Matching on a suffix of the whole callee text (e.g. "Runner.run")
+//     would false-positive on any unrelated class merely named *Runner
+//     (TaskRunner.run(), TestRunner.run(), ...) — the object segment must
+//     match exactly, not just the tail of the dotted string. The agent
+//     being run is the call's first positional argument (mirrors
+//     Runner.run(starting_agent, input, ...)).
+//
+//   - Pydantic AI: `<agent>.run(...)` is a bare method call on an
+//     arbitrary local variable — there is no fixed class name to match, so
+//     the agent being run is the method's RECEIVER, not a positional
+//     argument (unlike OpenAI). Over-capturing here is safe: a call whose
+//     receiver name doesn't correspond to any discovered PydanticAgent
+//     VarName in the same file simply never correlates in a downstream
+//     predicate (same same-file-VarName-only limitation ClaudeAgentOptions
+//     and other call-capture discoverers already accept). The file-level
+//     `fileImportsPydanticAI` gate keeps this from firing in files that
+//     never touch Pydantic AI at all.
+//
+// Both discoverers require the first positional arg (OpenAI) / receiver
+// (Pydantic AI) to be a plain identifier, silently skipping anything else
+// (a call expression, an attribute access, a keyword arg), mirroring
+// adk_agents.go's DiscoverADKTools.
+
+// openAIRunnerMethods is the closed set of Runner class methods that execute
+// an agent and accept max_turns.
+var openAIRunnerMethods = map[string]bool{
+	"run": true, "run_sync": true, "run_streamed": true,
+}
+
+// pydanticAIRunMethods is the closed set of Agent instance methods that
+// execute an agent and accept usage_limits.
+var pydanticAIRunMethods = map[string]bool{
+	"run": true, "run_sync": true, "run_stream": true,
+}
+
+// DiscoverAgentRunCalls walks each ParsedFile and emits one AgentRunCallDef
+// per recognized Runner.run-family call (OpenAI Agents SDK) or
+// <agent>.run-family call (Pydantic AI). Purely additive: it does not modify
+// or depend on the AgentDef list produced by DiscoverAgents /
+// DiscoverPydanticAIAgents, only on the same-file VarName convention they
+// already populate.
+func DiscoverAgentRunCalls(files []ParsedFile) []models.AgentRunCallDef {
+	var out []models.AgentRunCallDef
+	for _, pf := range files {
+		importsOpenAI := fileImportsOpenAIAgentsSDK(pf)
+		importsPydantic := fileImportsPydanticAI(pf)
+		if !importsOpenAI && !importsPydantic {
+			continue
+		}
+		out = append(out, discoverAgentRunCallsInFile(pf, importsOpenAI, importsPydantic)...)
+	}
+	return out
+}
+
+// isOpenAIAgentsModule reports whether a dotted module path belongs to the
+// OpenAI Agents SDK: `agents`, `agents.*`. Mirrors isPydanticAIModule.
+func isOpenAIAgentsModule(mod string) bool {
+	return mod == "agents" || strings.HasPrefix(mod, "agents.")
+}
+
+// fileImportsOpenAIAgentsSDK reports whether pf imports the OpenAI Agents SDK
+// via a real import statement (AST-based, not a source substring).
+func fileImportsOpenAIAgentsSDK(pf ParsedFile) bool {
+	return fileImportsModule(pf, isOpenAIAgentsModule)
+}
+
+func discoverAgentRunCallsInFile(pf ParsedFile, importsOpenAI, importsPydantic bool) []models.AgentRunCallDef {
+	var out []models.AgentRunCallDef
+	astutil.Walk(pf.Tree.RootNode(), func(n *sitter.Node) bool {
+		if n.Type() != "call" {
+			return true
+		}
+		fn := n.ChildByFieldName("function")
+		if fn == nil || fn.Type() != "attribute" {
+			return true
+		}
+		attr := fn.ChildByFieldName("attribute")
+		obj := fn.ChildByFieldName("object")
+		if attr == nil || obj == nil {
+			return true
+		}
+		method := astutil.NodeText(attr, pf.Source)
+
+		if importsOpenAI && openAIRunnerMethods[method] && isRunnerObject(obj, pf) {
+			if rc, ok := buildOpenAIRunCall(n, fn, pf); ok {
+				out = append(out, rc)
+			}
+			return true
+		}
+		if importsPydantic && pydanticAIRunMethods[method] && obj.Type() == "identifier" {
+			out = append(out, buildPydanticRunCall(n, obj, method, pf))
+		}
+		return true
+	})
+	return out
+}
+
+// isRunnerObject reports whether the attribute's object segment is exactly
+// "Runner" or a dotted-qualified access ending in ".Runner" (e.g.
+// `agents.Runner`). Deliberately NOT a suffix check on the whole callee text
+// — that would also match an unrelated TaskRunner.run() / TestRunner.run().
+func isRunnerObject(obj *sitter.Node, pf ParsedFile) bool {
+	text := astutil.NodeText(obj, pf.Source)
+	return text == "Runner" || strings.HasSuffix(text, ".Runner")
+}
+
+func buildOpenAIRunCall(n, fn *sitter.Node, pf ParsedFile) (models.AgentRunCallDef, bool) {
+	args := n.ChildByFieldName("arguments")
+	if args == nil || args.NamedChildCount() == 0 {
+		return models.AgentRunCallDef{}, false
+	}
+	first := args.NamedChild(0)
+	// Only a positional identifier is resolvable (e.g. Runner.run(my_agent, ...)).
+	// Anything else (Runner.run(get_agent()), Runner.run(agent=my_agent)) is
+	// silently skipped — those cannot be correlated to an AgentDef by name.
+	if first.Type() != "identifier" {
+		return models.AgentRunCallDef{}, false
+	}
+	kwargs, opaque := extractCallKwargs(n, pf.Source)
+	return models.AgentRunCallDef{
+		SDK:          models.SDKOpenAIAgents,
+		Callee:       astutil.NodeText(fn, pf.Source),
+		AgentVarName: astutil.NodeText(first, pf.Source),
+		Location: models.Location{
+			FilePath: pf.RelPath,
+			Line:     int(n.StartPoint().Row) + 1,
+			EndLine:  int(n.EndPoint().Row) + 1,
+		},
+		Kwargs: kwargs,
+		Opaque: opaque,
+	}, true
+}
+
+func buildPydanticRunCall(n, obj *sitter.Node, method string, pf ParsedFile) models.AgentRunCallDef {
+	kwargs, opaque := extractCallKwargs(n, pf.Source)
+	return models.AgentRunCallDef{
+		SDK:          models.SDKPydanticAI,
+		Callee:       astutil.NodeText(obj, pf.Source) + "." + method,
+		AgentVarName: astutil.NodeText(obj, pf.Source),
+		Location: models.Location{
+			FilePath: pf.RelPath,
+			Line:     int(n.StartPoint().Row) + 1,
+			EndLine:  int(n.EndPoint().Row) + 1,
+		},
+		Kwargs: kwargs,
+		Opaque: opaque,
+	}
+}

--- a/internal/analysis/agent_run_calls_test.go
+++ b/internal/analysis/agent_run_calls_test.go
@@ -1,0 +1,186 @@
+package analysis_test
+
+import (
+	"testing"
+
+	"github.com/trustabl/trustabl/internal/analysis"
+	"github.com/trustabl/trustabl/internal/models"
+)
+
+func TestDiscoverAgentRunCalls_OpenAI_CapturesMaxTurns(t *testing.T) {
+	src := `from agents import Agent, Runner
+
+agent = Agent(name="x")
+
+async def main():
+    result = await Runner.run(agent, "hi", max_turns=5)
+`
+	calls := analysis.DiscoverAgentRunCalls([]analysis.ParsedFile{parsePyFile(t, "main.py", src)})
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 run call, got %d: %+v", len(calls), calls)
+	}
+	rc := calls[0]
+	if rc.SDK != models.SDKOpenAIAgents {
+		t.Errorf("SDK = %q, want %q", rc.SDK, models.SDKOpenAIAgents)
+	}
+	if rc.AgentVarName != "agent" {
+		t.Errorf("AgentVarName = %q, want %q", rc.AgentVarName, "agent")
+	}
+	if rc.Kwargs == nil || rc.Kwargs.Children["max_turns"] == nil {
+		t.Fatalf("max_turns kwarg not captured: %+v", rc)
+	}
+	if rc.FilePath != "main.py" || rc.Line == 0 {
+		t.Errorf("unexpected location: %+v", rc.Location)
+	}
+}
+
+func TestDiscoverAgentRunCalls_OpenAI_SilentWhenMaxTurnsAbsent(t *testing.T) {
+	src := `from agents import Agent, Runner
+
+agent = Agent(name="x")
+
+async def main():
+    result = await Runner.run(agent, "hi")
+`
+	calls := analysis.DiscoverAgentRunCalls([]analysis.ParsedFile{parsePyFile(t, "main.py", src)})
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 run call, got %d", len(calls))
+	}
+	if calls[0].Kwargs != nil && calls[0].Kwargs.Children["max_turns"] != nil {
+		t.Errorf("expected no max_turns kwarg, got %+v", calls[0].Kwargs)
+	}
+}
+
+func TestDiscoverAgentRunCalls_OpenAI_RunSyncAndRunStreamed(t *testing.T) {
+	src := `from agents import Agent, Runner
+
+agent = Agent(name="x")
+result = Runner.run_sync(agent, "hi", max_turns=3)
+streamed = Runner.run_streamed(agent, "hi")
+`
+	calls := analysis.DiscoverAgentRunCalls([]analysis.ParsedFile{parsePyFile(t, "main.py", src)})
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 run calls, got %d: %+v", len(calls), calls)
+	}
+}
+
+func TestDiscoverAgentRunCalls_OpenAI_UnrelatedRunnerClassNotMatched(t *testing.T) {
+	// TaskRunner.run(...) must not match: the object segment is "TaskRunner",
+	// not "Runner" — a suffix check on the whole callee text would wrongly
+	// match this (isRunnerObject guards against exactly this).
+	src := `from agents import Agent
+
+agent = Agent(name="x")
+
+class TaskRunner:
+    pass
+
+TaskRunner.run(agent, "hi", max_turns=1)
+`
+	calls := analysis.DiscoverAgentRunCalls([]analysis.ParsedFile{parsePyFile(t, "main.py", src)})
+	if len(calls) != 0 {
+		t.Fatalf("expected 0 run calls (TaskRunner is not Runner), got %d: %+v", len(calls), calls)
+	}
+}
+
+func TestDiscoverAgentRunCalls_OpenAI_SilentWhenFirstArgNotIdentifier(t *testing.T) {
+	src := `from agents import Agent, Runner
+
+async def main():
+    result = await Runner.run(get_agent(), "hi", max_turns=5)
+`
+	calls := analysis.DiscoverAgentRunCalls([]analysis.ParsedFile{parsePyFile(t, "main.py", src)})
+	if len(calls) != 0 {
+		t.Fatalf("expected 0 run calls (non-identifier first arg), got %d: %+v", len(calls), calls)
+	}
+}
+
+func TestDiscoverAgentRunCalls_PydanticAI_CapturesUsageLimits(t *testing.T) {
+	src := `from pydantic_ai import Agent
+from pydantic_ai.usage import UsageLimits
+
+agent = Agent("openai:gpt-4o")
+
+async def main():
+    result = await agent.run("hi", usage_limits=UsageLimits(request_limit=5))
+`
+	calls := analysis.DiscoverAgentRunCalls([]analysis.ParsedFile{parsePyFile(t, "main.py", src)})
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 run call, got %d: %+v", len(calls), calls)
+	}
+	rc := calls[0]
+	if rc.SDK != models.SDKPydanticAI {
+		t.Errorf("SDK = %q, want %q", rc.SDK, models.SDKPydanticAI)
+	}
+	if rc.AgentVarName != "agent" {
+		t.Errorf("AgentVarName = %q, want %q", rc.AgentVarName, "agent")
+	}
+	if rc.Kwargs == nil || rc.Kwargs.Children["usage_limits"] == nil {
+		t.Fatalf("usage_limits kwarg not captured: %+v", rc)
+	}
+	ul := rc.Kwargs.Children["usage_limits"]
+	if ul.Value == nil || ul.Value.Kind != models.ExprCall {
+		t.Fatalf("usage_limits value not a call expr: %+v", ul.Value)
+	}
+}
+
+func TestDiscoverAgentRunCalls_PydanticAI_SilentWhenUsageLimitsAbsent(t *testing.T) {
+	src := `from pydantic_ai import Agent
+
+agent = Agent("openai:gpt-4o")
+
+async def main():
+    result = await agent.run("hi")
+`
+	calls := analysis.DiscoverAgentRunCalls([]analysis.ParsedFile{parsePyFile(t, "main.py", src)})
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 run call, got %d", len(calls))
+	}
+	if calls[0].Kwargs != nil && calls[0].Kwargs.Children["usage_limits"] != nil {
+		t.Errorf("expected no usage_limits kwarg, got %+v", calls[0].Kwargs)
+	}
+}
+
+func TestDiscoverAgentRunCalls_PydanticAI_RunSyncAndRunStream(t *testing.T) {
+	src := `from pydantic_ai import Agent
+
+agent = Agent("openai:gpt-4o")
+result = agent.run_sync("hi")
+with agent.run_stream("hi") as stream:
+    pass
+`
+	calls := analysis.DiscoverAgentRunCalls([]analysis.ParsedFile{parsePyFile(t, "main.py", src)})
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 run calls, got %d: %+v", len(calls), calls)
+	}
+}
+
+func TestDiscoverAgentRunCalls_PydanticAI_SilentWhenReceiverNotIdentifier(t *testing.T) {
+	src := `from pydantic_ai import Agent
+
+class Service:
+    def __init__(self):
+        self.agent = Agent("openai:gpt-4o")
+
+    async def go(self):
+        return await self.agent.run("hi")
+`
+	calls := analysis.DiscoverAgentRunCalls([]analysis.ParsedFile{parsePyFile(t, "main.py", src)})
+	if len(calls) != 0 {
+		t.Fatalf("expected 0 run calls (self.agent receiver is not a plain identifier), got %d: %+v", len(calls), calls)
+	}
+}
+
+func TestDiscoverAgentRunCalls_SilentWhenNeitherSDKImported(t *testing.T) {
+	src := `class Db:
+    def run(self, query):
+        return query
+
+db = Db()
+db.run("select 1")
+`
+	calls := analysis.DiscoverAgentRunCalls([]analysis.ParsedFile{parsePyFile(t, "main.py", src)})
+	if len(calls) != 0 {
+		t.Fatalf("expected 0 run calls (file imports neither SDK), got %d: %+v", len(calls), calls)
+	}
+}

--- a/internal/models/agent.go
+++ b/internal/models/agent.go
@@ -320,3 +320,23 @@ type ClaudeAgentOptionsDef struct {
 	Kwargs *KwargTree `json:"-"`
 	Opaque bool       `json:"opaque,omitempty"`
 }
+
+// AgentRunCallDef is one execution call discovered in code that actually runs
+// an agent: a Runner.run/run_sync/run_streamed call (OpenAI Agents SDK) or an
+// <agent>.run/run_sync/run_stream call (Pydantic AI). Execution limits like
+// max_turns or usage_limits are set at this call site, not at the agent's
+// constructor — ClaudeAgentOptionsDef-style construction-site capture can't
+// see them. AgentVarName is the resolved identifier naming the agent this
+// call runs (the first positional arg for Runner.run, the method receiver for
+// <agent>.run), so agent-scope rules can correlate a specific AgentDef (by
+// same-file FilePath+VarName) against the call that executes it. Kwargs is an
+// in-memory carrier (not serialized); Opaque is true when the call used **
+// unpacking that makes the kwarg set untrustworthy.
+type AgentRunCallDef struct {
+	Location
+	SDK          SDK        `json:"sdk"`
+	Callee       string     `json:"callee"` // raw callee text, e.g. "Runner.run", "agent.run_sync"
+	AgentVarName string     `json:"-"`
+	Kwargs       *KwargTree `json:"-"`
+	Opaque       bool       `json:"opaque,omitempty"`
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -400,6 +400,7 @@ type RepoInventory struct {
 	PluginManifests    []PluginManifest        `json:"plugin_manifests"`
 	ClaudeSettings     []ClaudeSettings        `json:"claude_settings"`
 	ClaudeAgentOptions []ClaudeAgentOptionsDef `json:"claude_agent_options,omitempty"`
+	AgentRunCalls      []AgentRunCallDef       `json:"agent_run_calls,omitempty"`
 	SDKsDetected       []SDK                   `json:"sdks_detected"`
 	// HasShellInvocations is true if any discovered ToolDef is a
 	// KindShellInvocation (a Python function whose body calls

--- a/internal/rules/evaluator.go
+++ b/internal/rules/evaluator.go
@@ -66,6 +66,12 @@ func (e MatchExpr) EvaluateAgent(a models.AgentDef, inv models.RepoInventory) bo
 	if e.AgentHostedToolKwargValue != nil && !PredAgentHostedToolKwargValue(*e.AgentHostedToolKwargValue, a) {
 		return false
 	}
+	if e.AgentRunCallMaxTurnsMissing != nil && PredAgentRunCallMaxTurnsMissing(a, inv) != *e.AgentRunCallMaxTurnsMissing {
+		return false
+	}
+	if e.AgentRunCallUsageLimitsMissing != nil && PredAgentRunCallUsageLimitsMissing(a, inv) != *e.AgentRunCallUsageLimitsMissing {
+		return false
+	}
 	return true
 }
 
@@ -373,6 +379,7 @@ var predicatesByScope = map[models.Scope]map[string]bool{
 		"agent_uses_hosted_tool_class":    true,
 		"agent_is_subagent_of_any":        true,
 		"agent_hosted_tool_kwarg_present": true, "agent_hosted_tool_kwarg_value": true,
+		"agent_run_call_max_turns_missing": true, "agent_run_call_usage_limits_missing": true,
 	},
 	models.ScopeSubagent: {
 		"subagent_grants_tool": true,
@@ -450,6 +457,8 @@ func (e MatchExpr) setPredicateNames() []string {
 	add(e.AgentIsSubagentOfAny != nil, "agent_is_subagent_of_any")
 	add(e.AgentHostedToolKwargPresent != nil, "agent_hosted_tool_kwarg_present")
 	add(e.AgentHostedToolKwargValue != nil, "agent_hosted_tool_kwarg_value")
+	add(e.AgentRunCallMaxTurnsMissing != nil, "agent_run_call_max_turns_missing")
+	add(e.AgentRunCallUsageLimitsMissing != nil, "agent_run_call_usage_limits_missing")
 	// Subagent scope
 	add(len(e.SubagentGrantsTool) > 0, "subagent_grants_tool")
 	// Skill scope

--- a/internal/rules/predicates.go
+++ b/internal/rules/predicates.go
@@ -799,6 +799,50 @@ func PredAgentIsSubagentOfAny(a models.AgentDef, inv models.RepoInventory) bool 
 	return false
 }
 
+// agentRunCallMissingKwarg fires when this AgentDef has a VarName, at least
+// one same-SDK, same-file, non-opaque AgentRunCallDef whose AgentVarName
+// resolves to it, and NONE of those matching run calls set kwarg. This is an
+// absence check across every matching run call for THIS agent specifically —
+// unlike PredRepoClaudeOptionsMaxTurnsMissing (repo-scoped, because
+// ClaudeAgentOptions configures a whole session), a Runner.run/agent.run call
+// names the exact agent it executes, so the correlation — and the finding —
+// is agent-scoped: two agents in the same repo can be in different execution-
+// limit postures, and flattening that to one repo-wide bool would lose the
+// attribution (see "Agent as the unit of analysis" in CLAUDE.md). An agent
+// with no VarName, or with no matching run call at all, never fires — no
+// resolvable execution site is not evidence that one is missing a cap.
+func agentRunCallMissingKwarg(a models.AgentDef, inv models.RepoInventory, sdk models.SDK, kwarg string) bool {
+	if a.SDK != sdk || a.VarName == "" {
+		return false
+	}
+	matched := false
+	for _, rc := range inv.AgentRunCalls {
+		if rc.SDK != sdk || rc.Opaque || rc.FilePath != a.FilePath || rc.AgentVarName != a.VarName {
+			continue
+		}
+		matched = true
+		if node := lookupKwargInTree(rc.Kwargs, kwarg); node != nil && node.Value != nil {
+			return false
+		}
+	}
+	return matched
+}
+
+// PredAgentRunCallMaxTurnsMissing fires when this OpenAI Agents SDK agent has
+// a resolvable Runner.run-family call and none of those calls set max_turns.
+// See agentRunCallMissingKwarg for the correlation and silence rules.
+func PredAgentRunCallMaxTurnsMissing(a models.AgentDef, inv models.RepoInventory) bool {
+	return agentRunCallMissingKwarg(a, inv, models.SDKOpenAIAgents, "max_turns")
+}
+
+// PredAgentRunCallUsageLimitsMissing fires when this Pydantic AI agent has a
+// resolvable <agent>.run-family call and none of those calls set
+// usage_limits. See agentRunCallMissingKwarg for the correlation and silence
+// rules.
+func PredAgentRunCallUsageLimitsMissing(a models.AgentDef, inv models.RepoInventory) bool {
+	return agentRunCallMissingKwarg(a, inv, models.SDKPydanticAI, "usage_limits")
+}
+
 // ─── subagent predicates ──────────────────────────────────────────────────────
 
 // PredSubagentGrantsTool reports whether the subagent grants any of names.

--- a/internal/rules/predicates_test.go
+++ b/internal/rules/predicates_test.go
@@ -1184,6 +1184,136 @@ func TestPredAgentIsSubagentOfAny(t *testing.T) {
 	}
 }
 
+func runCallKwargs(name, text string) *models.KwargTree {
+	return &models.KwargTree{
+		Children: map[string]*models.KwargTree{
+			name: {Value: &models.Expr{Kind: models.ExprLiteralInt, Text: text}},
+		},
+	}
+}
+
+func TestPredAgentRunCallMaxTurnsMissing(t *testing.T) {
+	agent := models.AgentDef{
+		SDK: models.SDKOpenAIAgents, Language: models.LanguagePython,
+		Location: models.Location{FilePath: "main.py"}, VarName: "agent",
+	}
+	cases := []struct {
+		name string
+		a    models.AgentDef
+		inv  models.RepoInventory
+		want bool
+	}{
+		{
+			"fires when the only matching run call sets no max_turns",
+			agent,
+			models.RepoInventory{AgentRunCalls: []models.AgentRunCallDef{
+				{SDK: models.SDKOpenAIAgents, Location: models.Location{FilePath: "main.py"}, AgentVarName: "agent"},
+			}},
+			true,
+		},
+		{
+			"silent when max_turns is set",
+			agent,
+			models.RepoInventory{AgentRunCalls: []models.AgentRunCallDef{
+				{SDK: models.SDKOpenAIAgents, Location: models.Location{FilePath: "main.py"}, AgentVarName: "agent", Kwargs: runCallKwargs("max_turns", "5")},
+			}},
+			false,
+		},
+		{
+			"silent when no run call matches this agent's VarName at all",
+			agent,
+			models.RepoInventory{AgentRunCalls: []models.AgentRunCallDef{
+				{SDK: models.SDKOpenAIAgents, Location: models.Location{FilePath: "main.py"}, AgentVarName: "other_agent"},
+			}},
+			false,
+		},
+		{
+			"silent when the matching call is in a different file",
+			agent,
+			models.RepoInventory{AgentRunCalls: []models.AgentRunCallDef{
+				{SDK: models.SDKOpenAIAgents, Location: models.Location{FilePath: "other.py"}, AgentVarName: "agent"},
+			}},
+			false,
+		},
+		{
+			"silent when the agent has no VarName",
+			models.AgentDef{SDK: models.SDKOpenAIAgents, Language: models.LanguagePython, Location: models.Location{FilePath: "main.py"}},
+			models.RepoInventory{AgentRunCalls: []models.AgentRunCallDef{
+				{SDK: models.SDKOpenAIAgents, Location: models.Location{FilePath: "main.py"}, AgentVarName: ""},
+			}},
+			false,
+		},
+		{
+			"silent when the matching call is opaque",
+			agent,
+			models.RepoInventory{AgentRunCalls: []models.AgentRunCallDef{
+				{SDK: models.SDKOpenAIAgents, Location: models.Location{FilePath: "main.py"}, AgentVarName: "agent", Opaque: true},
+			}},
+			false,
+		},
+		{
+			"never fires for a Pydantic AI agent, even with a matching-named OpenAI run call",
+			models.AgentDef{SDK: models.SDKPydanticAI, Language: models.LanguagePython, Location: models.Location{FilePath: "main.py"}, VarName: "agent"},
+			models.RepoInventory{AgentRunCalls: []models.AgentRunCallDef{
+				{SDK: models.SDKOpenAIAgents, Location: models.Location{FilePath: "main.py"}, AgentVarName: "agent"},
+			}},
+			false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := rules.PredAgentRunCallMaxTurnsMissing(c.a, c.inv)
+			if got != c.want {
+				t.Errorf("got %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestPredAgentRunCallUsageLimitsMissing(t *testing.T) {
+	agent := models.AgentDef{
+		SDK: models.SDKPydanticAI, Language: models.LanguagePython,
+		Location: models.Location{FilePath: "main.py"}, VarName: "agent",
+	}
+	cases := []struct {
+		name string
+		a    models.AgentDef
+		inv  models.RepoInventory
+		want bool
+	}{
+		{
+			"fires when the only matching run call sets no usage_limits",
+			agent,
+			models.RepoInventory{AgentRunCalls: []models.AgentRunCallDef{
+				{SDK: models.SDKPydanticAI, Location: models.Location{FilePath: "main.py"}, AgentVarName: "agent"},
+			}},
+			true,
+		},
+		{
+			"silent when usage_limits is set",
+			agent,
+			models.RepoInventory{AgentRunCalls: []models.AgentRunCallDef{
+				{SDK: models.SDKPydanticAI, Location: models.Location{FilePath: "main.py"}, AgentVarName: "agent", Kwargs: runCallKwargs("usage_limits", "UsageLimits(request_limit=5)")},
+			}},
+			false,
+		},
+		{
+			"silent when no run call matches this agent at all",
+			agent,
+			models.RepoInventory{},
+			false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := rules.PredAgentRunCallUsageLimitsMissing(c.a, c.inv)
+			if got != c.want {
+				t.Errorf("got %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
 func TestPredAgentKwargMissing_None(t *testing.T) {
 	mk := func(kind models.ExprKind, text string) models.AgentDef {
 		return models.AgentDef{

--- a/internal/rules/schema.go
+++ b/internal/rules/schema.go
@@ -76,17 +76,19 @@ type MatchExpr struct {
 	ToolDecoratorKwargPresent []string                     `yaml:"tool_decorator_kwarg_present,omitempty"`
 
 	// Agent-scope predicates
-	AgentClass                  []string                  `yaml:"agent_class,omitempty"`
-	AgentKwargPresent           []string                  `yaml:"agent_kwarg_present,omitempty"`
-	AgentKwargMissing           []string                  `yaml:"agent_kwarg_missing,omitempty"`
-	AgentKwargListEmpty         []string                  `yaml:"agent_kwarg_list_empty,omitempty"`
-	AgentKwargValue             *AgentKwargValueExpr      `yaml:"agent_kwarg_value,omitempty"`
-	AgentUsesToolKind           []string                  `yaml:"agent_uses_tool_kind,omitempty"`
-	AgentGrantsBuiltinTool      []string                  `yaml:"agent_grants_builtin_tool,omitempty"`
-	AgentUsesHostedToolClass    []string                  `yaml:"agent_uses_hosted_tool_class,omitempty"`
-	AgentIsSubagentOfAny        *bool                     `yaml:"agent_is_subagent_of_any,omitempty"`
-	AgentHostedToolKwargPresent *HostedToolKwargExpr      `yaml:"agent_hosted_tool_kwarg_present,omitempty"`
-	AgentHostedToolKwargValue   *HostedToolKwargValueExpr `yaml:"agent_hosted_tool_kwarg_value,omitempty"`
+	AgentClass                     []string                  `yaml:"agent_class,omitempty"`
+	AgentKwargPresent              []string                  `yaml:"agent_kwarg_present,omitempty"`
+	AgentKwargMissing              []string                  `yaml:"agent_kwarg_missing,omitempty"`
+	AgentKwargListEmpty            []string                  `yaml:"agent_kwarg_list_empty,omitempty"`
+	AgentKwargValue                *AgentKwargValueExpr      `yaml:"agent_kwarg_value,omitempty"`
+	AgentUsesToolKind              []string                  `yaml:"agent_uses_tool_kind,omitempty"`
+	AgentGrantsBuiltinTool         []string                  `yaml:"agent_grants_builtin_tool,omitempty"`
+	AgentUsesHostedToolClass       []string                  `yaml:"agent_uses_hosted_tool_class,omitempty"`
+	AgentIsSubagentOfAny           *bool                     `yaml:"agent_is_subagent_of_any,omitempty"`
+	AgentHostedToolKwargPresent    *HostedToolKwargExpr      `yaml:"agent_hosted_tool_kwarg_present,omitempty"`
+	AgentHostedToolKwargValue      *HostedToolKwargValueExpr `yaml:"agent_hosted_tool_kwarg_value,omitempty"`
+	AgentRunCallMaxTurnsMissing    *bool                     `yaml:"agent_run_call_max_turns_missing,omitempty"`
+	AgentRunCallUsageLimitsMissing *bool                     `yaml:"agent_run_call_usage_limits_missing,omitempty"`
 
 	// Subagent-scope predicates
 	SubagentGrantsTool []string `yaml:"subagent_grants_tool,omitempty"`

--- a/internal/rules/schema.yaml
+++ b/internal/rules/schema.yaml
@@ -333,6 +333,19 @@ rules:
 #       equals `value` (quote-stripped for string literals), e.g. ShellTool with
 #       needs_approval == "True".
 #
+#   agent_run_call_max_turns_missing: bool
+#       OpenAI Agents SDK only (agent.sdk == openai_agents). Returns true if
+#       the agent has at least one same-file Runner.run/run_sync/run_streamed
+#       call resolvable to it by variable name, and none of those calls set
+#       max_turns. Silent (false) if the agent has no resolvable run call at
+#       all — absence of evidence isn't evidence of absence.
+#
+#   agent_run_call_usage_limits_missing: bool
+#       Pydantic AI only (agent.sdk == pydantic_ai). Returns true if the agent
+#       has at least one same-file <agent>.run/run_sync/run_stream call
+#       resolvable to it by variable name, and none of those calls set
+#       usage_limits. Same silence rule as agent_run_call_max_turns_missing.
+#
 #
 # ━━━ SUBAGENT-SCOPE PREDICATES ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # (used only in scope: subagent rules)

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -403,6 +403,7 @@ func Run(cfg Config) (models.ScanResult, error) {
 	inventory.PluginManifests = analysis.DiscoverPlugins(profile.Manifest)
 	inventory.ClaudeSettings = analysis.DiscoverClaudeSettings(profile.Manifest)
 	inventory.ClaudeAgentOptions = analysis.DiscoverClaudeAgentOptions(parsed)
+	inventory.AgentRunCalls = analysis.DiscoverAgentRunCalls(parsed)
 	// Markdown subagents are an independent Claude Agent SDK signal: a repo can
 	// ship .claude/agents/*.md (or a flat collection) with no Claude SDK code.
 	// Fold them into SDKsDetected so LoadFor loads the claude_sdk pack (CSDK-110).


### PR DESCRIPTION
Adds a new discovery pass, DiscoverAgentRunCalls, that traces an agent from its construction site to its execution call site — closing the execution-limit detection gap for OpenAI Agents SDK and Pydantic AI, the two remaining SDKs where this check wasn't possible (every other supported SDK sets the limit at construction, which discovery already captures).

Two SDKs, two different resolution mechanisms:
- OpenAI Agents SDK: Runner.run(agent, ..., max_turns=N) — agent is the first positional argument. Runner discriminator matches the callee's object segment exactly ('Runner' or '.Runner' suffix), not a suffix of the whole callee text, to avoid false-positives on unrelated classes (TaskRunner.run(), TestRunner.run()).
- Pydantic AI: agent.run(..., usage_limits=UsageLimits(...)) — agent is the method's receiver, not an argument, since Agent is an arbitrary local variable with no fixed class name.

New predicates (PredAgentRunCallMaxTurnsMissing,
PredAgentRunCallUsageLimitsMissing) are agent-scoped, not repo-scoped like CSDK-204's ClaudeAgentOptions predicate — correlated by same-file VarName matching. Deliberately agent-scope rather than a flattened repo-wide bool: a Runner.run() call names one specific agent, so two agents in the same repo can be in different execution-limit postures, and collapsing that to one bool would lose the attribution (per CLAUDE.md's 'agent is the unit of analysis' principle).

Purely additive — DiscoverAgents, discoverPydanticAIAgentsInFile, and all existing predicates untouched.

13 new tests covering both SDKs, the Runner false-positive guard, non-identifier-argument silent-skip, and cross-SDK isolation. Full suite passes.

Rule YAML intentionally not included — discovery + predicate layer only, per the agreed scoping. Rules come next.