### PR TITLE
test(rules): mirror and cover AG2-015

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -1986,6 +1986,23 @@ def fetch_data(x: str) -> dict:
     return {}
 `,
 		toolConfig: nil, wantFires: false},
+
+	// ─── AG2-015: mutating AutoGen tool with no idempotency key ─────────────
+	{name: "AG2-015 fires on mutating tool without key", ruleID: "AG2-015", kind: models.KindAutoGenTool, src: `
+def refund_payment(charge_id: str, amount_cents: int) -> dict:
+    """Refund a charge."""
+    return {"ok": True}
+`, wantFires: true},
+	{name: "AG2-015 silent with idempotency key", ruleID: "AG2-015", kind: models.KindAutoGenTool, src: `
+def refund_payment(charge_id: str, amount_cents: int, idempotency_key: str) -> dict:
+    """Refund a charge."""
+    return {"ok": True}
+`, wantFires: false},
+	{name: "AG2-015 silent on a read-only tool name", ruleID: "AG2-015", kind: models.KindAutoGenTool, src: `
+def get_payment(charge_id: str) -> dict:
+    """Get a charge."""
+    return {"ok": True}
+`, wantFires: false},
 }
 
 // policyRepoRuleCases covers repo-scoped rules.
@@ -2246,7 +2263,6 @@ var policyRepoRuleCases = []policyRepoCase{
 		},
 		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKOpenAIAgents}},
 		false},
-
 }
 
 // optionsWithPermissionMode builds a ClaudeAgentOptionsDef whose captured

--- a/testdata/rules-fixture/autogen/idempotency.yaml
+++ b/testdata/rules-fixture/autogen/idempotency.yaml
@@ -1,0 +1,54 @@
+policy:
+  id: autogen_idempotency
+  name: AutoGen mutating-tool idempotency
+  category: autogen
+  description: >
+    Rules that flag mutating AutoGen tools (create/send/refund/...) with no
+    idempotency key. A two-agent conversation re-proposes an action whenever the
+    previous observation reads as inconclusive, so a mutation with no key can
+    commit once per round.
+
+rules:
+  - id: AG2-015
+    title: Mutating AutoGen tool has no idempotency key
+    severity: medium
+    confidence: 0.55
+    language: python
+    applies_to:
+      - autogen_tool
+    scope: tool
+    match:
+      all:
+        - name_has_prefix:
+            - create_
+            - send_
+            - delete_
+            - post_
+            - update_
+            - refund_
+            - charge_
+            - issue_
+        - not:
+            param_name_matches:
+              contains:
+                - idempot
+              exact:
+                - request_id
+                - txn_id
+    explanation: >
+      The tool name signals a side effect (create/send/refund/…) and the tool
+      takes no idempotency key, so a repeated call commits the mutation twice.
+      AutoGen's conversation loop makes repetition the default failure mode: the
+      assistant proposes the call, the executor runs it and replies with the
+      result, and if that reply reads as inconclusive — a timeout, an error
+      string, a truncated payload — the assistant proposes the same call again on
+      the next round, with no way to know the first one already committed. It
+      keeps doing so until AG2-004's max_round or AG2-006's auto-reply cap stops
+      the chat, which bounds how many duplicates land rather than preventing
+      them. A group chat is worse again: a second agent that reads the same
+      inconclusive transcript can re-propose the action independently.
+    fix: >
+      Accept an idempotency key parameter (idempotency_key / request_id),
+      require the caller to derive it from the unit of work rather than
+      generating a fresh one per call, and de-duplicate server-side so a
+      repeated call returns the first result instead of committing again.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **trustabl/trustabl-rules#63**, on a branch of the **same name**, so the `rules-sync` job resolves the matching pack rather than `main`. Neither half should merge alone — `check-rules-sync.sh` fails if they do.

## What the pair adds

AutoGen had no idempotency rule (CREW-006, PYD-007, MCP-007, CSDK-006, OAI-009 all exist). AutoGen's conversation loop makes repetition **the default failure mode**: the assistant proposes, the executor runs and replies, and an inconclusive reply leads the assistant to propose the same call again next round with no way to know the first committed. AG2-004's `max_round` and AG2-006's auto-reply cap **bound how many duplicates land rather than preventing them** — and in a group chat a second agent reading the same transcript can re-propose independently.

## What this PR does

1. Mirrors `autogen/idempotency.yaml` into `testdata/rules-fixture/`.
2. Adds cases to `policyRuleCases`, as `TestPolicyRules_AllRulesCovered` requires.

| case | expectation |
|---|---|
| `refund_payment(charge_id, amount_cents)` | fires |
| same tool with an `idempotency_key` param | silent |
| `get_payment(charge_id)` — read-only name | silent |

The third case pins **both halves** of the match: a missing key alone isn't enough, the name has to signal a side effect.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (87 files compared)

$ go vet ./internal/rules/
$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules
```