### PR TITLE
feat(vercel_ai): detect privileged tools without approval

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -362,6 +362,34 @@ import { z } from "zod";
 export const t = tool({ description: "x", inputSchema: z.object({ city: z.string() }), execute: async ({ city }) => city });
 `},
 
+	// VAI-013: privileged Vercel tools need an explicit human approval gate.
+	{name: "VAI-013 fires on shell tool with no needsApproval", ruleID: "VAI-013", kind: models.KindVercelAITool, lang: models.LanguageTypeScript, wantFires: true, src: `
+import { tool } from "ai";
+import { z } from "zod";
+import { execSync } from "child_process";
+export const t = tool({ description: "run", inputSchema: z.object({ cmd: z.string() }), execute: async ({ cmd }) => execSync(cmd).toString() });
+`},
+	{name: "VAI-013 fires on eval tool with needsApproval false", ruleID: "VAI-013", kind: models.KindVercelAITool, lang: models.LanguageTypeScript, wantFires: true, src: `
+import { tool } from "ai";
+import { z } from "zod";
+export const t = tool({ description: "calc", inputSchema: z.object({ expr: z.string() }), needsApproval: false, execute: async ({ expr }) => eval(expr) });
+`},
+	{name: "VAI-013 silent on approved dynamic shell tool", ruleID: "VAI-013", kind: models.KindVercelAITool, lang: models.LanguageTypeScript, wantFires: false, src: `
+import { dynamicTool } from "ai";
+import { execSync } from "child_process";
+export const t = dynamicTool({ description: "run", needsApproval: true, execute: async ({ cmd }) => execSync(cmd).toString() });
+`},
+	{name: "VAI-013 silent when approval is a callback", ruleID: "VAI-013", kind: models.KindVercelAITool, lang: models.LanguageTypeScript, wantFires: false, src: `
+import { tool } from "ai";
+import { z } from "zod";
+export const t = tool({ description: "calc", inputSchema: z.object({ expr: z.string() }), needsApproval: async ({ expr }) => expr.length > 0, execute: async ({ expr }) => eval(expr) });
+`},
+	{name: "VAI-013 silent on non-privileged tool without approval", ruleID: "VAI-013", kind: models.KindVercelAITool, lang: models.LanguageTypeScript, wantFires: false, src: `
+import { tool } from "ai";
+import { z } from "zod";
+export const t = tool({ description: "add", inputSchema: z.object({ a: z.number() }), execute: async ({ a }) => a + 1 });
+`},
+
 	// ─── CrewAI tool rules (CREW-*) ─────────────────────────────────────────
 	{name: "CREW-001 fires on tool with no docstring", ruleID: "CREW-001", kind: models.KindCrewAITool, src: `
 def search(q: str) -> str:

--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -374,12 +374,6 @@ import { tool } from "ai";
 import { z } from "zod";
 export const t = tool({ description: "calc", inputSchema: z.object({ expr: z.string() }), needsApproval: false, execute: async ({ expr }) => eval(expr) });
 `},
-	{name: "VAI-013 fires on filesystem write with no needsApproval", ruleID: "VAI-013", kind: models.KindVercelAITool, lang: models.LanguageTypeScript, wantFires: true, src: `
-import { tool } from "ai";
-import { z } from "zod";
-import { writeFileSync } from "fs";
-export const t = tool({ description: "save", inputSchema: z.object({ path: z.string(), data: z.string() }), execute: async ({ path, data }) => writeFileSync(path, data) });
-`},
 	{name: "VAI-013 silent on approved dynamic shell tool", ruleID: "VAI-013", kind: models.KindVercelAITool, lang: models.LanguageTypeScript, wantFires: false, src: `
 import { dynamicTool } from "ai";
 import { execSync } from "child_process";

--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -374,6 +374,12 @@ import { tool } from "ai";
 import { z } from "zod";
 export const t = tool({ description: "calc", inputSchema: z.object({ expr: z.string() }), needsApproval: false, execute: async ({ expr }) => eval(expr) });
 `},
+	{name: "VAI-013 fires on filesystem write with no needsApproval", ruleID: "VAI-013", kind: models.KindVercelAITool, lang: models.LanguageTypeScript, wantFires: true, src: `
+import { tool } from "ai";
+import { z } from "zod";
+import { writeFileSync } from "fs";
+export const t = tool({ description: "save", inputSchema: z.object({ path: z.string(), data: z.string() }), execute: async ({ path, data }) => writeFileSync(path, data) });
+`},
 	{name: "VAI-013 silent on approved dynamic shell tool", ruleID: "VAI-013", kind: models.KindVercelAITool, lang: models.LanguageTypeScript, wantFires: false, src: `
 import { dynamicTool } from "ai";
 import { execSync } from "child_process";

--- a/testdata/rules-fixture/vercel_ai/approvals.yaml
+++ b/testdata/rules-fixture/vercel_ai/approvals.yaml
@@ -3,12 +3,13 @@ policy:
   name: Vercel AI SDK tool approval gates
   category: vercel_ai
   description: >
-    Flags privileged Vercel AI SDK tools that can execute without the SDK's
-    built-in human approval gate.
+    Rules covering the human-in-the-loop approval gate the Vercel AI SDK
+    offers on sensitive tool calls. This policy inspects only the tool-level
+    needsApproval option, which defaults to false when omitted.
 
 rules:
   - id: VAI-013
-    title: Privileged Vercel AI tool has no needsApproval gate
+    title: Privileged tool has no needsApproval gate
     severity: high
     confidence: 0.7
     language: typescript
@@ -20,6 +21,7 @@ rules:
         - any:
             - has_shell_call: true
             - has_code_exec_call: true
+            - has_write_call: true
         - any:
             - not:
                 tool_decorator_kwarg_present:
@@ -28,9 +30,23 @@ rules:
                 kwarg: needsApproval
                 value: "false"
     explanation: >
-      This Vercel AI tool spawns a process or evaluates dynamic code but has no
-      needsApproval gate. A model-selected action can therefore execute without
-      a human checkpoint. A true value or callback counts as a configured gate.
+      This Vercel AI SDK tool shells out, executes dynamic code, or writes the
+      filesystem, but has no needsApproval gate — the option is absent or
+      explicitly set to false. needsApproval is the Vercel AI SDK's
+      human-in-the-loop gate for sensitive tool calls, and its default is
+      false — so an un-gated privileged tool executes attacker-influenced
+      model output with no human checkpoint. Passing true or a per-call
+      approval function both count as a gate and do not fire. This complements
+      VAI-001 (subprocess), VAI-002 (eval / new Function), and write-path
+      rules: those flag the dangerous call; VAI-013 flags the missing approval
+      gate around it. SDK 7 moved approval to toolApproval on generateText,
+      streamText, or ToolLoopAgent. This tool-scoped rule cannot verify that
+      separate setting, so a finding in SDK 7 code requires manual review.
     fix: >
-      Set needsApproval to true or to a per-call callback for sensitive inputs,
-      and handle the resulting approval request before executing the tool.
+      Pass needsApproval: true to the tool() or dynamicTool() options for
+      tools that execute commands, run code, or mutate the filesystem, and
+      handle the resulting approval requests in your agent loop. SDK 7+ uses
+      toolApproval on generateText, streamText, or ToolLoopAgent, but this rule
+      cannot yet verify that call or agent-level setting. If approval is
+      intentionally automated for a trusted tool, gate the agent with input
+      validation and document the decision.

--- a/testdata/rules-fixture/vercel_ai/approvals.yaml
+++ b/testdata/rules-fixture/vercel_ai/approvals.yaml
@@ -21,7 +21,6 @@ rules:
         - any:
             - has_shell_call: true
             - has_code_exec_call: true
-            - has_write_call: true
         - any:
             - not:
                 tool_decorator_kwarg_present:
@@ -30,22 +29,22 @@ rules:
                 kwarg: needsApproval
                 value: "false"
     explanation: >
-      This Vercel AI SDK tool shells out, executes dynamic code, or writes the
-      filesystem, but has no needsApproval gate — the option is absent or
+      This Vercel AI SDK tool shells out or executes dynamic code, but has no
+      needsApproval gate — the option is absent or
       explicitly set to false. needsApproval is the Vercel AI SDK's
       human-in-the-loop gate for sensitive tool calls, and its default is
       false — so an un-gated privileged tool executes attacker-influenced
       model output with no human checkpoint. Passing true or a per-call
       approval function both count as a gate and do not fire. This complements
-      VAI-001 (subprocess), VAI-002 (eval / new Function), and write-path
-      rules: those flag the dangerous call; VAI-013 flags the missing approval
-      gate around it. SDK 7 moved approval to toolApproval on generateText,
+      VAI-001 (subprocess) and VAI-002 (eval / new Function): those flag the
+      dangerous call; VAI-013 flags the missing approval gate around it. SDK 7
+      moved approval to toolApproval on generateText,
       streamText, or ToolLoopAgent. This tool-scoped rule cannot verify that
       separate setting, so a finding in SDK 7 code requires manual review.
     fix: >
       Pass needsApproval: true to the tool() or dynamicTool() options for
-      tools that execute commands, run code, or mutate the filesystem, and
-      handle the resulting approval requests in your agent loop. SDK 7+ uses
+      tools that execute commands or run code, and handle the resulting
+      approval requests in your agent loop. SDK 7+ uses
       toolApproval on generateText, streamText, or ToolLoopAgent, but this rule
       cannot yet verify that call or agent-level setting. If approval is
       intentionally automated for a trusted tool, gate the agent with input

--- a/testdata/rules-fixture/vercel_ai/approvals.yaml
+++ b/testdata/rules-fixture/vercel_ai/approvals.yaml
@@ -38,14 +38,14 @@ rules:
       not fire. This complements VAI-001 (subprocess) and VAI-002 (eval / new
       Function): those flag the dangerous call; VAI-013 flags the missing
       approval gate around it. SDK 7 deprecated needsApproval on tool() in
-      favor of toolApproval on generateText, streamText, or ToolLoopAgent;
-      existing code still works, but new code should migrate approval to the
-      call or agent level.
+      favor of toolApproval on generateText, streamText, or ToolLoopAgent.
+      This tool-scoped rule cannot verify that separate setting, so a finding
+      in SDK 7 code requires manual review.
     fix: >
       Pass needsApproval: true to the tool() or dynamicTool() options for
       tools that execute commands or run code, and
       handle the resulting approval requests in your agent loop. For SDK 7+,
-      prefer configuring toolApproval on generateText, streamText, or
-      ToolLoopAgent instead. If approval is intentionally automated for a
-      trusted tool, gate the agent with input validation and document the
-      decision.
+      configure toolApproval on generateText, streamText, or ToolLoopAgent;
+      this rule cannot verify that call or agent-level setting. If approval is
+      intentionally automated for a trusted tool, gate the agent with input
+      validation and document the decision.

--- a/testdata/rules-fixture/vercel_ai/approvals.yaml
+++ b/testdata/rules-fixture/vercel_ai/approvals.yaml
@@ -1,0 +1,36 @@
+policy:
+  id: vercel_ai_approvals
+  name: Vercel AI SDK tool approval gates
+  category: vercel_ai
+  description: >
+    Flags privileged Vercel AI SDK tools that can execute without the SDK's
+    built-in human approval gate.
+
+rules:
+  - id: VAI-013
+    title: Privileged Vercel AI tool has no needsApproval gate
+    severity: high
+    confidence: 0.7
+    language: typescript
+    applies_to:
+      - vercel_ai_tool
+    scope: tool
+    match:
+      all:
+        - any:
+            - has_shell_call: true
+            - has_code_exec_call: true
+        - any:
+            - not:
+                tool_decorator_kwarg_present:
+                  - needsApproval
+            - tool_decorator_kwarg_value:
+                kwarg: needsApproval
+                value: "false"
+    explanation: >
+      This Vercel AI tool spawns a process or evaluates dynamic code but has no
+      needsApproval gate. A model-selected action can therefore execute without
+      a human checkpoint. A true value or callback counts as a configured gate.
+    fix: >
+      Set needsApproval to true or to a per-call callback for sensitive inputs,
+      and handle the resulting approval request before executing the tool.

--- a/testdata/rules-fixture/vercel_ai/approvals.yaml
+++ b/testdata/rules-fixture/vercel_ai/approvals.yaml
@@ -30,22 +30,22 @@ rules:
                 value: "false"
     explanation: >
       This Vercel AI SDK tool shells out or executes dynamic code, but has no
-      needsApproval gate — the option is absent or
-      explicitly set to false. needsApproval is the Vercel AI SDK's
-      human-in-the-loop gate for sensitive tool calls, and its default is
-      false — so an un-gated privileged tool executes attacker-influenced
-      model output with no human checkpoint. Passing true or a per-call
-      approval function both count as a gate and do not fire. This complements
-      VAI-001 (subprocess) and VAI-002 (eval / new Function): those flag the
-      dangerous call; VAI-013 flags the missing approval gate around it. SDK 7
-      moved approval to toolApproval on generateText,
-      streamText, or ToolLoopAgent. This tool-scoped rule cannot verify that
-      separate setting, so a finding in SDK 7 code requires manual review.
+      needsApproval gate — the option is absent or explicitly set to false.
+      needsApproval is the Vercel AI SDK's human-in-the-loop gate for sensitive
+      tool calls, and its default is false — so an un-gated privileged tool
+      executes attacker-influenced model output with no human checkpoint.
+      Passing true or a per-call approval function both count as a gate and do
+      not fire. This complements VAI-001 (subprocess) and VAI-002 (eval / new
+      Function): those flag the dangerous call; VAI-013 flags the missing
+      approval gate around it. SDK 7 deprecated needsApproval on tool() in
+      favor of toolApproval on generateText, streamText, or ToolLoopAgent;
+      existing code still works, but new code should migrate approval to the
+      call or agent level.
     fix: >
       Pass needsApproval: true to the tool() or dynamicTool() options for
-      tools that execute commands or run code, and handle the resulting
-      approval requests in your agent loop. SDK 7+ uses
-      toolApproval on generateText, streamText, or ToolLoopAgent, but this rule
-      cannot yet verify that call or agent-level setting. If approval is
-      intentionally automated for a trusted tool, gate the agent with input
-      validation and document the decision.
+      tools that execute commands or run code, and
+      handle the resulting approval requests in your agent loop. For SDK 7+,
+      prefer configuring toolApproval on generateText, streamText, or
+      ToolLoopAgent instead. If approval is intentionally automated for a
+      trusted tool, gate the agent with input validation and document the
+      decision.


### PR DESCRIPTION
## Change  Mirrors the VAI-013 production rule in the engine fixture and covers missing, literal-false, literal-true, callback, and non-privileged tool cases.  ## Scope boundary  VAI-013 covers shell and dynamic-code execution only. It intentionally omits `has_write_call` because the Vercel AI pack has no matching shipped filesystem-write capability rule. SDK 7 `toolApproval` lives at call or agent scope and remains a documented manual-review limitation for this tool-scoped detector.  ## Validation  - [x] Engine fixture mirrors rules PR #102 exactly (`e6b4cfa`, `9cee430`) - [x] `git diff --check` - [x] Existing targeted and full Go coverage passed before the final text-only fixture synchronization; no predicate or test behavior changed afterward - [x] Rulebook check adds no new errors; known baseline remains `OAI-112` and `PYD-106`  ## Companion PRs  - Rules: https://github.com/trustabl/trustabl-rules/pull/102 - Rulebook: https://github.com/trustabl/trustabl-rulebook/pull/82  ## Team  - Calvin: engine fixture, tests, integration, and final QA - Justin (@jj-javascript): production YAML and rationale - Karlee (@kperpignant): consulting partner, threat model, and QA review  ## Maintainer decision  VAI-013 conflicts with the description-quality rule proposed in rules PR #69 and engine PR #148. This PR preserves the security rule's current ID pending maintainer direction.