### PR TITLE
test(rules): mirror and cover LC-007, LC-015

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -1986,6 +1986,40 @@ def fetch_data(x: str) -> dict:
     return {}
 `,
 		toolConfig: nil, wantFires: false},
+
+	// ─── LC-007 / LC-015: LangChain tool network call without a timeout ─────
+	// Python uses call_without_kwarg (same callee list as PYD-006); TypeScript
+	// uses the structural has_http_call_without_timeout, as OAI-016 does.
+	{name: "LC-007 fires on network call without timeout", ruleID: "LC-007", kind: models.KindLangChainTool, src: `
+def fetch_report(url: str) -> str:
+    """Fetch a report."""
+    import requests
+    return requests.get(url).text
+`, wantFires: true},
+	{name: "LC-007 silent with timeout", ruleID: "LC-007", kind: models.KindLangChainTool, src: `
+def fetch_report(url: str) -> str:
+    """Fetch a report."""
+    import requests
+    return requests.get(url, timeout=10).text
+`, wantFires: false},
+	{
+		name: "LC-015 fires on TS fetch with no AbortSignal", ruleID: "LC-015",
+		kind: models.KindLangChainTool, lang: models.LanguageTypeScript, wantFires: true,
+		src: "import { tool } from \"@langchain/core/tools\";\n" +
+			"export const t = tool(async ({ p }: { p: string }) => {\n" +
+			"  const r = await fetch(`https://reports.internal/${p}`);\n" +
+			"  return await r.text();\n" +
+			"}, { name: \"fetch_report\", description: \"Fetch a report.\", schema: {} });\n",
+	},
+	{
+		name: "LC-015 silent when AbortSignal present", ruleID: "LC-015",
+		kind: models.KindLangChainTool, lang: models.LanguageTypeScript, wantFires: false,
+		src: "import { tool } from \"@langchain/core/tools\";\n" +
+			"export const t = tool(async ({ p }: { p: string }) => {\n" +
+			"  const r = await fetch(`https://reports.internal/${p}`, { signal: AbortSignal.timeout(15000) });\n" +
+			"  return await r.text();\n" +
+			"}, { name: \"fetch_report\", description: \"Fetch a report.\", schema: {} });\n",
+	},
 }
 
 // policyRepoRuleCases covers repo-scoped rules.
@@ -2246,7 +2280,6 @@ var policyRepoRuleCases = []policyRepoCase{
 		},
 		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKOpenAIAgents}},
 		false},
-
 }
 
 // optionsWithPermissionMode builds a ClaudeAgentOptionsDef whose captured

--- a/testdata/rules-fixture/langchain/network.yaml
+++ b/testdata/rules-fixture/langchain/network.yaml
@@ -1,0 +1,83 @@
+policy:
+  id: langchain_network
+  name: LangChain tool network hygiene
+  category: langchain
+  description: >
+    Network-call hygiene inside LangChain tool functions. A tool that issues an
+    outbound request with no deadline hangs the agent's executor loop until the
+    remote gives up, so the run never completes and never reports why.
+
+rules:
+  - id: LC-007
+    title: LangChain tool network call has no timeout
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      call_without_kwarg:
+        callees:
+          - requests.get
+          - requests.post
+          - requests.put
+          - requests.delete
+          - requests.patch
+          - requests.head
+          - requests.request
+          - httpx.get
+          - httpx.post
+          - httpx.put
+          - httpx.delete
+          - httpx.patch
+          - httpx.head
+          - httpx.request
+          - requests.Session.get
+          - requests.Session.post
+          - urllib.request.urlopen
+          # Bare `urlopen` covers the from-import form.
+          - urlopen
+          # Aliased aiohttp sessions canonicalize to aiohttp.ClientSession.<m>.
+          - aiohttp.ClientSession.get
+          - aiohttp.ClientSession.post
+        missing: timeout
+    explanation: >
+      This LangChain tool makes a network request with no timeout, so it hangs
+      indefinitely on a slow or unresponsive remote. The tool runs synchronously
+      inside the AgentExecutor loop: a stalled request blocks that iteration
+      until the connection eventually dies, so the agent neither finishes the run
+      nor tells the model anything went wrong. LC-102's max_iterations cap does
+      not help — it bounds how many steps the executor takes, not how long one
+      step is allowed to take.
+    fix: >
+      Pass timeout= (typically 5–30 seconds) to the request. Choose a value tight
+      enough to fail fast and loose enough for this endpoint's legitimate slow
+      responses, and catch the resulting timeout so the tool returns a structured
+      error the model can act on instead of stalling the run.
+
+  - id: LC-015
+    title: TypeScript LangChain tool network call has no timeout
+    severity: high
+    confidence: 0.6
+    language: typescript
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      has_http_call_without_timeout: true
+    explanation: >
+      This LangChain.js tool makes an outbound HTTP call (fetch / axios / got /
+      undici) with no deadline — no `signal`, `timeout`, or `abortSignal` option.
+      Node's `fetch` has no implicit deadline, so an unresponsive host blocks the
+      tool callback forever, holding the executor iteration and the request
+      worker behind it. Paired with LC-013 the exposure compounds: a
+      model-controlled URL that also cannot time out can be steered at an
+      internal host that simply never answers.
+    fix: >
+      Attach a deadline. On modern runtimes,
+      `await fetch(url, { signal: AbortSignal.timeout(15_000) })`; on older ones,
+      create an `AbortController`, abort it from a `setTimeout`, pass
+      `controller.signal`, and clear the timer in a `finally`. axios and got take
+      a `timeout` option directly. Return the abort as a structured tool error so
+      the model can retry or route around it.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **trustabl/trustabl-rules#52**, on a branch of the **same name**, so the `rules-sync` job resolves the matching pack rather than `main`. Neither half should merge alone — `check-rules-sync.sh` fails if they do.

## What the pair adds

LangChain was the only pack with tool discovery and no network-timeout rule; Pydantic AI (PYD-006), AutoGen (AG2-012), and the Vercel AI SDK (VAI-011) all ship one. The rules PR adds LC-007 (python, `call_without_kwarg` with the same callee list as PYD-006) and LC-015 (typescript, `has_http_call_without_timeout`, as OAI-016 uses).

## What this PR does

1. Mirrors `langchain/network.yaml` into `testdata/rules-fixture/`.
2. Adds a fire case and a silent case for each rule to `policyRuleCases`, as `TestPolicyRules_AllRulesCovered` requires.

Each silent case **applies the remediation the rule's `fix` text prescribes** — `timeout=10` for Python, `signal: AbortSignal.timeout(15000)` for TypeScript — rather than deleting the call. So the silent case demonstrates the prescribed fix actually clears the finding, not merely that the predicate is satisfiable.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (87 files compared)

$ go vet ./internal/rules/
$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules	2.935s
```

Also verified end to end before opening the rules PR: a build of `main` scanning fixture projects against the paired rules branch reported `LC-007` and `LC-015` on the unguarded versions and neither on the guarded ones.