### PR TITLE
test(rules): mirror and cover LC-007, CREW-007, AG2-013, PYD-008

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -219,6 +219,22 @@ def fetch(q: str) -> str:
     return requests.get("https://api.example.com/data").text
 `, wantFires: false},
 
+	{name: "LC-007 fires on bare raise", ruleID: "LC-007", kind: models.KindLangChainTool, src: `
+def lookup(key: str) -> str:
+    """Look up a key."""
+    if not key:
+        raise ValueError("key required")
+    return key
+`, wantFires: true},
+	{name: "LC-007 silent when the raise is caught", ruleID: "LC-007", kind: models.KindLangChainTool, src: `
+def lookup(key: str) -> dict:
+    """Look up a key."""
+    try:
+        return {"value": key}
+    except KeyError as e:
+        return {"error": str(e), "retryable": False}
+`, wantFires: false},
+
 	{name: "LC-006 fires on return_direct=True", ruleID: "LC-006", kind: models.KindLangChainTool, src: `
 def f(x: str) -> str:
     """Doc."""
@@ -425,6 +441,22 @@ def fetch(q: str) -> str:
     return requests.get("https://api.example.com/data").text
 `, wantFires: false},
 
+	{name: "CREW-007 fires on bare raise", ruleID: "CREW-007", kind: models.KindCrewAITool, src: `
+def fetch_record(record_id: str) -> str:
+    """Fetch a record."""
+    if not record_id:
+        raise ValueError("record_id required")
+    return record_id
+`, wantFires: true},
+	{name: "CREW-007 silent when the raise is caught", ruleID: "CREW-007", kind: models.KindCrewAITool, src: `
+def fetch_record(record_id: str) -> dict:
+    """Fetch a record."""
+    try:
+        return {"record": record_id}
+    except KeyError as e:
+        return {"error": str(e), "retryable": False}
+`, wantFires: false},
+
 	{name: "CREW-006 fires on mutating tool without key", ruleID: "CREW-006", kind: models.KindCrewAITool, src: `
 def create_order(customer_id: str, amount: float) -> dict:
     """Create an order."""
@@ -508,6 +540,22 @@ def fetch(q: str) -> str:
     """Fetch."""
     import requests
     return requests.get("https://api.example.com/data").text
+`, wantFires: false},
+
+	{name: "AG2-013 fires on bare raise", ruleID: "AG2-013", kind: models.KindAutoGenTool, src: `
+def load_config(name: str) -> str:
+    """Load a config."""
+    if not name:
+        raise ValueError("name required")
+    return name
+`, wantFires: true},
+	{name: "AG2-013 silent when the raise is caught", ruleID: "AG2-013", kind: models.KindAutoGenTool, src: `
+def load_config(name: str) -> dict:
+    """Load a config."""
+    try:
+        return {"config": name}
+    except FileNotFoundError as e:
+        return {"error": str(e), "retryable": False}
 `, wantFires: false},
 
 	{name: "AG2-012 fires on network call without timeout", ruleID: "AG2-012", kind: models.KindAutoGenTool, src: `
@@ -597,6 +645,22 @@ def fetch(q: str) -> str:
     """Fetch."""
     import requests
     return requests.get("https://api.example.com/data", timeout=10).text
+`, wantFires: false},
+
+	{name: "PYD-008 fires on bare raise", ruleID: "PYD-008", kind: models.KindPydanticAITool, src: `
+def get_user(user_id: str) -> str:
+    """Get a user."""
+    if not user_id:
+        raise ValueError("user_id required")
+    return user_id
+`, wantFires: true},
+	{name: "PYD-008 silent when the raise is caught", ruleID: "PYD-008", kind: models.KindPydanticAITool, src: `
+def get_user(user_id: str) -> dict:
+    """Get a user."""
+    try:
+        return {"user": user_id}
+    except KeyError as e:
+        return {"error": str(e), "retryable": False}
 `, wantFires: false},
 
 	{name: "PYD-007 fires on mutating tool without key", ruleID: "PYD-007", kind: models.KindPydanticAITool, src: `

--- a/testdata/rules-fixture/autogen/error_handling.yaml
+++ b/testdata/rules-fixture/autogen/error_handling.yaml
@@ -1,0 +1,35 @@
+policy:
+  id: autogen_error_handling
+  name: AutoGen error contract hygiene
+  category: autogen
+  description: >
+    Rules covering how an AutoGen / AG2 tool surfaces failures back to the
+    conversation. A registered tool's return value becomes a message in the chat
+    history, so an uncaught exception is what the next speaker reasons over.
+
+rules:
+  - id: AG2-013
+    title: AutoGen tool raises exceptions without a structured error contract
+    severity: low
+    confidence: 0.6
+    language: python
+    applies_to:
+      - autogen_tool
+    scope: tool
+    match:
+      all:
+        - has_raise: true
+        - has_try_except: false
+    explanation: >
+      An AutoGen tool that raises produces a tool-response message carrying the
+      stringified exception, and that message stays in the conversation history
+      for every subsequent turn. The model cannot branch on it — there is no field
+      separating a malformed argument from an unreachable dependency — so it
+      re-calls the tool or hands the failure to another agent as prose. In a group
+      chat the bad message is replayed to every participant on each round, so one
+      opaque traceback consumes context for the rest of the run.
+    fix: >
+      Catch the failure modes you expect and return a structured result the model
+      can act on — e.g. {"error": "...", "retryable": true} — so the response that
+      lands in the history is something the next speaker can reason about. Reserve
+      raises for unrecoverable states.

--- a/testdata/rules-fixture/crewai/error_handling.yaml
+++ b/testdata/rules-fixture/crewai/error_handling.yaml
@@ -1,0 +1,35 @@
+policy:
+  id: crewai_error_handling
+  name: CrewAI error contract hygiene
+  category: crewai
+  description: >
+    Rules covering how a CrewAI tool surfaces failures back to the agent. A tool
+    that raises is caught by the executor and replayed to the model as text, so
+    an uncaught exception becomes the model's only account of what failed.
+
+rules:
+  - id: CREW-007
+    title: CrewAI tool raises exceptions without a structured error contract
+    severity: low
+    confidence: 0.6
+    language: python
+    applies_to:
+      - crewai_tool
+    scope: tool
+    match:
+      all:
+        - has_raise: true
+        - has_try_except: false
+    explanation: >
+      A CrewAI tool that raises hands the executor an exception it can only
+      stringify back into the agent's scratchpad. The model sees a message, not a
+      status: it cannot distinguish an invalid argument it should fix from a
+      transient timeout it should retry, so it burns iterations re-calling the
+      tool the same way until max_iter stops the agent. Because the tool's output
+      is also what a delegating agent reads, an opaque error propagates across the
+      crew rather than staying local to the task that failed.
+    fix: >
+      Catch the failures you expect and return a structured result the model can
+      branch on — e.g. {"error": "...", "retryable": true} — and keep raises for
+      states no retry can fix. Name the failing input in the message so the model
+      can correct its next call instead of repeating it.

--- a/testdata/rules-fixture/langchain/error_handling.yaml
+++ b/testdata/rules-fixture/langchain/error_handling.yaml
@@ -1,0 +1,37 @@
+policy:
+  id: langchain_error_handling
+  name: LangChain error contract hygiene
+  category: langchain
+  description: >
+    Rules covering how a LangChain / LangGraph tool surfaces failures back to
+    the agent. A tool that raises is converted into a message the model reads as
+    prose, so an uncaught exception becomes the model's only signal about what
+    went wrong.
+
+rules:
+  - id: LC-007
+    title: LangChain tool raises exceptions without a structured error contract
+    severity: low
+    confidence: 0.6
+    language: python
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      all:
+        - has_raise: true
+        - has_try_except: false
+    explanation: >
+      When a LangChain tool raises, the executor either aborts the run or, with
+      handle_tool_error set, stringifies the exception into a ToolMessage the
+      model reads as prose. Either way the model gets no field it can branch on:
+      it cannot tell a bad argument it should correct from a remote outage it
+      should retry from a permission denial it should stop on, so it typically
+      re-calls the tool with the same arguments. The stringified traceback can
+      also carry internal paths and stack frames into the transcript.
+    fix: >
+      Catch the failure modes you expect and return a structured result the model
+      can act on — e.g. {"error": "...", "retryable": true} — reserving raises
+      for genuinely unrecoverable states. If you do want the executor to relay
+      errors, set handle_tool_error to a function that maps the exception to that
+      same structured shape rather than to True.

--- a/testdata/rules-fixture/pydantic_ai/error_handling.yaml
+++ b/testdata/rules-fixture/pydantic_ai/error_handling.yaml
@@ -1,0 +1,35 @@
+policy:
+  id: pydantic_ai_error_handling
+  name: Pydantic AI error contract hygiene
+  category: pydantic_ai
+  description: >
+    Rules covering how a Pydantic AI tool surfaces failures back to the model.
+    The framework has an explicit retry channel (ModelRetry); an arbitrary
+    exception bypasses it and ends the run instead.
+
+rules:
+  - id: PYD-008
+    title: Pydantic AI tool raises exceptions without a structured error contract
+    severity: low
+    confidence: 0.6
+    language: python
+    applies_to:
+      - pydantic_ai_tool
+    scope: tool
+    match:
+      all:
+        - has_raise: true
+        - has_try_except: false
+    explanation: >
+      Pydantic AI distinguishes two kinds of tool failure: a ModelRetry, which is
+      fed back to the model as guidance so it can correct its arguments and try
+      again, and any other exception, which propagates out of agent.run() and ends
+      the run. A tool that raises whatever the underlying library raised takes the
+      second path for failures that belonged in the first — a validation error or a
+      404 aborts the whole run rather than giving the model a chance to fix its
+      call.
+    fix: >
+      Catch the failures you expect and either raise ModelRetry with a message
+      telling the model what to change, or return a structured result it can
+      branch on — e.g. {"error": "...", "retryable": true}. Let only genuinely
+      unrecoverable exceptions escape the tool.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **trustabl/trustabl-rules#81**, on a branch of the **same name**, so the `rules-sync` job resolves the matching production pack rather than `main`. Neither half should merge alone — `check-rules-sync.sh` fails if they do.

## What the pair adds

Four packs ship a rule for a tool that raises without catching — CSDK-005, OAI-008, ADK-005, MCP-006. LangChain, CrewAI, AutoGen and Pydantic AI ship none, so the same defect goes unreported in four of the five packs listed as weakest. The rules PR adds LC-007, CREW-007, AG2-013 and PYD-008 using the same `has_raise` + `has_try_except` predicate pair.

## What this PR does

1. Mirrors the four new `error_handling.yaml` files into `testdata/rules-fixture/`.
2. Adds a fire case and a silent case for each to `policyRuleCases`, as `TestPolicyRules_AllRulesCovered` requires.

Each silent case **catches and returns `{"error": ..., "retryable": ...}`** — the exact shape the rules' `fix` text prescribes — rather than just deleting the `raise`. So the silent case demonstrates the remediation actually clears the finding, not merely that the predicate is satisfiable.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (90 files compared)

$ go vet ./...
$ go test ./...
(all packages ok)
```

And end to end, with a build of this branch scanning real sample projects against the paired rules branch:

```
LC-007   [low] lookup_order  tools.py:5
CREW-007 [low] fetch_invoice tools.py:5
AG2-013  [low] load_profile  tools.py:6
PYD-008  [low] get_account   tools.py:7
```

Each sample also holds a second tool that catches and returns a structured error; no rule fired on those.

## Note

`internal/rules/policies_test.go` is not `gofmt`-clean on `main` (the raw-string test sources), and I left that alone rather than mixing a whole-file reformat into this diff. The added cases follow the surrounding style. CI runs `go vet`, which passes.