### PR TITLE
test(rules): mirror and cover CREW-008

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -1986,6 +1986,25 @@ def fetch_data(x: str) -> dict:
     return {}
 `,
 		toolConfig: nil, wantFires: false},
+
+	// ─── CREW-008: CrewAI tool raises with no structured error contract ─────
+	{name: "CREW-008 fires on uncaught raise", ruleID: "CREW-008", kind: models.KindCrewAITool, src: `
+def lookup_order(order_id: str) -> str:
+    """Look up an order."""
+    if not order_id:
+        raise ValueError("order_id is required")
+    return order_id
+`, wantFires: true},
+	{name: "CREW-008 silent when the failure is caught", ruleID: "CREW-008", kind: models.KindCrewAITool, src: `
+def lookup_order(order_id: str) -> str:
+    """Look up an order."""
+    try:
+        if not order_id:
+            raise ValueError("order_id is required")
+        return order_id
+    except ValueError:
+        return "error: order_id was empty; supply the customer's order number"
+`, wantFires: false},
 }
 
 // policyRepoRuleCases covers repo-scoped rules.
@@ -2246,7 +2265,6 @@ var policyRepoRuleCases = []policyRepoCase{
 		},
 		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKOpenAIAgents}},
 		false},
-
 }
 
 // optionsWithPermissionMode builds a ClaudeAgentOptionsDef whose captured

--- a/testdata/rules-fixture/crewai/error_handling.yaml
+++ b/testdata/rules-fixture/crewai/error_handling.yaml
@@ -1,0 +1,39 @@
+policy:
+  id: crewai_error_handling
+  name: CrewAI error contract hygiene
+  category: crewai
+  description: >
+    Rules covering how a CrewAI tool surfaces failure. A tool that raises hands
+    the agent a stringified exception in place of a result, and in a sequential
+    crew that unusable output is threaded forward as context to every task
+    behind it.
+
+rules:
+  - id: CREW-008
+    title: CrewAI tool raises without a structured error contract
+    severity: low
+    confidence: 0.6
+    language: python
+    applies_to:
+      - crewai_tool
+    scope: tool
+    match:
+      all:
+        - has_raise: true
+        - has_try_except: false
+    explanation: >
+      This tool raises an exception it never catches. CrewAI stringifies the
+      exception and returns it to the agent as the tool's observation, so the
+      agent sees a bare message — no failure mode, no signal about whether a
+      retry could succeed — and typically burns its remaining max_iter budget
+      re-calling the same tool the same way. The damage does not stop at that
+      agent: a crew threads each task's output forward as context, so an
+      unusable error string becomes the input every downstream task reasons
+      over. The raw message also crosses into the conversation intact, carrying
+      whatever internal detail it held (file paths, hostnames, query fragments).
+    fix: >
+      Catch the failure modes you expect and return a structured string the
+      agent can act on — name the failure and say plainly whether retrying could
+      help and what would have to change — rather than letting the exception
+      escape. Reserve raising for programmer errors the agent genuinely cannot
+      work around.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **trustabl/trustabl-rules#56**, on a branch of the **same name**, so the `rules-sync` job resolves the matching pack rather than `main`. Neither half should merge alone — `check-rules-sync.sh` fails if they do.

## What the pair adds

CrewAI had no error-contract rule (CSDK-005, OAI-008, ADK-005, MCP-006 all exist). CREW-008 is framed for how CrewAI behaves: an uncaught exception is stringified into the agent's observation, so the agent typically burns its remaining `max_iter` budget re-calling the same tool the same way — and in a crew, that unusable output is threaded forward as context to every task behind it.

## What this PR does

1. Mirrors `crewai/error_handling.yaml` into `testdata/rules-fixture/`.
2. Adds a fire case and a silent case to `policyRuleCases`, as `TestPolicyRules_AllRulesCovered` requires.

The silent case returns the **actionable error string** CREW-008's `fix` text prescribes, not the `{"error": ..., "retryable": ...}` dict the other packs' rules ask for. CrewAI hands the agent a string observation rather than a structured payload, so the remediation shape genuinely differs — the case reflects the SDK instead of copying the Claude SDK shape.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (87 files compared)

$ go vet ./internal/rules/
$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules	3.165s
```