### PR TITLE
test(rules): mirror and cover LC-008, CREW-008, AG2-014, PYD-009

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -219,6 +219,23 @@ def fetch(q: str) -> str:
     return requests.get("https://api.example.com/data").text
 `, wantFires: false},
 
+	{name: "LC-008 fires on unresolved path param", ruleID: "LC-008", kind: models.KindLangChainTool, src: `
+def read_doc(path: str) -> str:
+    """Read a file."""
+    with open(path) as f:
+        return f.read()
+`, wantFires: true},
+	{name: "LC-008 silent when the path is resolved and contained", ruleID: "LC-008", kind: models.KindLangChainTool, src: `
+def read_doc(path: str) -> str:
+    """Read a file."""
+    from pathlib import Path
+    p = Path(path).resolve()
+    if not p.is_relative_to(ROOT):
+        return "denied"
+    with open(p) as f:
+        return f.read()
+`, wantFires: false},
+
 	{name: "LC-006 fires on return_direct=True", ruleID: "LC-006", kind: models.KindLangChainTool, src: `
 def f(x: str) -> str:
     """Doc."""
@@ -425,6 +442,23 @@ def fetch(q: str) -> str:
     return requests.get("https://api.example.com/data").text
 `, wantFires: false},
 
+	{name: "CREW-008 fires on unresolved path param", ruleID: "CREW-008", kind: models.KindCrewAITool, src: `
+def read_report(path: str) -> str:
+    """Read a file."""
+    with open(path) as f:
+        return f.read()
+`, wantFires: true},
+	{name: "CREW-008 silent when the path is resolved and contained", ruleID: "CREW-008", kind: models.KindCrewAITool, src: `
+def read_report(path: str) -> str:
+    """Read a file."""
+    from pathlib import Path
+    p = Path(path).resolve()
+    if not p.is_relative_to(ROOT):
+        return "denied"
+    with open(p) as f:
+        return f.read()
+`, wantFires: false},
+
 	{name: "CREW-006 fires on mutating tool without key", ruleID: "CREW-006", kind: models.KindCrewAITool, src: `
 def create_order(customer_id: str, amount: float) -> dict:
     """Create an order."""
@@ -508,6 +542,23 @@ def fetch(q: str) -> str:
     """Fetch."""
     import requests
     return requests.get("https://api.example.com/data").text
+`, wantFires: false},
+
+	{name: "AG2-014 fires on unresolved path param", ruleID: "AG2-014", kind: models.KindAutoGenTool, src: `
+def read_notes(path: str) -> str:
+    """Read a file."""
+    with open(path) as f:
+        return f.read()
+`, wantFires: true},
+	{name: "AG2-014 silent when the path is resolved and contained", ruleID: "AG2-014", kind: models.KindAutoGenTool, src: `
+def read_notes(path: str) -> str:
+    """Read a file."""
+    from pathlib import Path
+    p = Path(path).resolve()
+    if not p.is_relative_to(ROOT):
+        return "denied"
+    with open(p) as f:
+        return f.read()
 `, wantFires: false},
 
 	{name: "AG2-012 fires on network call without timeout", ruleID: "AG2-012", kind: models.KindAutoGenTool, src: `
@@ -597,6 +648,23 @@ def fetch(q: str) -> str:
     """Fetch."""
     import requests
     return requests.get("https://api.example.com/data", timeout=10).text
+`, wantFires: false},
+
+	{name: "PYD-009 fires on unresolved path param", ruleID: "PYD-009", kind: models.KindPydanticAITool, src: `
+def read_ledger(path: str) -> str:
+    """Read a file."""
+    with open(path) as f:
+        return f.read()
+`, wantFires: true},
+	{name: "PYD-009 silent when the path is resolved and contained", ruleID: "PYD-009", kind: models.KindPydanticAITool, src: `
+def read_ledger(path: str) -> str:
+    """Read a file."""
+    from pathlib import Path
+    p = Path(path).resolve()
+    if not p.is_relative_to(ROOT):
+        return "denied"
+    with open(p) as f:
+        return f.read()
 `, wantFires: false},
 
 	{name: "PYD-007 fires on mutating tool without key", ruleID: "PYD-007", kind: models.KindPydanticAITool, src: `

--- a/testdata/rules-fixture/autogen/path_safety.yaml
+++ b/testdata/rules-fixture/autogen/path_safety.yaml
@@ -1,0 +1,42 @@
+policy:
+  id: autogen_path_safety
+  name: AutoGen filesystem path safety
+  category: autogen
+  description: >
+    Rules that catch a model-chosen filesystem path flowing into I/O inside an
+    AutoGen / AG2 tool without containment. Tool arguments are produced by the
+    model from the shared conversation, so a traversal payload reaches real
+    filesystem state if the function does not resolve and gate it.
+
+rules:
+  - id: AG2-014
+    title: AutoGen tool uses a caller-supplied path without containment
+    severity: high
+    confidence: 0.7
+    language: python
+    applies_to:
+      - autogen_tool
+    scope: tool
+    # call_uses_unnormalized_path_param is per-param: a tool with two path
+    # params and one .resolve() correctly fires on the unresolved one.
+    match:
+      call_uses_unnormalized_path_param:
+        callees:
+          - open
+          - Path
+        callee_prefixes:
+          - shutil.
+          - os.
+    explanation: >
+      The tool takes a path-like parameter and hands it to file or directory
+      operations without resolving it or checking it against an allowed root.
+      AutoGen fills the argument from the conversation, and in a group chat every
+      participant writes into that conversation, so a path proposed by any agent
+      — including one summarizing untrusted content — reaches this function. A
+      ../../etc/passwd then reads or writes state outside the intended directory.
+      Detection is heuristic: confirm the parameter is genuinely model-supplied.
+    fix: >
+      Resolve the path with Path(...).resolve() and assert it sits under an
+      allowed root before any I/O touches it, rejecting anything that escapes.
+      Do the check on the resolved path — validating the raw string still lets
+      symlinks and .. segments through.

--- a/testdata/rules-fixture/crewai/path_safety.yaml
+++ b/testdata/rules-fixture/crewai/path_safety.yaml
@@ -1,0 +1,42 @@
+policy:
+  id: crewai_path_safety
+  name: CrewAI filesystem path safety
+  category: crewai
+  description: >
+    Rules that catch a model-chosen filesystem path flowing into I/O inside a
+    CrewAI tool without containment. Tool arguments come from the agent, and in
+    a crew they may originate in another agent's output, so a traversal payload
+    reaches real filesystem state if the handler does not resolve and gate it.
+
+rules:
+  - id: CREW-008
+    title: CrewAI tool uses a caller-supplied path without containment
+    severity: high
+    confidence: 0.7
+    language: python
+    applies_to:
+      - crewai_tool
+    scope: tool
+    # call_uses_unnormalized_path_param is per-param: a tool with two path
+    # params and one .resolve() correctly fires on the unresolved one.
+    match:
+      call_uses_unnormalized_path_param:
+        callees:
+          - open
+          - Path
+        callee_prefixes:
+          - shutil.
+          - os.
+    explanation: >
+      The tool takes a path-like parameter and hands it to file or directory
+      operations without resolving it or checking it against an allowed root.
+      The argument is chosen by the agent from its context, and in a crew that
+      context includes other agents' task output and any document they fetched,
+      so the path is attacker-reachable through any of those. A ../../etc/passwd
+      then reads or writes state outside the intended directory. Detection is
+      heuristic: confirm the parameter is genuinely agent-supplied.
+    fix: >
+      Resolve the path with Path(...).resolve() and assert it sits under an
+      allowed root before any I/O touches it, rejecting anything that escapes.
+      Do the check on the resolved path — validating the raw string still lets
+      symlinks and .. segments through.

--- a/testdata/rules-fixture/langchain/path_safety.yaml
+++ b/testdata/rules-fixture/langchain/path_safety.yaml
@@ -1,0 +1,42 @@
+policy:
+  id: langchain_path_safety
+  name: LangChain filesystem path safety
+  category: langchain
+  description: >
+    Rules that catch a model-chosen filesystem path flowing into I/O inside a
+    LangChain / LangGraph tool without containment. The tool's arguments are
+    produced by the model from conversation context, so a traversal payload
+    reaches real filesystem state if the handler does not resolve and gate it.
+
+rules:
+  - id: LC-008
+    title: LangChain tool uses a caller-supplied path without containment
+    severity: high
+    confidence: 0.7
+    language: python
+    applies_to:
+      - langchain_tool
+    scope: tool
+    # call_uses_unnormalized_path_param is per-param: a tool with two path
+    # params and one .resolve() correctly fires on the unresolved one.
+    match:
+      call_uses_unnormalized_path_param:
+        callees:
+          - open
+          - Path
+        callee_prefixes:
+          - shutil.
+          - os.
+    explanation: >
+      The tool takes a path-like parameter and hands it to file or directory
+      operations without resolving it or checking it against an allowed root.
+      A LangChain tool's arguments are filled in by the model from whatever is in
+      its context — retrieved documents, tool output, user text — so the path is
+      attacker-reachable wherever any of that is untrusted, and a
+      ../../etc/passwd reads or writes state outside the intended directory.
+      Detection is heuristic: confirm the parameter is genuinely model-supplied.
+    fix: >
+      Resolve the path with Path(...).resolve() and assert it sits under an
+      allowed root before any I/O touches it, rejecting anything that escapes.
+      Do the check on the resolved path — validating the raw string still lets
+      symlinks and .. segments through.

--- a/testdata/rules-fixture/pydantic_ai/path_safety.yaml
+++ b/testdata/rules-fixture/pydantic_ai/path_safety.yaml
@@ -1,0 +1,43 @@
+policy:
+  id: pydantic_ai_path_safety
+  name: Pydantic AI filesystem path safety
+  category: pydantic_ai
+  description: >
+    Rules that catch a model-chosen filesystem path flowing into I/O inside a
+    Pydantic AI tool without containment. A validated argument type constrains
+    the shape of the path, not where it points, so a traversal payload reaches
+    real filesystem state if the tool does not resolve and gate it.
+
+rules:
+  - id: PYD-009
+    title: Pydantic AI tool uses a caller-supplied path without containment
+    severity: high
+    confidence: 0.7
+    language: python
+    applies_to:
+      - pydantic_ai_tool
+    scope: tool
+    # call_uses_unnormalized_path_param is per-param: a tool with two path
+    # params and one .resolve() correctly fires on the unresolved one.
+    match:
+      call_uses_unnormalized_path_param:
+        callees:
+          - open
+          - Path
+        callee_prefixes:
+          - shutil.
+          - os.
+    explanation: >
+      The tool takes a path-like parameter and hands it to file or directory
+      operations without resolving it or checking it against an allowed root.
+      Pydantic AI validates the argument against its annotation, which is easy to
+      mistake for having validated it: str and Path both accept ../../etc/passwd,
+      because the type says what the value looks like and not where it points.
+      The model fills the argument from its context, so the path is
+      attacker-reachable wherever that context is. Detection is heuristic:
+      confirm the parameter is genuinely model-supplied.
+    fix: >
+      Resolve the path with Path(...).resolve() and assert it sits under an
+      allowed root before any I/O touches it, rejecting anything that escapes.
+      A Pydantic field validator is a good place for it, provided it checks the
+      resolved path — validating the raw string still lets symlinks and .. through.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **https://github.com/trustabl/trustabl-rules/pull/97**, on a branch of the **same name**, so the `rules-sync` job resolves the matching production pack rather than `main`. Neither half should merge alone — `check-rules-sync.sh` fails if they do.

## What the pair adds

Claude, OpenAI, Google ADK and MCP each ship a high-severity rule for a caller-supplied path reaching filesystem I/O unresolved (CSDK-004, OAI-006, ADK-004, MCP-005). LangChain, CrewAI, AutoGen and Pydantic AI ship none. The rules PR adds LC-008, CREW-008, AG2-014 and PYD-009 using the existing `call_uses_unnormalized_path_param` predicate.

## What this PR does

1. Mirrors the four new `path_safety.yaml` files into `testdata/rules-fixture/`.
2. Adds a fire case and a silent case for each to `policyRuleCases`.

The fire case passes a `str` parameter straight to `open()`. The silent case does exactly what the rules' `fix` text prescribes:

```python
p = Path(path).resolve()
if not p.is_relative_to(ROOT):
    return "denied"
with open(p) as f:
    return f.read()
```

so it demonstrates that the prescribed remediation actually clears the finding — not merely that removing the I/O call does.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (90 files compared)

$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules
$ go vet ./... && go test ./...
(all packages ok)
```

Before the fixture cases were added, the coverage guard failed exactly as intended:

```
--- FAIL: TestPolicyRules_AllRulesCovered
    policies_test.go:4151: rules with no policy_test coverage at all: [AG2-014 CREW-008 LC-008 PYD-009]
```

And end to end, a build of this branch scanning sample projects against the paired rules branch:

```
LC-008   [high] read_doc    tools.py:8
CREW-008 [high] read_doc    tools.py:8
AG2-014  [high] read_notes  tools.py:8
PYD-009  [high] read_ledger tools.py:9
```

Each sample also holds a resolved-and-contained twin; no rule fired on those.