### PR TITLE
test(rules): mirror and cover CREW-007

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -1986,6 +1986,21 @@ def fetch_data(x: str) -> dict:
     return {}
 `,
 		toolConfig: nil, wantFires: false},
+
+	// ─── CREW-007: CrewAI tool network call without a timeout ───────────────
+	// Same call_without_kwarg callee list as PYD-006.
+	{name: "CREW-007 fires on network call without timeout", ruleID: "CREW-007", kind: models.KindCrewAITool, src: `
+def fetch_report(url: str) -> str:
+    """Fetch a report."""
+    import requests
+    return requests.get(url).text
+`, wantFires: true},
+	{name: "CREW-007 silent with timeout", ruleID: "CREW-007", kind: models.KindCrewAITool, src: `
+def fetch_report(url: str) -> str:
+    """Fetch a report."""
+    import requests
+    return requests.get(url, timeout=10).text
+`, wantFires: false},
 }
 
 // policyRepoRuleCases covers repo-scoped rules.
@@ -2246,7 +2261,6 @@ var policyRepoRuleCases = []policyRepoCase{
 		},
 		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKOpenAIAgents}},
 		false},
-
 }
 
 // optionsWithPermissionMode builds a ClaudeAgentOptionsDef whose captured

--- a/testdata/rules-fixture/crewai/network.yaml
+++ b/testdata/rules-fixture/crewai/network.yaml
@@ -1,0 +1,57 @@
+policy:
+  id: crewai_network
+  name: CrewAI tool network hygiene
+  category: crewai
+  description: >
+    Network-call hygiene inside CrewAI tool functions. A tool that issues an
+    outbound request with no deadline stalls the agent that called it, and in a
+    crew that agent's task blocks every task sequenced behind it.
+
+rules:
+  - id: CREW-007
+    title: CrewAI tool network call has no timeout
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - crewai_tool
+    scope: tool
+    match:
+      call_without_kwarg:
+        callees:
+          - requests.get
+          - requests.post
+          - requests.put
+          - requests.delete
+          - requests.patch
+          - requests.head
+          - requests.request
+          - httpx.get
+          - httpx.post
+          - httpx.put
+          - httpx.delete
+          - httpx.patch
+          - httpx.head
+          - httpx.request
+          - requests.Session.get
+          - requests.Session.post
+          - urllib.request.urlopen
+          # Bare `urlopen` covers the from-import form.
+          - urlopen
+          # Aliased aiohttp sessions canonicalize to aiohttp.ClientSession.<m>.
+          - aiohttp.ClientSession.get
+          - aiohttp.ClientSession.post
+        missing: timeout
+    explanation: >
+      This CrewAI tool makes a network request with no timeout, so it hangs
+      indefinitely on a slow or unresponsive remote. The cost is worse than one
+      stuck agent: a crew executes tasks in sequence and passes each task's
+      output forward as context, so a tool stalled inside one task blocks every
+      task behind it and the whole crew produces nothing. CREW-110's max_iter cap
+      bounds how many reasoning steps an agent takes, not how long a single tool
+      call may run, so it never breaks the stall.
+    fix: >
+      Pass timeout= (typically 5–30 seconds) to the request. Choose a value tight
+      enough to fail fast and loose enough for this endpoint's legitimate slow
+      responses, and catch the resulting timeout so the tool returns a structured
+      error string the agent can reason about instead of leaving the crew hung.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **trustabl/trustabl-rules#53**, on a branch of the **same name**, so the `rules-sync` job resolves the matching pack rather than `main`. Neither half should merge alone — `check-rules-sync.sh` fails if they do.

## What the pair adds

CrewAI had no network-timeout rule, unlike Pydantic AI (PYD-006), AutoGen (AG2-012), and the Vercel AI SDK (VAI-011). The blast radius is larger in a crew: tasks run in sequence and each task's output is threaded forward as context, so a tool stalled inside one task blocks every task behind it. CREW-110's `max_iter` doesn't help — it bounds reasoning steps, not the wall-clock of a single tool call.

CREW-007 uses the same `call_without_kwarg` callee list as PYD-006, so the alias-aware `requests.Session` / `aiohttp.ClientSession` handling matches the shipped rules.

## What this PR does

1. Mirrors `crewai/network.yaml` into `testdata/rules-fixture/`.
2. Adds a fire case and a silent case to `policyRuleCases`, as `TestPolicyRules_AllRulesCovered` requires.

The silent case **applies the remediation the rule's `fix` text prescribes** (`timeout=10`) rather than deleting the call, so it demonstrates the prescribed fix actually clears the finding, not merely that the predicate is satisfiable.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (87 files compared)

$ go vet ./internal/rules/
$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules	3.026s
```