### PR TITLE
test(rules): mirror and cover LC-008

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -1986,6 +1986,25 @@ def fetch_data(x: str) -> dict:
     return {}
 `,
 		toolConfig: nil, wantFires: false},
+
+	// ─── LC-008: LangChain tool raises with no structured error contract ────
+	{name: "LC-008 fires on uncaught raise", ruleID: "LC-008", kind: models.KindLangChainTool, src: `
+def lookup_order(order_id: str) -> str:
+    """Look up an order."""
+    if not order_id:
+        raise ValueError("order_id is required")
+    return order_id
+`, wantFires: true},
+	{name: "LC-008 silent when the failure is caught", ruleID: "LC-008", kind: models.KindLangChainTool, src: `
+def lookup_order(order_id: str) -> dict:
+    """Look up an order."""
+    try:
+        if not order_id:
+            raise ValueError("order_id is required")
+        return {"order_id": order_id}
+    except ValueError as exc:
+        return {"error": str(exc), "retryable": False}
+`, wantFires: false},
 }
 
 // policyRepoRuleCases covers repo-scoped rules.
@@ -2246,7 +2265,6 @@ var policyRepoRuleCases = []policyRepoCase{
 		},
 		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKOpenAIAgents}},
 		false},
-
 }
 
 // optionsWithPermissionMode builds a ClaudeAgentOptionsDef whose captured

--- a/testdata/rules-fixture/langchain/error_handling.yaml
+++ b/testdata/rules-fixture/langchain/error_handling.yaml
@@ -1,0 +1,39 @@
+policy:
+  id: langchain_error_handling
+  name: LangChain error contract hygiene
+  category: langchain
+  description: >
+    Rules covering how a LangChain tool surfaces failure. By default an
+    exception raised inside a tool escapes the AgentExecutor and ends the run,
+    so the model never sees the failure and never gets a chance to recover from
+    it.
+
+rules:
+  - id: LC-008
+    title: LangChain tool raises without a structured error contract
+    severity: low
+    confidence: 0.6
+    language: python
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      all:
+        - has_raise: true
+        - has_try_except: false
+    explanation: >
+      This tool raises an exception it never catches. LangChain does not feed
+      tool exceptions back to the model unless you opt in: with the default
+      handle_tool_error=False the exception propagates out of the AgentExecutor
+      and aborts the run, so the model is never told the step failed and the
+      caller gets a traceback instead of an answer. Opting in with
+      handle_tool_error=True is barely better — the model receives the raw
+      str(exception), an opaque sentence with no failure mode, no indication
+      whether a retry could succeed, and whatever internal detail the message
+      happened to carry (file paths, hostnames, query fragments).
+    fix: >
+      Catch the failure modes you expect and return a structured result the
+      model can branch on — an error field naming the failure and a retryable
+      flag — instead of letting the exception escape. Where you do want
+      LangChain to intercept, set handle_tool_error to a callable that maps the
+      exception to a specific, model-readable message rather than to True.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **trustabl/trustabl-rules#55**, on a branch of the **same name**, so the `rules-sync` job resolves the matching pack rather than `main`. Neither half should merge alone — `check-rules-sync.sh` fails if they do.

## What the pair adds

LangChain had no error-contract rule (CSDK-005, OAI-008, ADK-005, MCP-006 all exist). LC-008 is framed for LangChain's actual behavior: with the default `handle_tool_error=False` the exception propagates out of the `AgentExecutor` and aborts the run, and opting in with `handle_tool_error=True` only hands the model the raw `str(exception)`.

## What this PR does

1. Mirrors `langchain/error_handling.yaml` into `testdata/rules-fixture/`.
2. Adds a fire case and a silent case to `policyRuleCases`, as `TestPolicyRules_AllRulesCovered` requires.

The silent case returns the `{"error": ..., "retryable": ...}` shape the rule's `fix` text prescribes rather than deleting the `raise`, so it demonstrates the prescribed remediation clears the finding.

## A gap this turned up

**Python only, deliberately.** I drafted a LangChain.js counterpart (LC-016) and dropped it after testing: `PredHasRaise` matches the Python grammar node `raise_statement`, so `has_raise` is structurally always false for a TypeScript tool — whose throws parse as `throw_statement`. The rule validated cleanly and never fired on a fixture that throws.

That blocks TS error-contract rules in *every* pack, not just this one. `PredHasShellCall` already branches on `models.IsTSOrJS` and reads a discovery-computed fact, so `PredHasRaise`/`PredHasTryExcept` could do the same. Happy to open that PR if you'd want it — it'd unblock a TS half for CSDK-005, OAI-008, ADK-005, MCP-006 and the four newer packs at once.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (87 files compared)

$ go vet ./internal/rules/
$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules	3.149s
```