### PR TITLE
test(rules): mirror MCP-029 PHP untyped-params into fixture

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -810,7 +810,7 @@ For each language recon cleared, do the AST work and produce a `RepoInventory`:
   `#[...]` is parsed as a `comment` node — so the attribute is read from the
   comment text immediately preceding the method via regex. Emits
   `ToolDef{Kind: mcp_tool, Language: php}`, so deriveSDKsDetected stamps SDKMCP
-  and the mcp/ pack's `language: php` rules (MCP-019/020/023) audit them. Multi-line
+  and the mcp/ pack's `language: php` rules (MCP-019/020/029) audit them. Multi-line
   `#[...]` attributes, `#[McpResource]` / `#[McpPrompt]`, and PHP body-fact
   predicates are v1 gaps.
 - **DiscoverRustMCPTools** (`rust_mcp.go`) — Rust MCP tools parsed with

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -810,7 +810,7 @@ For each language recon cleared, do the AST work and produce a `RepoInventory`:
   `#[...]` is parsed as a `comment` node — so the attribute is read from the
   comment text immediately preceding the method via regex. Emits
   `ToolDef{Kind: mcp_tool, Language: php}`, so deriveSDKsDetected stamps SDKMCP
-  and the mcp/ pack's `language: php` rules (MCP-019/020) audit them. Multi-line
+  and the mcp/ pack's `language: php` rules (MCP-019/020/023) audit them. Multi-line
   `#[...]` attributes, `#[McpResource]` / `#[McpPrompt]`, and PHP body-fact
   predicates are v1 gaps.
 - **DiscoverRustMCPTools** (`rust_mcp.go`) — Rust MCP tools parsed with

--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -1362,6 +1362,21 @@ def run_cmd(name: str) -> str:
 		src: "<?php\nuse PhpMcp\\Server\\Attributes\\McpTool;\nclass T {\n    #[McpTool(name: 'summarize_invoice', description: 'Summarize')]\n    public function summarizeInvoice(string $input): string { return $input; }\n}\n",
 	},
 	{
+		name: "MCP-023 fires on PHP untyped params", ruleID: "MCP-023",
+		kind: models.KindMCPTool, lang: models.LanguagePHP, wantFires: true,
+		src: "<?php\nuse PhpMcp\\Server\\Attributes\\McpTool;\nclass T {\n    #[McpTool(name: 'search_docs', description: 'Search')]\n    public function searchDocs($query, $limit) { return $query; }\n}\n",
+	},
+	{
+		name: "MCP-023 silent with PHP type hints", ruleID: "MCP-023",
+		kind: models.KindMCPTool, lang: models.LanguagePHP, wantFires: false,
+		src: "<?php\nuse PhpMcp\\Server\\Attributes\\McpTool;\nclass T {\n    #[McpTool(name: 'search_docs', description: 'Search')]\n    public function searchDocs(string $query, int $limit): string { return $query; }\n}\n",
+	},
+	{
+		name: "MCP-023 silent on zero-param PHP tool", ruleID: "MCP-023",
+		kind: models.KindMCPTool, lang: models.LanguagePHP, wantFires: false,
+		src: "<?php\nuse PhpMcp\\Server\\Attributes\\McpTool;\nclass T {\n    #[McpTool(name: 'ping', description: 'Health check')]\n    public function ping(): string { return 'ok'; }\n}\n",
+	},
+	{
 		name: "MCP-021 fires on Rust tool with no description", ruleID: "MCP-021",
 		kind: models.KindMCPTool, lang: models.LanguageRust, wantFires: true,
 		src: "use rmcp::tool;\nimpl T {\n    #[tool]\n    fn fetch_weather(&self) -> String { String::new() }\n}\n",

--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -1362,17 +1362,17 @@ def run_cmd(name: str) -> str:
 		src: "<?php\nuse PhpMcp\\Server\\Attributes\\McpTool;\nclass T {\n    #[McpTool(name: 'summarize_invoice', description: 'Summarize')]\n    public function summarizeInvoice(string $input): string { return $input; }\n}\n",
 	},
 	{
-		name: "MCP-023 fires on PHP untyped params", ruleID: "MCP-023",
+		name: "MCP-029 fires on PHP untyped params", ruleID: "MCP-029",
 		kind: models.KindMCPTool, lang: models.LanguagePHP, wantFires: true,
 		src: "<?php\nuse PhpMcp\\Server\\Attributes\\McpTool;\nclass T {\n    #[McpTool(name: 'search_docs', description: 'Search')]\n    public function searchDocs($query, $limit) { return $query; }\n}\n",
 	},
 	{
-		name: "MCP-023 silent with PHP type hints", ruleID: "MCP-023",
+		name: "MCP-029 silent with PHP type hints", ruleID: "MCP-029",
 		kind: models.KindMCPTool, lang: models.LanguagePHP, wantFires: false,
 		src: "<?php\nuse PhpMcp\\Server\\Attributes\\McpTool;\nclass T {\n    #[McpTool(name: 'search_docs', description: 'Search')]\n    public function searchDocs(string $query, int $limit): string { return $query; }\n}\n",
 	},
 	{
-		name: "MCP-023 silent on zero-param PHP tool", ruleID: "MCP-023",
+		name: "MCP-029 silent on zero-param PHP tool", ruleID: "MCP-029",
 		kind: models.KindMCPTool, lang: models.LanguagePHP, wantFires: false,
 		src: "<?php\nuse PhpMcp\\Server\\Attributes\\McpTool;\nclass T {\n    #[McpTool(name: 'ping', description: 'Health check')]\n    public function ping(): string { return 'ok'; }\n}\n",
 	},

--- a/testdata/rules-fixture/mcp/tool_definition.yaml
+++ b/testdata/rules-fixture/mcp/tool_definition.yaml
@@ -310,7 +310,7 @@ rules:
       Rename the method (or set the `#[tool]` `name = "..."` argument) to a
       verb-object form, e.g. `summarize_invoice`, `fetch_weather`.
 
-  - id: MCP-023
+  - id: MCP-029
     title: PHP MCP tool has no type-annotated parameters
     severity: medium
     confidence: 0.85

--- a/testdata/rules-fixture/mcp/tool_definition.yaml
+++ b/testdata/rules-fixture/mcp/tool_definition.yaml
@@ -309,3 +309,27 @@ rules:
     fix: >
       Rename the method (or set the `#[tool]` `name = "..."` argument) to a
       verb-object form, e.g. `summarize_invoice`, `fetch_weather`.
+
+  - id: MCP-023
+    title: PHP MCP tool has no type-annotated parameters
+    severity: medium
+    confidence: 0.85
+    language: php
+    applies_to:
+      - mcp_tool
+    scope: tool
+    match:
+      has_params: true
+      has_typed_params: false
+    explanation: >
+      MCP derives a PHP tool's advertised input JSON schema from the handler's
+      parameter type hints. PHP type hints are optional; without them the
+      published schema is unconstrained, so connecting models send unvalidated
+      inputs that frequently cause runtime errors inside the server. Go, C#,
+      and Rust MCP tools cannot express this gap — those languages are
+      statically typed — which is why this sibling of MCP-002 exists only for
+      PHP.
+    fix: >
+      Add type hints to every parameter (`function search(string $query, int
+      $limit = 10): array`). Use typed properties or DTO classes for structured
+      inputs so the published schema constrains them.


### PR DESCRIPTION
Fixture mirror for MCP-029 — the PHP sibling of `MCP-002`, untyped tool parameters — from [trustabl-rules#80](https://github.com/trustabl/trustabl-rules/pull/80), byte-for-byte. No engine code, no new predicates, no schema bump.

Renumbered from MCP-023 to clear a collision with rules PRs #82/#85/#88/#91, which claim 023 through 028. A duplicate rule ID stops the loader at startup, so shipping both would have broken every scan rather than failing a test. Reasoning is on #80.

`ARCHITECTURE.md` is updated in the same commit since it enumerates the `language: php` rules — that line now reads MCP-019/020/029.

Three test cases. `searchDocs($query, $limit)` fires; the fully hinted version is silent on `has_typed_params`; `ping(): string` is silent on `has_params`. That third one is worth a look, because `has_params: true` is doing real work in the match and a rule that fired on every zero-argument health check would be pure noise.

`go test ./...` passes and `check-rules-sync.sh` reports the fixture in sync against a local checkout of the #80 branch. I also scanned a PHP server end to end and got the finding at `src/Tools.php:10-13`, with the typed, zero-param and mixed-hint handlers all quiet.

On that last one — `HasTypedParams` is set when any parameter carries a type:

```go
if p.ChildByFieldName("type") != nil {
	td.HasTypedParams = true
}
```

so `mixedHints(string $query, $limit)` reports nothing despite `$limit` being bare. I confirmed that with a scan rather than inferring it. It's pre-existing shared behavior — nine packs match on the same field — so tightening it would change `MCP-002` and eight others and belongs in a separate PR. It's documented in the rationale doc and it's why the rule ships at 0.85.

Until #80 merges, the `rules-sync` job will fall back to `main` and report this fixture file as production-only, because `git ls-remote` can't see a branch on my fork. That red check is a visibility artifact rather than real drift.

Rationale doc is [trustabl-rulebook#45](https://github.com/trustabl/trustabl-rulebook/pull/45).

Made with [Cursor](https://cursor.com)
