### PR TITLE
fix(rules): mirror OAI-112, PYD-106 into engine fixture

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -3721,6 +3721,26 @@ var policyAgentRuleCases = []policyAgentCase{
 		models.RepoInventory{},
 		false},
 
+	// ─── OAI-112 agent has no explicit max_turns limit ────────────────────────
+	{"OAI-112 fires when the matching Runner.run call sets no max_turns", "OAI-112",
+		models.AgentDef{
+			SDK: models.SDKOpenAIAgents, Class: "Agent", Language: models.LanguagePython,
+			Location: models.Location{FilePath: "main.py"}, VarName: "agent",
+		},
+		models.RepoInventory{AgentRunCalls: []models.AgentRunCallDef{
+			{SDK: models.SDKOpenAIAgents, Location: models.Location{FilePath: "main.py"}, AgentVarName: "agent"},
+		}},
+		true},
+	{"OAI-112 silent when max_turns is set", "OAI-112",
+		models.AgentDef{
+			SDK: models.SDKOpenAIAgents, Class: "Agent", Language: models.LanguagePython,
+			Location: models.Location{FilePath: "main.py"}, VarName: "agent",
+		},
+		models.RepoInventory{AgentRunCalls: []models.AgentRunCallDef{
+			{SDK: models.SDKOpenAIAgents, Location: models.Location{FilePath: "main.py"}, AgentVarName: "agent", Kwargs: runCallKwargs("max_turns", "5")},
+		}},
+		false},
+
 	// ─── CSDK-120 TS agent bypassPermissions ─────────────────────────────────
 	{"CSDK-120 fires on bypassPermissions TS agent", "CSDK-120",
 		parseTSAgentInline("import { query } from \"@anthropic-ai/claude-agent-sdk\";\n" +
@@ -3851,6 +3871,25 @@ var policyAgentRuleCases = []policyAgentCase{
 				"end_strategy": {Value: &models.Expr{Kind: models.ExprLiteralString, Text: `"early"`}},
 			}}},
 		models.RepoInventory{}, false},
+
+	{"PYD-106 fires when the matching agent.run call sets no usage_limits", "PYD-106",
+		models.AgentDef{
+			SDK: models.SDKPydanticAI, Class: "PydanticAgent", Language: models.LanguagePython,
+			Location: models.Location{FilePath: "main.py"}, VarName: "agent",
+		},
+		models.RepoInventory{AgentRunCalls: []models.AgentRunCallDef{
+			{SDK: models.SDKPydanticAI, Location: models.Location{FilePath: "main.py"}, AgentVarName: "agent"},
+		}},
+		true},
+	{"PYD-106 silent when usage_limits is set", "PYD-106",
+		models.AgentDef{
+			SDK: models.SDKPydanticAI, Class: "PydanticAgent", Language: models.LanguagePython,
+			Location: models.Location{FilePath: "main.py"}, VarName: "agent",
+		},
+		models.RepoInventory{AgentRunCalls: []models.AgentRunCallDef{
+			{SDK: models.SDKPydanticAI, Location: models.Location{FilePath: "main.py"}, AgentVarName: "agent", Kwargs: runCallKwargs("usage_limits", "UsageLimits(request_limit=5)")},
+		}},
+		false},
 
 	// ─── Vercel AI SDK agent rules (VAI-*) ────────────────────────────────────
 	// The object-record tools walk: a provider hosted-tool call

--- a/testdata/rules-fixture/openai_sdk/agent_safety.yaml
+++ b/testdata/rules-fixture/openai_sdk/agent_safety.yaml
@@ -165,6 +165,35 @@ rules:
       on the Agent(...) constructor. It should inspect the final output for
       data exfiltration and unsafe content before it is returned.
 
+  - id: OAI-112
+    title: OpenAI Agents SDK agent has no explicit max_turns limit
+    severity: low
+    confidence: 0.6
+    language: python
+    applies_to:
+      - openai_agent
+      - openai_sandbox_agent
+    scope: agent
+    match:
+      agent_run_call_max_turns_missing: true
+    explanation: >
+      No Runner.run/run_sync/run_streamed call that executes this agent sets
+      max_turns, so the loop runs to whatever ceiling the SDK's
+      DEFAULT_MAX_TURNS applies rather than to a bound sized for this task. A
+      model that loops or oscillates — retrying a failing tool, re-reading the
+      same file, ping-ponging between two steps — keeps consuming turns,
+      tokens, and tool side effects until that implicit ceiling is reached,
+      and an implicit ceiling can shift between SDK versions without any
+      change on your side. An explicit cap also turns a stuck run into a
+      clean, observable MaxTurnsExceeded instead of a slow burn.
+    fix: >
+      Pass max_turns= to Runner.run(...) (or run_sync/run_streamed), sized to
+      the work this agent actually does — a handful of turns for a
+      single-lookup agent, more for a multi-step task. Treat hitting the cap
+      as a signal to surface and handle rather than to raise it: if a task
+      legitimately needs many turns, split it into bounded sub-runs instead of
+      removing the bound.
+
   - id: OAI-105
     title: TypeScript agent wires a content-fetching hosted tool without inputGuardrails
     severity: high

--- a/testdata/rules-fixture/pydantic_ai/agent_safety.yaml
+++ b/testdata/rules-fixture/pydantic_ai/agent_safety.yaml
@@ -124,3 +124,30 @@ rules:
       model produces a final result, skipping pending tool calls. Only choose
       exhaustive when every tool the agent can call is side-effect-free and you
       specifically need the remaining calls to complete.
+
+  - id: PYD-106
+    title: Pydantic AI agent has no explicit usage_limits set
+    severity: low
+    confidence: 0.6
+    language: python
+    applies_to:
+      - pydantic_ai_agent
+    scope: agent
+    match:
+      agent_run_call_usage_limits_missing: true
+    explanation: >
+      No run/run_sync/run_stream call that executes this agent sets
+      usage_limits, so Pydantic AI falls back to a bare UsageLimits() —
+      capping request count but leaving token and cost usage completely
+      unbounded. A model that loops or oscillates, or a single run that
+      balloons into an unexpectedly long tool-calling chain, can burn far more
+      tokens and cost than the task warrants before the request cap is ever
+      reached, and nothing stops a single expensive run from running the bill
+      up. An explicit, task-sized UsageLimits also turns a runaway run into a
+      clean UsageLimitExceeded instead of a silent cost overrun.
+    fix: >
+      Pass usage_limits=UsageLimits(...) to agent.run/run_sync/run_stream,
+      sized to the task — request_limit for a hard step count, and
+      total_tokens_limit or input_tokens_limit/output_tokens_limit to bound
+      token spend directly. Treat hitting the limit as a signal to surface and
+      handle rather than to raise it.


### PR DESCRIPTION
PR #114 (feat/openai-pydantic-execution-limit-discovery) shipped the discovery pass and predicates but missed the fixture mirror step — both rules were live in production trustabl-rules but absent from the engine's test fixture, causing check-rules-sync.sh to fail on unrelated PRs.

Mirrors both rules byte-for-byte from production, including matching OAI-112's exact position in the file (between OAI-110 and OAI-105), not just appending at the end. Adds fire/silent test cases for both.

Verified: byte-diff clean against production, go build/test pass, check-rules-sync.sh reports full sync (86 files compared).