### PR TITLE
test(rules): mirror and cover LC-018, LC-019

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -1986,6 +1986,32 @@ def fetch_data(x: str) -> dict:
     return {}
 `,
 		toolConfig: nil, wantFires: false},
+
+	// ─── LC-018 / LC-019: LangChain description quality ─────────────────────
+	{name: "LC-018 fires on placeholder description", ruleID: "LC-018", kind: models.KindLangChainTool, src: `
+def lookup_order(order_id: str) -> str:
+    """TODO: describe this tool."""
+    return order_id
+`, wantFires: true},
+	{name: "LC-018 silent on a real description", ruleID: "LC-018", kind: models.KindLangChainTool, src: `
+def lookup_order(order_id: str) -> str:
+    """Look up a single order by its identifier and return its current status."""
+    return order_id
+`, wantFires: false},
+	{name: "LC-019 fires on a too-short description", ruleID: "LC-019", kind: models.KindLangChainTool, src: `
+def list_orders(customer_id: str) -> str:
+    """Gets data."""
+    return customer_id
+`, wantFires: true},
+	{name: "LC-019 silent on a full description", ruleID: "LC-019", kind: models.KindLangChainTool, src: `
+def list_orders(customer_id: str) -> str:
+    """List every order belonging to one customer, most recent first."""
+    return customer_id
+`, wantFires: false},
+	{name: "LC-019 silent when the docstring is absent (LC-001's case)", ruleID: "LC-019", kind: models.KindLangChainTool, src: `
+def list_orders(customer_id: str) -> str:
+    return customer_id
+`, wantFires: false},
 }
 
 // policyRepoRuleCases covers repo-scoped rules.
@@ -2246,7 +2272,6 @@ var policyRepoRuleCases = []policyRepoCase{
 		},
 		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKOpenAIAgents}},
 		false},
-
 }
 
 // optionsWithPermissionMode builds a ClaudeAgentOptionsDef whose captured

--- a/testdata/rules-fixture/langchain/tool_definition.yaml
+++ b/testdata/rules-fixture/langchain/tool_definition.yaml
@@ -77,3 +77,63 @@ rules:
       Pass a one-sentence description in the tool() config (or the
       DynamicStructuredTool options) naming what the tool does, the inputs it
       expects, and what it returns. Write it for the model, not a human reader.
+
+  - id: LC-018
+    title: LangChain tool description is a placeholder
+    severity: low
+    confidence: 0.85
+    language: python
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      has_description_text:
+        - todo
+        - tbd
+        - fixme
+        - placeholder
+        - no description
+        - does stuff
+    explanation: >
+      The docstring passes the LC-001 has-a-description check but carries a
+      placeholder marker instead of real content. LangChain derives the tool
+      description from the docstring and puts it in front of the model as the
+      tool's only selection signal, so a stub like "TODO: describe this tool" is
+      functionally indistinguishable from no description at all — the model
+      still has to guess from the function name. The failure is quiet and gets
+      worse with scale: LangChain agents are routinely handed a dozen or more
+      tools at once, and mis-selection between similarly named neighbors shows
+      up as wrong answers and wasted executor iterations rather than as an
+      error anyone can trace back to this docstring.
+    fix: >
+      Replace the placeholder with a real description covering what the tool
+      does, what it returns, and when the model should call it rather than a
+      neighboring tool. Where the name alone is genuinely ambiguous, pass an
+      explicit description= at the @tool decorator instead of relying on the
+      docstring.
+
+  - id: LC-019
+    title: LangChain tool description is too short to guide model selection
+    severity: low
+    confidence: 0.8
+    language: python
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      all:
+        - has_docstring: true
+        - description_length_lt: 40
+    explanation: >
+      A description under 40 characters is rarely enough to convey what a tool
+      does, what it returns, and when to call it rather than a similarly named
+      neighbor. LangChain passes this text to the model as the tool's only
+      selection signal, so a stub like "Gets data." leaves scope and
+      preconditions to guesswork. In an AgentExecutor loop the cost compounds:
+      each mis-selected call consumes an iteration against LC-102's
+      max_iterations budget, so a run can exhaust its steps re-trying tools it
+      picked badly and return nothing useful.
+    fix: >
+      Expand the description to at least a full sentence covering inputs,
+      outputs, and the situation in which this tool should be used over the
+      alternatives.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **trustabl/trustabl-rules#66**, on a branch of the **same name**, so the `rules-sync` job resolves the matching pack rather than `main`. Neither half should merge alone — `check-rules-sync.sh` fails if they do.

## What the pair adds

Ports the CSDK-017/018 description-quality pair to LangChain. LC-001 only checks that a docstring *exists*, so `"""TODO: describe this tool."""` and `"""Gets data."""` pass today. Two things make the LangChain framing its own: mis-selection scales badly because agents are routinely handed a dozen or more tools at once, and each wrong pick burns an iteration against LC-102's `max_iterations` budget — so a run can exhaust its steps and return nothing useful.

## What this PR does

1. Mirrors `langchain/tool_definition.yaml` into `testdata/rules-fixture/`.
2. Adds cases to `policyRuleCases`, as `TestPolicyRules_AllRulesCovered` requires.

| case | expectation |
|---|---|
| LC-018 — `"""TODO: describe this tool."""` | fires |
| LC-018 — real description | silent |
| LC-019 — `"""Gets data."""` | fires |
| LC-019 — full sentence | silent |
| LC-019 — **no docstring at all** | silent |

**Five cases rather than four.** LC-019 pairs `description_length_lt: 40` with `has_docstring: true` so an absent docstring stays LC-001's finding rather than double-reporting — an empty description is length 0, which is also under the threshold. The fifth case pins that guard.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (86 files compared)

$ go vet ./internal/rules/
$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules
```