### PR TITLE
test(rules): mirror and cover AG2-014

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -1986,6 +1986,27 @@ def fetch_data(x: str) -> dict:
     return {}
 `,
 		toolConfig: nil, wantFires: false},
+
+	// ─── AG2-014: AutoGen path param reaching I/O unnormalized ──────────────
+	{name: "AG2-014 fires on path param in open()", ruleID: "AG2-014", kind: models.KindAutoGenTool, src: `
+def read_note(note_path: str) -> str:
+    """Read a note."""
+    with open(note_path, "r") as f:
+        return f.read()
+`, wantFires: true},
+	{name: "AG2-014 silent with .resolve()", ruleID: "AG2-014", kind: models.KindAutoGenTool, src: `
+from pathlib import Path
+def read_note(note_path: str) -> str:
+    """Read a note."""
+    p = Path(note_path).resolve()
+    with open(p, "r") as f:
+        return f.read()
+`, wantFires: false},
+	{name: "AG2-014 silent on non-pathish param", ruleID: "AG2-014", kind: models.KindAutoGenTool, src: `
+def get_note_meta(note_id: str) -> dict:
+    """Get note metadata."""
+    return {"id": note_id}
+`, wantFires: false},
 }
 
 // policyRepoRuleCases covers repo-scoped rules.
@@ -2246,7 +2267,6 @@ var policyRepoRuleCases = []policyRepoCase{
 		},
 		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKOpenAIAgents}},
 		false},
-
 }
 
 // optionsWithPermissionMode builds a ClaudeAgentOptionsDef whose captured

--- a/testdata/rules-fixture/autogen/path_safety.yaml
+++ b/testdata/rules-fixture/autogen/path_safety.yaml
@@ -1,0 +1,50 @@
+policy:
+  id: autogen_path_safety
+  name: AutoGen filesystem path safety
+  category: autogen
+  description: >
+    Rules that catch a model-supplied filesystem path flowing into an I/O call
+    inside a registered AutoGen tool without containment. A traversal payload
+    like ../../etc/passwd reaches real filesystem state if the tool does not
+    resolve the path and check it against an allowed root.
+
+rules:
+  - id: AG2-014
+    title: AutoGen tool uses a path parameter in I/O without validation
+    severity: high
+    confidence: 0.7
+    language: python
+    applies_to:
+      - autogen_tool
+    scope: tool
+    # call_uses_unnormalized_path_param is per-param: a tool with two path
+    # params and one .resolve() correctly fires on the unresolved one. A
+    # body-wide check would suppress the finding whenever any normalization
+    # appears, masking real exposure on the other param.
+    match:
+      call_uses_unnormalized_path_param:
+        callees:
+          - open
+          - Path
+        callee_prefixes:
+          - shutil.
+          - os.
+    explanation: >
+      This registered tool takes a path-like parameter and hands it to a file or
+      directory operation without resolving it or checking it against an allowed
+      root, so a model-supplied ../../etc/passwd reaches the real filesystem.
+      Type hints do not close this: a parameter annotated str or Path passes
+      AutoGen's schema generation while still carrying a traversal payload,
+      because the annotation constrains the argument's type and not the region
+      of the filesystem it points at. Registered tools also sidestep the
+      containment AG2-001 is about — a crew may run its generated code inside a
+      Docker executor, but a tool registered with register_for_execution runs in
+      the host process, with the host's filesystem view, whatever the code
+      executor is configured to do. Whatever the tool reads is then posted into
+      the message history both agents keep reasoning over.
+    fix: >
+      Resolve the path with Path(...).resolve() and assert the result sits under
+      an allowed root before touching it, rejecting anything that escapes. Keep
+      that check inside the registered function itself: it is the only boundary
+      the tool path crosses, since the code executor's sandbox does not apply
+      here.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **trustabl/trustabl-rules#61**, on a branch of the **same name**, so the `rules-sync` job resolves the matching pack rather than `main`. Neither half should merge alone — `check-rules-sync.sh` fails if they do.

## What the pair adds

AutoGen had no path-safety rule (CSDK-004, OAI-006, ADK-004, MCP-005 all exist). The AutoGen-specific point in the rule text is one people reasonably assume they're already covered on: **a registered tool sidesteps the containment AG2-001 is about.** Generated code may run in a Docker executor, but a function registered with `register_for_execution` runs in the host process with the host's filesystem view regardless — so "we run code in Docker" isn't an answer to this finding, and the check has to live inside the registered function.

## What this PR does

1. Mirrors `autogen/path_safety.yaml` into `testdata/rules-fixture/`.
2. Adds cases to `policyRuleCases`, as `TestPolicyRules_AllRulesCovered` requires.

| case | expectation |
|---|---|
| `open(note_path)` on a raw param | fires |
| `Path(note_path).resolve()` first | silent |
| non-pathish param (`note_id`), no I/O | silent |

The third guards the per-param behavior of `call_uses_unnormalized_path_param`.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (87 files compared)

$ go vet ./internal/rules/
$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules
```