### PR TITLE
test(rules): mirror and cover LC-017

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -1986,6 +1986,25 @@ def fetch_data(x: str) -> dict:
     return {}
 `,
 		toolConfig: nil, wantFires: false},
+
+	// ─── LC-017: mutating LangChain tool with no idempotency key ────────────
+	// Same name_has_prefix + param_name_matches shape as MCP-007. Third case
+	// pins that a non-mutating name is not swept in by the missing key alone.
+	{name: "LC-017 fires on mutating tool without key", ruleID: "LC-017", kind: models.KindLangChainTool, src: `
+def refund_payment(charge_id: str, amount_cents: int) -> dict:
+    """Refund a charge."""
+    return {"ok": True}
+`, wantFires: true},
+	{name: "LC-017 silent with idempotency key", ruleID: "LC-017", kind: models.KindLangChainTool, src: `
+def refund_payment(charge_id: str, amount_cents: int, idempotency_key: str) -> dict:
+    """Refund a charge."""
+    return {"ok": True}
+`, wantFires: false},
+	{name: "LC-017 silent on a read-only tool name", ruleID: "LC-017", kind: models.KindLangChainTool, src: `
+def get_payment(charge_id: str) -> dict:
+    """Get a charge."""
+    return {"ok": True}
+`, wantFires: false},
 }
 
 // policyRepoRuleCases covers repo-scoped rules.
@@ -2246,7 +2265,6 @@ var policyRepoRuleCases = []policyRepoCase{
 		},
 		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKOpenAIAgents}},
 		false},
-
 }
 
 // optionsWithPermissionMode builds a ClaudeAgentOptionsDef whose captured

--- a/testdata/rules-fixture/langchain/idempotency.yaml
+++ b/testdata/rules-fixture/langchain/idempotency.yaml
@@ -1,0 +1,53 @@
+policy:
+  id: langchain_idempotency
+  name: LangChain mutating-tool idempotency
+  category: langchain
+  description: >
+    Rules that flag mutating LangChain tools (create/send/refund/...) with no
+    idempotency key. A ReAct agent re-calls a tool whenever an observation reads
+    as inconclusive, so a mutation with no key can commit twice.
+
+rules:
+  - id: LC-017
+    title: Mutating LangChain tool has no idempotency key
+    severity: medium
+    confidence: 0.55
+    language: python
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      all:
+        - name_has_prefix:
+            - create_
+            - send_
+            - delete_
+            - post_
+            - update_
+            - refund_
+            - charge_
+            - issue_
+        - not:
+            param_name_matches:
+              contains:
+                - idempot
+              exact:
+                - request_id
+                - txn_id
+    explanation: >
+      The tool name signals a side effect (create/send/refund/…) and the tool
+      takes no idempotency key, so a repeated call commits the mutation twice.
+      The LangChain agent loop makes repetition routine rather than
+      exceptional: an AgentExecutor step whose observation reads as
+      inconclusive — a timeout, a truncated response, an error string returned
+      under handle_tool_error — leads the model to reason about the same goal
+      again and re-issue the same action, and it cannot know the first call
+      already committed. Retry wrappers and LangChain's own with_retry compound
+      it, since a network failure after the side effect landed is
+      indistinguishable from one before. The result is a duplicate charge,
+      order, or message.
+    fix: >
+      Accept an idempotency key parameter (idempotency_key / request_id),
+      require the caller to derive it from the unit of work rather than
+      generating a fresh one per call, and de-duplicate server-side so a
+      repeated call returns the first result instead of committing again.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **trustabl/trustabl-rules#62**, on a branch of the **same name**, so the `rules-sync` job resolves the matching pack rather than `main`. Neither half should merge alone — `check-rules-sync.sh` fails if they do.

## What the pair adds

LangChain had no idempotency rule (CREW-006, PYD-007, MCP-007, CSDK-006, OAI-009 all exist). The LangChain-specific argument is that **repetition is routine here, not exceptional**: an `AgentExecutor` step whose observation reads as inconclusive — a timeout, a truncated response, an error string returned under `handle_tool_error` — leads the model to re-issue the same action, with no way to know the first call already committed. `with_retry` compounds it, since a network failure *after* the side effect landed is indistinguishable from one before.

LC-017 uses the same `name_has_prefix` + `param_name_matches` shape as MCP-007.

## What this PR does

1. Mirrors `langchain/idempotency.yaml` into `testdata/rules-fixture/`.
2. Adds cases to `policyRuleCases`, as `TestPolicyRules_AllRulesCovered` requires.

| case | expectation |
|---|---|
| `refund_payment(charge_id, amount_cents)` | fires |
| same tool with an `idempotency_key` param | silent |
| `get_payment(charge_id)` — read-only name | silent |

The third case pins **both halves** of the match: a missing key alone isn't enough, the name has to signal a side effect. Without it the rule could quietly broaden into "every tool without an idempotency key" and the suite would stay green.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (87 files compared)

$ go vet ./internal/rules/
$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules
```