### PR TITLE
test(rules): mirror and cover PYD-008

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -1986,6 +1986,36 @@ def fetch_data(x: str) -> dict:
     return {}
 `,
 		toolConfig: nil, wantFires: false},
+
+	// ─── PYD-008: Pydantic AI tool raises with no ModelRetry path ───────────
+	// has_raise + no try/except, minus a has_body_text suppressor for
+	// ModelRetry. Three cases: the raise, and BOTH silencing routes — catching
+	// the failure, and raising ModelRetry (the SDK's own recovery channel,
+	// which must not be reported as a defect).
+	{name: "PYD-008 fires on uncaught raise", ruleID: "PYD-008", kind: models.KindPydanticAITool, src: `
+def lookup_order(order_id: str) -> str:
+    """Look up an order."""
+    if not order_id:
+        raise ValueError("order_id is required")
+    return order_id
+`, wantFires: true},
+	{name: "PYD-008 silent when the failure is caught", ruleID: "PYD-008", kind: models.KindPydanticAITool, src: `
+def lookup_order(order_id: str) -> dict:
+    """Look up an order."""
+    try:
+        if not order_id:
+            raise ValueError("order_id is required")
+        return {"order_id": order_id}
+    except ValueError as exc:
+        return {"error": str(exc), "retryable": False}
+`, wantFires: false},
+	{name: "PYD-008 silent on raise ModelRetry", ruleID: "PYD-008", kind: models.KindPydanticAITool, src: `
+def lookup_order(order_id: str) -> str:
+    """Look up an order."""
+    if not order_id:
+        raise ModelRetry("order_id was empty; supply the customer's order number")
+    return order_id
+`, wantFires: false},
 }
 
 // policyRepoRuleCases covers repo-scoped rules.
@@ -2246,7 +2276,6 @@ var policyRepoRuleCases = []policyRepoCase{
 		},
 		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKOpenAIAgents}},
 		false},
-
 }
 
 // optionsWithPermissionMode builds a ClaudeAgentOptionsDef whose captured

--- a/testdata/rules-fixture/pydantic_ai/error_handling.yaml
+++ b/testdata/rules-fixture/pydantic_ai/error_handling.yaml
@@ -1,0 +1,51 @@
+policy:
+  id: pydantic_ai_error_handling
+  name: Pydantic AI error contract hygiene
+  category: pydantic_ai
+  description: >
+    Rules covering how a Pydantic AI tool surfaces failure. Pydantic AI draws a
+    hard line between the two: ModelRetry is fed back to the model as a
+    correction it can act on, while any other exception aborts the whole run.
+    A tool that raises the wrong kind turns a recoverable failure into a dead
+    run.
+
+rules:
+  - id: PYD-008
+    title: Pydantic AI tool raises without a ModelRetry or structured error path
+    severity: low
+    confidence: 0.6
+    language: python
+    applies_to:
+      - pydantic_ai_tool
+    scope: tool
+    # has_raise + no try/except is the same shape as CSDK-005 and MCP-006. The
+    # `not: has_body_text` clause is a suppressor, not the detection signal: a
+    # tool whose only raise IS `raise ModelRetry(...)` is already using the
+    # SDK's recovery channel correctly, and firing on it would be a false
+    # positive. ModelRetry is a bare imported name with no structural
+    # signature, which is the narrow case the schema reserves has_body_text for.
+    match:
+      all:
+        - has_raise: true
+        - has_try_except: false
+        - not:
+            has_body_text:
+              - ModelRetry
+    explanation: >
+      This tool raises an exception that is neither caught nor a ModelRetry.
+      Pydantic AI treats the two paths very differently: ModelRetry is captured
+      by the agent, appended to the message history as feedback, and the model
+      gets another attempt bounded by the agent's retries setting. Every other
+      exception propagates out of agent.run() and ends the run, so a transient
+      failure the model could have worked around — a bad argument it could
+      correct, a lookup that missed — kills the whole call instead. The caller
+      also receives a raw traceback rather than a result, and the message may
+      carry internal detail (paths, connection strings) the tool never meant to
+      expose.
+    fix: >
+      Decide which failures the model can act on. For those, raise
+      ModelRetry("...") with a message that tells the model exactly what to
+      change, so the agent re-prompts within its retry budget. For failures the
+      model cannot fix, catch the specific exception and return a structured
+      result the caller can branch on (an error field plus a retryable flag)
+      rather than letting it escape agent.run().


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **trustabl/trustabl-rules#54**, on a branch of the **same name**, so the `rules-sync` job resolves the matching pack rather than `main`. Neither half should merge alone — `check-rules-sync.sh` fails if they do.

## What the pair adds

Pydantic AI was the last Python pack with tool discovery and no error-contract rule (CSDK-005, OAI-008, ADK-005, MCP-006 all exist). PYD-008 is framed around the split Pydantic AI actually makes: `ModelRetry` is appended to the message history and re-prompts the model within its `retries` budget, while any other exception propagates out of `agent.run()` and ends the run.

## What this PR does

1. Mirrors `pydantic_ai/error_handling.yaml` into `testdata/rules-fixture/`.
2. Adds cases to `policyRuleCases`, as `TestPolicyRules_AllRulesCovered` requires.

**Three cases rather than two**, because PYD-008 has two distinct silencing routes and both are worth pinning:

| case | expectation |
|---|---|
| `raise ValueError(...)`, uncaught | fires |
| try/except returning `{"error": ..., "retryable": ...}` | silent |
| `raise ModelRetry(...)` | silent |

The third is the one that matters most. The rule carries a `not: has_body_text: [ModelRetry]` clause purely as a **false-positive suppressor** — a tool already using the SDK's recovery channel is correct code and must not be reported. That case is what guards the suppressor against regression; without it, someone simplifying the rule to plain `has_raise` + `has_try_except` would break correct Pydantic AI code and the suite would stay green.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (87 files compared)

$ go vet ./internal/rules/
$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules	3.194s
```