### PR TITLE
test(rules): mirror and cover LC-009, LC-023

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -1986,6 +1986,50 @@ def fetch_data(x: str) -> dict:
     return {}
 `,
 		toolConfig: nil, wantFires: false},
+
+	// ─── LC-009 / LC-023: LangChain path safety (python + typescript) ───────
+	// LC-009 is the per-param Python flow check; LC-023 is the coarse TS
+	// filesystem-write signal, mirroring CSDK-012 until TS path normalization
+	// analysis exists.
+	{name: "LC-009 fires on path param in open()", ruleID: "LC-009", kind: models.KindLangChainTool, src: `
+def read_note(note_path: str) -> str:
+    """Read a note."""
+    with open(note_path, "r") as f:
+        return f.read()
+`, wantFires: true},
+	{name: "LC-009 silent with .resolve()", ruleID: "LC-009", kind: models.KindLangChainTool, src: `
+from pathlib import Path
+def read_note(note_path: str) -> str:
+    """Read a note."""
+    p = Path(note_path).resolve()
+    with open(p, "r") as f:
+        return f.read()
+`, wantFires: false},
+	{name: "LC-009 silent on non-pathish param", ruleID: "LC-009", kind: models.KindLangChainTool, src: `
+def get_note_meta(note_id: str) -> dict:
+    """Get note metadata."""
+    return {"id": note_id}
+`, wantFires: false},
+	{
+		name: "LC-023 fires on TS filesystem write", ruleID: "LC-023",
+		kind: models.KindLangChainTool, lang: models.LanguageTypeScript, wantFires: true,
+		src: "import { tool } from \"@langchain/core/tools\";\n" +
+			"import { writeFileSync } from \"node:fs\";\n" +
+			"export const t = tool(async ({ p, body }: { p: string; body: string }) => {\n" +
+			"  writeFileSync(p, body);\n" +
+			"  return \"saved\";\n" +
+			"}, { name: \"save_note\", description: \"Save a note.\", schema: {} });\n",
+	},
+	{
+		name: "LC-023 silent with no filesystem write", ruleID: "LC-023",
+		kind: models.KindLangChainTool, lang: models.LanguageTypeScript, wantFires: false,
+		src: "import { tool } from \"@langchain/core/tools\";\n" +
+			"const notes = new Map<string, string>();\n" +
+			"export const t = tool(async ({ body }: { body: string }) => {\n" +
+			"  notes.set(\"n1\", body);\n" +
+			"  return \"n1\";\n" +
+			"}, { name: \"save_note\", description: \"Save a note.\", schema: {} });\n",
+	},
 }
 
 // policyRepoRuleCases covers repo-scoped rules.
@@ -2246,7 +2290,6 @@ var policyRepoRuleCases = []policyRepoCase{
 		},
 		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKOpenAIAgents}},
 		false},
-
 }
 
 // optionsWithPermissionMode builds a ClaudeAgentOptionsDef whose captured

--- a/testdata/rules-fixture/langchain/path_safety.yaml
+++ b/testdata/rules-fixture/langchain/path_safety.yaml
@@ -1,0 +1,79 @@
+policy:
+  id: langchain_path_safety
+  name: LangChain filesystem path safety
+  category: langchain
+  description: >
+    Rules that catch a model-supplied filesystem path flowing into an I/O call
+    inside a LangChain tool without containment. A traversal payload like
+    ../../etc/passwd reaches real filesystem state if the tool does not resolve
+    the path and check it against an allowed root.
+
+rules:
+  - id: LC-009
+    title: LangChain tool uses a path parameter in I/O without validation
+    severity: high
+    confidence: 0.7
+    language: python
+    applies_to:
+      - langchain_tool
+    scope: tool
+    # call_uses_unnormalized_path_param is per-param: a tool with two path
+    # params and one .resolve() correctly fires on the unresolved one. A
+    # body-wide check would suppress the finding whenever any normalization
+    # appears, masking real exposure on the other param.
+    match:
+      call_uses_unnormalized_path_param:
+        callees:
+          - open
+          - Path
+        callee_prefixes:
+          - shutil.
+          - os.
+    explanation: >
+      This tool takes a path-like parameter and hands it to a file or directory
+      operation without resolving it or checking it against an allowed root, so
+      a model-supplied ../../etc/passwd reaches the real filesystem. The tool's
+      args_schema does not close this: a Pydantic field typed str or Path
+      validates fine while still carrying a traversal payload, because the
+      schema constrains the argument's type and not the region of the filesystem
+      it points at. LangChain agents are also a common target for indirect
+      injection — a retrieved document or a page fetched mid-run can carry the
+      path the model then passes here — so the argument should be treated as
+      hostile even when the user is not. Detection is heuristic; confirm the
+      parameter is genuinely model-supplied before applying the fix.
+    fix: >
+      Resolve the path with Path(...).resolve() and assert the result sits under
+      an allowed root before touching it, rejecting anything that escapes.
+      Encode the check as a validator on the args_schema field so containment
+      holds for every tool that accepts the path rather than being
+      re-implemented per call site.
+
+  - id: LC-023
+    title: TypeScript LangChain tool writes to the filesystem
+    severity: low
+    confidence: 0.5
+    language: typescript
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      has_write_call: true
+    explanation: >
+      This LangChain.js tool writes to the filesystem. If the path or the
+      contents derive from the tool's arguments, the model chooses both, and a
+      prompt injection can steer the write at any file the Node process can
+      reach. The injection route is the ordinary one in this framework rather
+      than an exotic case: a retrieval chain feeds fetched documents into the
+      same context the model plans from, so text in a page or a knowledge-base
+      record can supply the filename the model then passes here. The Zod schema
+      does not help — it constrains the argument's type, not the region of the
+      filesystem it points at, so a traversal payload validates cleanly.
+      (Coarse signal — it flags any filesystem write, not only unnormalized
+      paths, because TypeScript path-normalization analysis is not yet wired.
+      Confirm the path is genuinely model-supplied before acting.)
+    fix: >
+      Confine writes to a dedicated working directory: resolve the final path,
+      verify it stays under that root before writing, and reject absolute paths
+      and any input containing "..". Where the tool only ever writes generated
+      names, derive the filename from an id rather than accepting a path from
+      the model at all.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **trustabl/trustabl-rules#59**, on a branch of the **same name**, so the `rules-sync` job resolves the matching pack rather than `main`. Neither half should merge alone — `check-rules-sync.sh` fails if they do.

## What the pair adds

LangChain had no path-safety rule (CSDK-004/012, OAI-006, ADK-004, MCP-005 all exist). The rules PR ships the python/TypeScript pair this pack uses throughout: LC-009 (per-param `call_uses_unnormalized_path_param`, same callee set as CSDK-004) and LC-023 (coarse `has_write_call`, mirroring CSDK-012 until TS path-normalization analysis exists).

## What this PR does

1. Mirrors `langchain/path_safety.yaml` into `testdata/rules-fixture/`.
2. Adds cases to `policyRuleCases`, as `TestPolicyRules_AllRulesCovered` requires.

| case | expectation |
|---|---|
| LC-009 — `open(note_path)` on a raw param | fires |
| LC-009 — `Path(note_path).resolve()` first | silent |
| LC-009 — non-pathish param (`note_id`), no I/O | silent |
| LC-023 — `writeFileSync(p, body)` | fires |
| LC-023 — in-memory store, no filesystem write | silent |

LC-009's third case guards the per-param behavior of `call_uses_unnormalized_path_param` — it's what keeps the rule from broadening into "any tool with a string param" if the predicate is ever reworked.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (87 files compared)

$ go vet ./internal/rules/
$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules	3.210s
```