### PR TITLE
test(rules): mirror and cover CREW-009

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -1986,6 +1986,27 @@ def fetch_data(x: str) -> dict:
     return {}
 `,
 		toolConfig: nil, wantFires: false},
+
+	// ─── CREW-009: CrewAI path param reaching I/O unnormalized ──────────────
+	{name: "CREW-009 fires on path param in open()", ruleID: "CREW-009", kind: models.KindCrewAITool, src: `
+def read_note(note_path: str) -> str:
+    """Read a note."""
+    with open(note_path, "r") as f:
+        return f.read()
+`, wantFires: true},
+	{name: "CREW-009 silent with .resolve()", ruleID: "CREW-009", kind: models.KindCrewAITool, src: `
+from pathlib import Path
+def read_note(note_path: str) -> str:
+    """Read a note."""
+    p = Path(note_path).resolve()
+    with open(p, "r") as f:
+        return f.read()
+`, wantFires: false},
+	{name: "CREW-009 silent on non-pathish param", ruleID: "CREW-009", kind: models.KindCrewAITool, src: `
+def get_note_meta(note_id: str) -> dict:
+    """Get note metadata."""
+    return {"id": note_id}
+`, wantFires: false},
 }
 
 // policyRepoRuleCases covers repo-scoped rules.
@@ -2246,7 +2267,6 @@ var policyRepoRuleCases = []policyRepoCase{
 		},
 		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKOpenAIAgents}},
 		false},
-
 }
 
 // optionsWithPermissionMode builds a ClaudeAgentOptionsDef whose captured

--- a/testdata/rules-fixture/crewai/path_safety.yaml
+++ b/testdata/rules-fixture/crewai/path_safety.yaml
@@ -1,0 +1,49 @@
+policy:
+  id: crewai_path_safety
+  name: CrewAI filesystem path safety
+  category: crewai
+  description: >
+    Rules that catch a model-supplied filesystem path flowing into an I/O call
+    inside a CrewAI tool without containment. A traversal payload like
+    ../../etc/passwd reaches real filesystem state if the tool does not resolve
+    the path and check it against an allowed root.
+
+rules:
+  - id: CREW-009
+    title: CrewAI tool uses a path parameter in I/O without validation
+    severity: high
+    confidence: 0.7
+    language: python
+    applies_to:
+      - crewai_tool
+    scope: tool
+    # call_uses_unnormalized_path_param is per-param: a tool with two path
+    # params and one .resolve() correctly fires on the unresolved one. A
+    # body-wide check would suppress the finding whenever any normalization
+    # appears, masking real exposure on the other param.
+    match:
+      call_uses_unnormalized_path_param:
+        callees:
+          - open
+          - Path
+        callee_prefixes:
+          - shutil.
+          - os.
+    explanation: >
+      This tool takes a path-like parameter and hands it to a file or directory
+      operation without resolving it or checking it against an allowed root, so
+      a model-supplied ../../etc/passwd reaches the real filesystem. The tool's
+      args_schema does not close this: a Pydantic field typed str or Path
+      validates fine while still carrying a traversal payload, because the
+      schema constrains the argument's type and not the region of the filesystem
+      it points at. Reach is wider than the agent that owns the tool — a crew
+      shares one process and threads each task's output forward as context, so a
+      file read through this tool lands in the transcript every downstream task
+      reasons over, and CREW-104's delegation means an agent that was never
+      granted the tool can still reach it by asking a peer.
+    fix: >
+      Resolve the path with Path(...).resolve() and assert the result sits under
+      an allowed root before touching it, rejecting anything that escapes.
+      Encode the check as a validator on the args_schema field so containment
+      holds wherever the tool is shared across the crew rather than being
+      re-implemented per call site.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **trustabl/trustabl-rules#60**, on a branch of the **same name**, so the `rules-sync` job resolves the matching pack rather than `main`. Neither half should merge alone — `check-rules-sync.sh` fails if they do.

## What the pair adds

CrewAI had no path-safety rule (CSDK-004, OAI-006, ADK-004, MCP-005 all exist). Two CrewAI-specific points shape the rule text: the `args_schema` constrains the argument's *type*, not where it points, so a traversal payload validates cleanly; and the reach is wider than the owning agent, since a crew shares one process, threads task output forward as context, and CREW-104 delegation lets a peer reach the tool.

## What this PR does

1. Mirrors `crewai/path_safety.yaml` into `testdata/rules-fixture/`.
2. Adds cases to `policyRuleCases`, as `TestPolicyRules_AllRulesCovered` requires.

| case | expectation |
|---|---|
| `open(note_path)` on a raw param | fires |
| `Path(note_path).resolve()` first | silent |
| non-pathish param (`note_id`), no I/O | silent |

The third guards the per-param behavior of `call_uses_unnormalized_path_param` — it's what keeps the rule from broadening into "any tool with a string param" if the predicate is ever reworked.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (87 files compared)

$ go vet ./internal/rules/
$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules
```