### PR TITLE
test(rules): mirror and cover PYD-010, PYD-011

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -1986,6 +1986,35 @@ def fetch_data(x: str) -> dict:
     return {}
 `,
 		toolConfig: nil, wantFires: false},
+
+	// ─── PYD-010 / PYD-011: Pydantic AI description quality ─────────────────
+	// PYD-010 is has_description_text (placeholder markers); PYD-011 pairs
+	// description_length_lt with has_docstring so an ABSENT docstring stays
+	// PYD-001's finding rather than double-reporting here.
+	{name: "PYD-010 fires on placeholder description", ruleID: "PYD-010", kind: models.KindPydanticAITool, src: `
+def lookup_order(order_id: str) -> str:
+    """TODO: describe this tool."""
+    return order_id
+`, wantFires: true},
+	{name: "PYD-010 silent on a real description", ruleID: "PYD-010", kind: models.KindPydanticAITool, src: `
+def lookup_order(order_id: str) -> str:
+    """Look up a single order by its identifier and return its current status."""
+    return order_id
+`, wantFires: false},
+	{name: "PYD-011 fires on a too-short description", ruleID: "PYD-011", kind: models.KindPydanticAITool, src: `
+def list_orders(customer_id: str) -> str:
+    """Gets data."""
+    return customer_id
+`, wantFires: true},
+	{name: "PYD-011 silent on a full description", ruleID: "PYD-011", kind: models.KindPydanticAITool, src: `
+def list_orders(customer_id: str) -> str:
+    """List every order belonging to one customer, most recent first."""
+    return customer_id
+`, wantFires: false},
+	{name: "PYD-011 silent when the docstring is absent (PYD-001's case)", ruleID: "PYD-011", kind: models.KindPydanticAITool, src: `
+def list_orders(customer_id: str) -> str:
+    return customer_id
+`, wantFires: false},
 }
 
 // policyRepoRuleCases covers repo-scoped rules.
@@ -2246,7 +2275,6 @@ var policyRepoRuleCases = []policyRepoCase{
 		},
 		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKOpenAIAgents}},
 		false},
-
 }
 
 // optionsWithPermissionMode builds a ClaudeAgentOptionsDef whose captured

--- a/testdata/rules-fixture/pydantic_ai/tool_definition.yaml
+++ b/testdata/rules-fixture/pydantic_ai/tool_definition.yaml
@@ -62,3 +62,62 @@ rules:
       list[str], a Pydantic model, etc.). Pydantic AI propagates these
       annotations into the schema the model sees, so the model emits
       correctly-shaped arguments and validation stops rejecting them.
+
+  - id: PYD-010
+    title: Pydantic AI tool description is a placeholder
+    severity: low
+    confidence: 0.85
+    language: python
+    applies_to:
+      - pydantic_ai_tool
+    scope: tool
+    match:
+      has_description_text:
+        - todo
+        - tbd
+        - fixme
+        - placeholder
+        - no description
+        - does stuff
+    explanation: >
+      The docstring passes the PYD-001 has-a-description check but carries a
+      placeholder marker instead of real content. Pydantic AI forwards this text
+      to the model verbatim as the tool's selection signal, so a stub like
+      "TODO: describe this tool" is functionally indistinguishable from no
+      description at all and the model still has to guess from the function
+      name. It also costs more here than in most SDKs: Pydantic AI parses the
+      docstring's parameter sections into the argument schema, so a placeholder
+      body strips the per-argument guidance at the same time as the tool-level
+      guidance, and nothing in the pipeline reports the omission.
+    fix: >
+      Replace the placeholder with a real description covering what the tool
+      does, what it returns, and when the model should call it, and add the
+      parameter section (Google, NumPy, or Sphinx style) that Pydantic AI reads
+      into the argument schema.
+
+  - id: PYD-011
+    title: Pydantic AI tool description is too short to guide model selection
+    severity: low
+    confidence: 0.8
+    language: python
+    applies_to:
+      - pydantic_ai_tool
+    scope: tool
+    match:
+      all:
+        - has_docstring: true
+        - description_length_lt: 40
+    explanation: >
+      A description under 40 characters is rarely enough to convey what a tool
+      does, what it returns, and when to call it rather than a similarly named
+      neighbor. Pydantic AI passes the docstring to the model as its only
+      selection signal, so a stub like "Gets data." leaves scope and
+      preconditions to guesswork, which shows up as mis-selection or missed
+      calls under ambiguous prompts. A docstring this short also has no room for
+      the parameter section Pydantic AI parses into the argument schema, so the
+      arguments reach the model undescribed as well.
+    fix: >
+      Expand the description to at least a full sentence covering inputs,
+      outputs, and when this tool should be used over the alternatives, and
+      document each parameter in a section Pydantic AI can parse into the
+      argument schema.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **trustabl/trustabl-rules#64**, on a branch of the **same name**, so the `rules-sync` job resolves the matching pack rather than `main`. Neither half should merge alone — `check-rules-sync.sh` fails if they do.

## What the pair adds

Ports the CSDK-017/018 description-quality pair to Pydantic AI. PYD-001 only checks that a docstring *exists*, so `"""TODO: describe this tool."""` and `"""Gets data."""` pass today. The cost is higher in this pack than in the Claude SDK: Pydantic AI also parses the docstring's parameter sections into the argument schema, so a placeholder strips per-argument guidance at the same time as tool-level guidance.

## What this PR does

1. Mirrors `pydantic_ai/tool_definition.yaml` into `testdata/rules-fixture/`.
2. Adds cases to `policyRuleCases`, as `TestPolicyRules_AllRulesCovered` requires.

| case | expectation |
|---|---|
| PYD-010 — `"""TODO: describe this tool."""` | fires |
| PYD-010 — real description | silent |
| PYD-011 — `"""Gets data."""` | fires |
| PYD-011 — full sentence | silent |
| PYD-011 — **no docstring at all** | silent |

**Five cases rather than four.** PYD-011 pairs `description_length_lt: 40` with `has_docstring: true` specifically so an absent docstring stays PYD-001's finding rather than double-reporting — an empty description is length 0, which is also under the threshold. The fifth case is what pins that guard; without it, someone dropping the `has_docstring` conjunct would make both rules fire on the same tool and the suite would stay green.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (87 files compared)

$ go vet ./internal/rules/
$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules
```