### PR TITLE
test(rules): mirror and cover LC-009

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -219,6 +219,19 @@ def fetch(q: str) -> str:
     return requests.get("https://api.example.com/data").text
 `, wantFires: false},
 
+	{name: "LC-009 fires on request without timeout", ruleID: "LC-009", kind: models.KindLangChainTool, src: `
+def fetch_status(service: str) -> str:
+    """Fetch a service status page."""
+    import requests
+    return requests.get("https://status.example.com/" + service).text
+`, wantFires: true},
+	{name: "LC-009 silent with timeout", ruleID: "LC-009", kind: models.KindLangChainTool, src: `
+def fetch_status(service: str) -> str:
+    """Fetch a service status page."""
+    import requests
+    return requests.get("https://status.example.com/" + service, timeout=10).text
+`, wantFires: false},
+
 	{name: "LC-006 fires on return_direct=True", ruleID: "LC-006", kind: models.KindLangChainTool, src: `
 def f(x: str) -> str:
     """Doc."""

--- a/testdata/rules-fixture/langchain/network.yaml
+++ b/testdata/rules-fixture/langchain/network.yaml
@@ -1,0 +1,57 @@
+policy:
+  id: langchain_network
+  name: LangChain tool network hygiene
+  category: langchain
+  description: >
+    Network-call hygiene inside LangChain tool functions. A tool that makes a
+    network request without a timeout can hang the agent run indefinitely.
+
+rules:
+  - id: LC-009
+    title: LangChain tool network call has no timeout
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      call_without_kwarg:
+        callees:
+          - requests.get
+          - requests.post
+          - requests.put
+          - requests.delete
+          - requests.patch
+          - requests.head
+          - requests.request
+          - httpx.get
+          - httpx.post
+          - httpx.put
+          - httpx.delete
+          - httpx.patch
+          - httpx.head
+          - httpx.request
+          - requests.Session.get
+          - requests.Session.post
+          - urllib.request.urlopen
+          # Bare `urlopen` covers the from-import form.
+          - urlopen
+          # Aliased aiohttp sessions canonicalize to aiohttp.ClientSession.<m>.
+          - aiohttp.ClientSession.get
+          - aiohttp.ClientSession.post
+        missing: timeout
+    explanation: >
+      This LangChain tool makes a network request with no timeout, so it hangs
+      indefinitely on a slow or unresponsive remote. The call runs inside the
+      agent's step, so the whole executor blocks on it — max_iterations bounds how
+      many steps an agent takes, not how long one step lasts, and no LangChain
+      setting caps the duration of a tool call. The agent therefore has no bound
+      at all on that path: it does not fail, retry, or surface anything to the
+      model; it simply stops, holding whatever runtime is hosting it until the
+      connection eventually dies.
+    fix: >
+      Pass timeout= (typically 5–30 seconds) to the request. Choose a value tight
+      enough to fail fast and loose enough for a legitimately slow endpoint, and
+      return the timeout to the model as a structured, retryable error so it can
+      react rather than waiting on a call that will never return.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **https://github.com/trustabl/trustabl-rules/pull/98**, on a branch of the **same name**, so `rules-sync` resolves the matching production pack rather than `main`. Neither half should merge alone.

## What the pair adds

Every pack except LangChain ships a no-timeout rule — CSDK-003, OAI-005, ADK-003, MCP-004, AG2-012, PYD-006, VAI-011. The rules PR adds LC-009 using the existing `call_without_kwarg` predicate.

What makes it matter in LangChain specifically: `max_iterations` bounds how many steps an agent takes, not how long one lasts, and no LangChain setting caps a tool call's duration. A hung request is an unbounded path, not a slow one.

## What this PR does

Mirrors `langchain/network.yaml` into `testdata/rules-fixture/` and adds a fire and a silent case to `policyRuleCases`. The silent case is the same request with `timeout=10`, so it demonstrates the rule's own fix clears the finding rather than that deleting the call does.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (87 files compared)

$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules
```

End to end, a build of this branch against the paired rules branch:

```
LC-009 [high] fetch_status tools.py:6
```

with the `timeout=10` twin in the same file not firing.