### PR TITLE
test(rules): mirror and cover AG2-015

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -510,6 +510,17 @@ def fetch(q: str) -> str:
     return requests.get("https://api.example.com/data").text
 `, wantFires: false},
 
+	{name: "AG2-015 fires on mutating tool without key", ruleID: "AG2-015", kind: models.KindAutoGenTool, src: `
+def refund_payment(payment_id: str, amount: int) -> str:
+    """Refund a payment."""
+    return billing.refund(payment_id, amount)
+`, wantFires: true},
+	{name: "AG2-015 silent with idempotency key", ruleID: "AG2-015", kind: models.KindAutoGenTool, src: `
+def refund_payment(payment_id: str, amount: int, idempotency_key: str) -> str:
+    """Refund a payment."""
+    return billing.refund(payment_id, amount, idempotency_key=idempotency_key)
+`, wantFires: false},
+
 	{name: "AG2-012 fires on network call without timeout", ruleID: "AG2-012", kind: models.KindAutoGenTool, src: `
 def fetch(q: str) -> str:
     """Fetch."""

--- a/testdata/rules-fixture/autogen/idempotency.yaml
+++ b/testdata/rules-fixture/autogen/idempotency.yaml
@@ -1,0 +1,55 @@
+policy:
+  id: autogen_idempotency
+  name: AutoGen mutating-tool idempotency
+  category: autogen
+  description: >
+    Rules that flag mutating tools (create/send/refund/...) without an
+    idempotency key. Retries (model re-invocation, a group-chat speaker
+    re-issuing a call, or your own retry policy) can re-run a side-effecting
+    call; without a key the same action can fire twice.
+
+rules:
+  - id: AG2-015
+    title: Mutating AutoGen tool has no idempotency key
+    severity: medium
+    confidence: 0.55
+    language: python
+    applies_to:
+      - autogen_tool
+    scope: tool
+    match:
+      all:
+        - name_has_prefix:
+            - create_
+            - send_
+            - delete_
+            - post_
+            - update_
+            - refund_
+            - charge_
+            - issue_
+        - not:
+            param_name_matches:
+              contains:
+                - idempot
+              exact:
+                - request_id
+                - txn_id
+    explanation: >
+      Tool name suggests a side effect (create/send/refund/…). A mutating tool
+      with no idempotency key cannot tell a new request from a retry of one whose
+      result was lost, and AutoGen supplies more ways for that retry to happen
+      than a single-agent loop does. The tool response is a message in a
+      conversation that is re-sent in full on every later turn, so a call whose
+      result read as inconclusive stays visible and re-invitable for the rest of
+      the run; in a group chat any speaker the manager selects can re-issue it,
+      including an agent that was not the original caller and cannot know the
+      side effect already committed. Without a key the same action fires twice —
+      a duplicate charge, a double-sent message, a repeated delete. Downstream
+      services must also honor the key for this protection to be effective.
+    fix: >
+      Add an `idempotency_key: str` parameter and pass it through to the backing
+      API so a retried call is recognized and deduplicated rather than
+      re-executed. Derive the key from the request's own identity, not from a
+      fresh uuid4() per call — a key regenerated on the retry deduplicates
+      nothing.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **https://github.com/trustabl/trustabl-rules/pull/101**, on a branch of the **same name**, so `rules-sync` resolves the matching production pack rather than `main`. Neither half should merge alone.

## What the pair adds

Six packs ship an idempotency rule — CSDK-006/016, OAI-009/019, ADK-006, MCP-007, CREW-006, PYD-007. AutoGen ships none. The rules PR adds AG2-015 using the existing `name_has_prefix` + `param_name_matches` predicate pair.

What makes it matter in AutoGen specifically: the tool response is a message in a conversation re-sent in full on every later turn, so an inconclusive call stays re-invitable for the whole run — and in a group chat any speaker the manager selects can re-issue it, including an agent that never saw the first attempt.

## What this PR does

Mirrors `autogen/idempotency.yaml` into `testdata/rules-fixture/` and adds a fire and a silent case to `policyRuleCases`.

The silent case is the same `refund_payment` with an `idempotency_key` parameter **threaded through to the backing call**, so it demonstrates the rule's own fix clears the finding — rather than that renaming the tool out of the mutating-prefix set does.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (87 files compared)

$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules
```

End to end, a build of this branch against the paired rules branch:

```
AG2-015 [medium] refund_payment tools.py:6
```

with the keyed twin in the same file not firing.