### PR TITLE
test(rules): mirror and cover PYD-009

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -1986,6 +1986,29 @@ def fetch_data(x: str) -> dict:
     return {}
 `,
 		toolConfig: nil, wantFires: false},
+
+	// ─── PYD-009: Pydantic AI path param reaching I/O unnormalized ──────────
+	// call_uses_unnormalized_path_param is per-param, so the third case pins
+	// that a non-pathish param does not drag the rule in.
+	{name: "PYD-009 fires on path param in open()", ruleID: "PYD-009", kind: models.KindPydanticAITool, src: `
+def read_note(note_path: str) -> str:
+    """Read a note."""
+    with open(note_path, "r") as f:
+        return f.read()
+`, wantFires: true},
+	{name: "PYD-009 silent with .resolve()", ruleID: "PYD-009", kind: models.KindPydanticAITool, src: `
+from pathlib import Path
+def read_note(note_path: str) -> str:
+    """Read a note."""
+    p = Path(note_path).resolve()
+    with open(p, "r") as f:
+        return f.read()
+`, wantFires: false},
+	{name: "PYD-009 silent on non-pathish param", ruleID: "PYD-009", kind: models.KindPydanticAITool, src: `
+def get_note_meta(note_id: str) -> dict:
+    """Get note metadata."""
+    return {"id": note_id}
+`, wantFires: false},
 }
 
 // policyRepoRuleCases covers repo-scoped rules.
@@ -2246,7 +2269,6 @@ var policyRepoRuleCases = []policyRepoCase{
 		},
 		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKOpenAIAgents}},
 		false},
-
 }
 
 // optionsWithPermissionMode builds a ClaudeAgentOptionsDef whose captured

--- a/testdata/rules-fixture/pydantic_ai/path_safety.yaml
+++ b/testdata/rules-fixture/pydantic_ai/path_safety.yaml
@@ -1,0 +1,47 @@
+policy:
+  id: pydantic_ai_path_safety
+  name: Pydantic AI filesystem path safety
+  category: pydantic_ai
+  description: >
+    Rules that catch a model-supplied filesystem path flowing into an I/O call
+    inside a Pydantic AI tool without containment. A traversal payload like
+    ../../etc/passwd reaches real filesystem state if the tool does not resolve
+    the path and check it against an allowed root.
+
+rules:
+  - id: PYD-009
+    title: Pydantic AI tool uses a path parameter in I/O without validation
+    severity: high
+    confidence: 0.7
+    language: python
+    applies_to:
+      - pydantic_ai_tool
+    scope: tool
+    # call_uses_unnormalized_path_param is per-param: a tool with two path
+    # params and one .resolve() correctly fires on the unresolved one. A
+    # body-wide check would suppress the finding whenever any normalization
+    # appears, masking real exposure on the other param.
+    match:
+      call_uses_unnormalized_path_param:
+        callees:
+          - open
+          - Path
+        callee_prefixes:
+          - shutil.
+          - os.
+    explanation: >
+      This tool takes a path-like parameter and hands it to a file or directory
+      operation without resolving it or checking it against an allowed root, so
+      a model-supplied ../../etc/passwd reaches the real filesystem. Pydantic
+      AI's type layer does not help here: a parameter annotated str or Path
+      validates fine while still carrying a traversal payload, because the
+      annotation constrains the value's type, not the region of the filesystem
+      it points at. Whatever the agent process can read or write, the model can
+      reach through this tool. Detection is heuristic — confirm the parameter is
+      genuinely model-supplied before applying the fix.
+    fix: >
+      Resolve the path with Path(...).resolve() and assert the result sits under
+      an allowed root before touching it, rejecting anything that escapes.
+      Encode that as a validator on the parameter's type (a Pydantic
+      AfterValidator or a custom path type) so containment holds for every tool
+      that accepts it rather than being re-implemented per call site.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **trustabl/trustabl-rules#58**, on a branch of the **same name**, so the `rules-sync` job resolves the matching pack rather than `main`. Neither half should merge alone — `check-rules-sync.sh` fails if they do.

## What the pair adds

Pydantic AI had no path-safety rule (CSDK-004, OAI-006, ADK-004, MCP-005 all exist). The SDK-specific point is that Pydantic AI's type layer looks like it covers this and doesn't: a parameter annotated `str` or `Path` validates cleanly while still carrying `../../etc/passwd`, because the annotation constrains the value's *type*, not the region of the filesystem it points at.

## What this PR does

1. Mirrors `pydantic_ai/path_safety.yaml` into `testdata/rules-fixture/`.
2. Adds cases to `policyRuleCases`, as `TestPolicyRules_AllRulesCovered` requires.

Three cases, following CSDK-004's own table:

| case | expectation |
|---|---|
| `open(note_path)` on a raw param | fires |
| `Path(note_path).resolve()` first | silent |
| non-pathish param (`note_id`), no I/O | silent |

The third guards the per-param behavior of `call_uses_unnormalized_path_param` — it's what keeps the rule from broadening into "any tool with a string param" if the predicate is ever reworked.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (87 files compared)

$ go vet ./internal/rules/
$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules	3.112s
```