### PR TITLE
test(rules): mirror and cover CREW-009

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -425,6 +425,19 @@ def fetch(q: str) -> str:
     return requests.get("https://api.example.com/data").text
 `, wantFires: false},
 
+	{name: "CREW-009 fires on request without timeout", ruleID: "CREW-009", kind: models.KindCrewAITool, src: `
+def fetch_quote(symbol: str) -> str:
+    """Fetch a price quote."""
+    import requests
+    return requests.get("https://quotes.example.com/" + symbol).text
+`, wantFires: true},
+	{name: "CREW-009 silent with timeout", ruleID: "CREW-009", kind: models.KindCrewAITool, src: `
+def fetch_quote(symbol: str) -> str:
+    """Fetch a price quote."""
+    import requests
+    return requests.get("https://quotes.example.com/" + symbol, timeout=10).text
+`, wantFires: false},
+
 	{name: "CREW-006 fires on mutating tool without key", ruleID: "CREW-006", kind: models.KindCrewAITool, src: `
 def create_order(customer_id: str, amount: float) -> dict:
     """Create an order."""

--- a/testdata/rules-fixture/crewai/network.yaml
+++ b/testdata/rules-fixture/crewai/network.yaml
@@ -1,0 +1,56 @@
+policy:
+  id: crewai_network
+  name: CrewAI tool network hygiene
+  category: crewai
+  description: >
+    Network-call hygiene inside CrewAI tool functions. A tool that makes a
+    network request without a timeout can hang the agent run indefinitely.
+
+rules:
+  - id: CREW-009
+    title: CrewAI tool network call has no timeout
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - crewai_tool
+    scope: tool
+    match:
+      call_without_kwarg:
+        callees:
+          - requests.get
+          - requests.post
+          - requests.put
+          - requests.delete
+          - requests.patch
+          - requests.head
+          - requests.request
+          - httpx.get
+          - httpx.post
+          - httpx.put
+          - httpx.delete
+          - httpx.patch
+          - httpx.head
+          - httpx.request
+          - requests.Session.get
+          - requests.Session.post
+          - urllib.request.urlopen
+          # Bare `urlopen` covers the from-import form.
+          - urlopen
+          # Aliased aiohttp sessions canonicalize to aiohttp.ClientSession.<m>.
+          - aiohttp.ClientSession.get
+          - aiohttp.ClientSession.post
+        missing: timeout
+    explanation: >
+      This CrewAI tool makes a network request with no timeout, so it hangs
+      indefinitely on a slow or unresponsive remote. The call runs inside the
+      agent's step, and max_iter bounds how many steps an agent takes rather than
+      how long one lasts, so nothing in the crew caps it. In a sequential process
+      the stall also blocks every task queued behind this one: a single
+      unresponsive endpoint stops the whole crew, not just the agent that called
+      it, and no result is produced for any of them.
+    fix: >
+      Pass timeout= (typically 5–30 seconds) to the request. Choose a value tight
+      enough to fail fast and loose enough for a legitimately slow endpoint, and
+      return the timeout to the model as a structured, retryable error so the
+      agent can react rather than waiting on a call that will never return.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **https://github.com/trustabl/trustabl-rules/pull/99**, on a branch of the **same name**, so `rules-sync` resolves the matching production pack rather than `main`. Neither half should merge alone.

## What the pair adds

Every pack except CrewAI ships a no-timeout rule — CSDK-003, OAI-005, ADK-003, MCP-004, AG2-012, PYD-006, VAI-011. The rules PR adds CREW-009 using the existing `call_without_kwarg` predicate.

What makes it matter in CrewAI specifically: `max_iter` bounds steps, not time, and in a sequential process a stalled tool call blocks every task queued behind it — one unresponsive endpoint stops the whole crew, not just the calling agent.

## What this PR does

Mirrors `crewai/network.yaml` into `testdata/rules-fixture/` and adds a fire and a silent case to `policyRuleCases`. The silent case is the same request with `timeout=10`, so it demonstrates the rule's own fix clears the finding.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (87 files compared)

$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules
```

End to end, a build of this branch against the paired rules branch:

```
CREW-009 [high] fetch_quote tools.py:6
```

with the `timeout=10` twin in the same file not firing.