### PR TITLE
test(rules): mirror and cover AG2-013

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -1986,6 +1986,25 @@ def fetch_data(x: str) -> dict:
     return {}
 `,
 		toolConfig: nil, wantFires: false},
+
+	// ─── AG2-013: AutoGen tool raises with no structured error contract ─────
+	{name: "AG2-013 fires on uncaught raise", ruleID: "AG2-013", kind: models.KindAutoGenTool, src: `
+def lookup_order(order_id: str) -> str:
+    """Look up an order."""
+    if not order_id:
+        raise ValueError("order_id is required")
+    return order_id
+`, wantFires: true},
+	{name: "AG2-013 silent when the failure is caught", ruleID: "AG2-013", kind: models.KindAutoGenTool, src: `
+def lookup_order(order_id: str) -> str:
+    """Look up an order."""
+    try:
+        if not order_id:
+            raise ValueError("order_id is required")
+        return order_id
+    except ValueError:
+        return "error: order_id was empty; supply the customer's order number"
+`, wantFires: false},
 }
 
 // policyRepoRuleCases covers repo-scoped rules.
@@ -2246,7 +2265,6 @@ var policyRepoRuleCases = []policyRepoCase{
 		},
 		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKOpenAIAgents}},
 		false},
-
 }
 
 // optionsWithPermissionMode builds a ClaudeAgentOptionsDef whose captured

--- a/testdata/rules-fixture/autogen/error_handling.yaml
+++ b/testdata/rules-fixture/autogen/error_handling.yaml
@@ -1,0 +1,41 @@
+policy:
+  id: autogen_error_handling
+  name: AutoGen error contract hygiene
+  category: autogen
+  description: >
+    Rules covering how a registered AutoGen tool surfaces failure. An
+    unhandled exception in a tool breaks the two-agent reply loop the whole
+    conversation is built on, so the failure surfaces as a stalled or aborted
+    chat rather than something either agent can reason about.
+
+rules:
+  - id: AG2-013
+    title: AutoGen tool raises without a structured error contract
+    severity: low
+    confidence: 0.6
+    language: python
+    applies_to:
+      - autogen_tool
+    scope: tool
+    match:
+      all:
+        - has_raise: true
+        - has_try_except: false
+    explanation: >
+      This registered tool raises an exception it never catches. AutoGen
+      executes tools on the executor agent's side of the conversation and sends
+      the result back as that agent's reply, so an uncaught exception either
+      aborts initiate_chat outright or comes back as a stringified traceback
+      posted into the message history. In the second case both agents keep
+      talking with a traceback as the last observation: the assistant has no
+      failure mode to branch on and no signal about whether a retry could
+      succeed, so it re-issues the same call until the max_round or auto-reply
+      cap (AG2-004, AG2-006) ends the conversation. The traceback also stays in
+      the transcript, carrying file paths and internal detail into every
+      subsequent turn's context.
+    fix: >
+      Catch the failure modes you expect and return a structured value the
+      assistant can branch on — name the failure and say whether retrying could
+      help and what would need to change — instead of letting the exception
+      escape the registered function. Reserve raising for programmer errors no
+      amount of agent reasoning can work around.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **trustabl/trustabl-rules#57**, on a branch of the **same name**, so the `rules-sync` job resolves the matching pack rather than `main`. Neither half should merge alone — `check-rules-sync.sh` fails if they do.

## What the pair adds

AutoGen had no error-contract rule (CSDK-005, OAI-008, ADK-005, MCP-006 all exist). AG2-013 is framed for AutoGen's two-agent reply loop: tools execute on the executor's side and the result is sent back as that agent's reply, so an uncaught exception either aborts `initiate_chat` or lands in the message history as a stringified traceback that both agents keep reasoning over until AG2-004's `max_round` or AG2-006's auto-reply cap ends the chat.

## What this PR does

1. Mirrors `autogen/error_handling.yaml` into `testdata/rules-fixture/`.
2. Adds a fire case and a silent case to `policyRuleCases`, as `TestPolicyRules_AllRulesCovered` requires.

The silent case returns the **actionable string** AG2-013's `fix` text prescribes rather than the `{"error": ..., "retryable": ...}` dict the Claude SDK and MCP rules ask for. AutoGen posts the tool result back as the executor agent's reply, so what the assistant reasons over is a message — the case matches the SDK rather than copying another pack's remediation shape.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (87 files compared)

$ go vet ./internal/rules/
$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules	2.996s
```