### PR TITLE
test(rules): mirror LC-008, LC-016 LangChain idempotency into fixture

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -230,6 +230,22 @@ def f(x: str) -> str:
     return x
 `, toolConfig: map[string]string{}, wantFires: false},
 
+	{name: "LC-008 fires on mutating tool without idempotency key", ruleID: "LC-008", kind: models.KindLangChainTool, src: `
+def create_order(customer_id: str, amount: float) -> dict:
+    """Create an order."""
+    return {"ok": True}
+`, wantFires: true},
+	{name: "LC-008 silent with idempotency key", ruleID: "LC-008", kind: models.KindLangChainTool, src: `
+def create_order(customer_id: str, amount: float, idempotency_key: str) -> dict:
+    """Create an order."""
+    return {"ok": True}
+`, wantFires: false},
+	{name: "LC-008 silent on non-mutating tool name", ruleID: "LC-008", kind: models.KindLangChainTool, src: `
+def get_order(order_id: str) -> dict:
+    """Fetch an order."""
+    return {"id": order_id}
+`, wantFires: false},
+
 	// LangChain TypeScript tool rules — parseTSTool runs DiscoverTSLangChainTools,
 	// so each snippet must import from the langchain ecosystem to be discovered.
 	{name: "LC-010 fires on TS tool with no description", ruleID: "LC-010", kind: models.KindLangChainTool, lang: models.LanguageTypeScript, wantFires: true, src: `
@@ -286,6 +302,22 @@ export const t = tool(async (i) => i.q, { name: "x", description: "X.", schema: 
 import { tool } from "@langchain/core/tools";
 import { z } from "zod";
 export const t = tool(async (i) => i.q, { name: "x", description: "X.", schema: z.object({ q: z.string() }) });
+`},
+
+	{name: "LC-016 fires on TS mutating tool with no idempotency param", ruleID: "LC-016", kind: models.KindLangChainTool, lang: models.LanguageTypeScript, wantFires: true, src: `
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+export const t = tool(async (i) => i.amount, { name: "createCharge", description: "Charge a card.", schema: z.object({ amount: z.number() }) });
+`},
+	{name: "LC-016 silent when idempotency key present", ruleID: "LC-016", kind: models.KindLangChainTool, lang: models.LanguageTypeScript, wantFires: false, src: `
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+export const t = tool(async (i) => i.amount, { name: "createCharge", description: "Charge a card.", schema: z.object({ amount: z.number(), idempotencyKey: z.string() }) });
+`},
+	{name: "LC-016 silent on non-mutating TS tool name", ruleID: "LC-016", kind: models.KindLangChainTool, lang: models.LanguageTypeScript, wantFires: false, src: `
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+export const t = tool(async (i) => i.id, { name: "getBalance", description: "Read balance.", schema: z.object({ id: z.string() }) });
 `},
 
 	// ─── Vercel AI SDK tool rules (VAI-*) ───────────────────────────────────

--- a/testdata/rules-fixture/langchain/idempotency.yaml
+++ b/testdata/rules-fixture/langchain/idempotency.yaml
@@ -1,0 +1,95 @@
+policy:
+  id: langchain_idempotency
+  name: LangChain mutating-tool idempotency
+  category: langchain
+  description: >
+    Flags mutating LangChain tools (create/send/refund/...) without an
+    idempotency key. AgentExecutor and LangGraph re-invoke tool nodes under
+    timeouts and ambiguous failures, so without a key the same side effect
+    can fire twice.
+
+rules:
+  - id: LC-008
+    title: Mutating LangChain tool has no idempotency key
+    severity: medium
+    confidence: 0.55
+    language: python
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      all:
+        - name_has_prefix:
+            - create_
+            - send_
+            - delete_
+            - post_
+            - update_
+            - refund_
+            - charge_
+            - issue_
+        - not:
+            param_name_matches:
+              contains:
+                - idempot
+              exact:
+                - request_id
+                - txn_id
+    explanation: >
+      Tool name suggests a side effect (create/send/refund/…). LangChain retries
+      a tool call when AgentExecutor or a LangGraph tool node times out, when
+      the model re-selects the same tool after an inconclusive result, or when
+      a response is lost after the side effect already committed
+      (at-least-once delivery). Without an idempotency key the same action can
+      fire twice — a duplicate charge, a double-sent message, a repeated
+      delete. An iteration cap such as max_iterations does not help: it bounds
+      how many steps the executor takes, not whether one mutating step may run
+      twice. The downstream service must also honor the key for this
+      protection to be effective.
+    fix: >
+      Add an `idempotency_key: str` parameter and pass it through to the backing
+      API so a retried call is recognized and deduplicated rather than
+      re-executed.
+
+  - id: LC-016
+    title: TypeScript LangChain mutating tool has no idempotency key
+    severity: medium
+    confidence: 0.5
+    language: typescript
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      all:
+        - name_has_prefix:
+            - create
+            - send
+            - delete
+            - post
+            - update
+            - refund
+            - charge
+            - issue
+        - not:
+            param_name_matches:
+              contains:
+                - idempot
+              exact:
+                - requestId
+                - request_id
+                - txnId
+                - txn_id
+    explanation: >
+      This LangChain.js tool's name implies a side effect (create/send/refund/…)
+      but its Zod schema exposes no idempotency field. Retries happen outside
+      the tool — createReactAgent / AgentExecutor re-issues after a timeout,
+      the model re-selects the same tool after an inconclusive result, or a
+      response is lost after the side effect already committed — so the same
+      charge, send, or delete can fire twice. The prefix set matches both
+      `create_charge` and `createCharge`, so it fires on idiomatic TypeScript
+      tool names. Without a key the model and the graph cannot make the retry
+      safe.
+    fix: >
+      Add an `idempotencyKey` (or `requestId`) field to the tool's Zod schema,
+      thread it to the downstream API, and confirm that API treats a repeated
+      key as a no-op rather than a second mutation.


### PR DESCRIPTION
Fixture mirror for LC-008 and LC-016 from [trustabl-rules#77](https://github.com/trustabl/trustabl-rules/pull/77), copied byte-for-byte. No engine code, no schema change.

Six test cases rather than the four the coverage guard needs, because each rule gets two silent cases and they test different things. `create_order(..., idempotency_key)` has the mutating prefix and is silenced by the key; `get_order` never matches the name test at all. Same split on the TypeScript side with `createCharge` + `idempotencyKey` versus `getBalance`. The guarded-but-mutating one is the case I'd want a reviewer to look at, since a rule that fires on both is worthless.

`go test ./...` passes, and `check-rules-sync.sh` reports the fixture in sync against a local checkout of the #77 branch. I also built the binary and scanned sample projects to confirm the rules attribute to the right file and line: `tools.py:5-7` for LC-008, `src/tools.ts:4-10` for LC-016, with both negative controls clean.

One thing that'll look wrong until #77 merges: the `rules-sync` job resolves the paired pack with `git ls-remote` against `trustabl/trustabl-rules`, which can't see a branch on my fork, so it falls back to `main` and reports this fixture file as production-only. That red check is a fork visibility artifact, not drift — merging #77 clears it, or pushing the same branch name to the rules repo clears it early.

Rationale doc is [trustabl-rulebook#43](https://github.com/trustabl/trustabl-rulebook/pull/43).

Made with [Cursor](https://cursor.com)
