### PR TITLE
test(rules): mirror and cover CREW-010, CREW-011

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -1986,6 +1986,32 @@ def fetch_data(x: str) -> dict:
     return {}
 `,
 		toolConfig: nil, wantFires: false},
+
+	// ─── CREW-010 / CREW-011: CrewAI description quality ────────────────────
+	{name: "CREW-010 fires on placeholder description", ruleID: "CREW-010", kind: models.KindCrewAITool, src: `
+def lookup_order(order_id: str) -> str:
+    """TODO: describe this tool."""
+    return order_id
+`, wantFires: true},
+	{name: "CREW-010 silent on a real description", ruleID: "CREW-010", kind: models.KindCrewAITool, src: `
+def lookup_order(order_id: str) -> str:
+    """Look up a single order by its identifier and return its current status."""
+    return order_id
+`, wantFires: false},
+	{name: "CREW-011 fires on a too-short description", ruleID: "CREW-011", kind: models.KindCrewAITool, src: `
+def list_orders(customer_id: str) -> str:
+    """Gets data."""
+    return customer_id
+`, wantFires: true},
+	{name: "CREW-011 silent on a full description", ruleID: "CREW-011", kind: models.KindCrewAITool, src: `
+def list_orders(customer_id: str) -> str:
+    """List every order belonging to one customer, most recent first."""
+    return customer_id
+`, wantFires: false},
+	{name: "CREW-011 silent when the docstring is absent (CREW-001's case)", ruleID: "CREW-011", kind: models.KindCrewAITool, src: `
+def list_orders(customer_id: str) -> str:
+    return customer_id
+`, wantFires: false},
 }
 
 // policyRepoRuleCases covers repo-scoped rules.
@@ -2246,7 +2272,6 @@ var policyRepoRuleCases = []policyRepoCase{
 		},
 		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKOpenAIAgents}},
 		false},
-
 }
 
 // optionsWithPermissionMode builds a ClaudeAgentOptionsDef whose captured

--- a/testdata/rules-fixture/crewai/tool_definition.yaml
+++ b/testdata/rules-fixture/crewai/tool_definition.yaml
@@ -52,3 +52,60 @@ rules:
       Annotate every parameter with a concrete type (str, int, list[str], a
       Pydantic model, etc.). CrewAI propagates these annotations into the schema the
       model sees, so the model emits correctly-shaped arguments.
+
+  - id: CREW-010
+    title: CrewAI tool description is a placeholder
+    severity: low
+    confidence: 0.85
+    language: python
+    applies_to:
+      - crewai_tool
+    scope: tool
+    match:
+      has_description_text:
+        - todo
+        - tbd
+        - fixme
+        - placeholder
+        - no description
+        - does stuff
+    explanation: >
+      The docstring passes the CREW-001 has-a-description check but carries a
+      placeholder marker instead of real content. CrewAI puts the tool
+      description in front of the agent as its only basis for choosing between
+      the tools it holds, so a stub like "TODO: describe this tool" is
+      functionally indistinguishable from no description at all. In a crew the
+      consequence travels: an agent that picks the wrong tool produces a task
+      output that is threaded forward as context to every task behind it, so one
+      undescribed tool degrades work the agent that owns it never touches — and
+      CREW-104 delegation means peers can reach this tool on the strength of the
+      same placeholder.
+    fix: >
+      Replace the placeholder with a real description covering what the tool
+      does, what it returns, and when the agent should reach for it rather than
+      a neighboring tool.
+
+  - id: CREW-011
+    title: CrewAI tool description is too short to guide agent selection
+    severity: low
+    confidence: 0.8
+    language: python
+    applies_to:
+      - crewai_tool
+    scope: tool
+    match:
+      all:
+        - has_docstring: true
+        - description_length_lt: 40
+    explanation: >
+      A description under 40 characters is rarely enough to convey what a tool
+      does, what it returns, and when to call it rather than a similarly named
+      neighbor. CrewAI passes this text to the agent as its only selection
+      signal, so a stub like "Gets data." leaves scope and preconditions to
+      guesswork. Each mis-selected call also spends one of the agent's CREW-110
+      max_iter steps, so an agent can hit its iteration cap and hand the next
+      task a half-finished result rather than an answer.
+    fix: >
+      Expand the description to at least a full sentence covering inputs,
+      outputs, and the situation in which this tool should be used over the
+      alternatives.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **trustabl/trustabl-rules#67**, on a branch of the **same name**, so the `rules-sync` job resolves the matching pack rather than `main`. Neither half should merge alone — `check-rules-sync.sh` fails if they do.

## What the pair adds

Ports the CSDK-017/018 description-quality pair to CrewAI. CREW-001 only checks that a docstring *exists*, so `"""TODO: describe this tool."""` and `"""Gets data."""` pass today. What makes the CrewAI framing its own is that **the consequence travels**: an agent that picks the wrong tool produces a task output threaded forward as context to every task behind it, and CREW-104 delegation lets peers reach the tool on the strength of the same placeholder.

## What this PR does

1. Mirrors `crewai/tool_definition.yaml` into `testdata/rules-fixture/`.
2. Adds cases to `policyRuleCases`, as `TestPolicyRules_AllRulesCovered` requires.

| case | expectation |
|---|---|
| CREW-010 — `"""TODO: describe this tool."""` | fires |
| CREW-010 — real description | silent |
| CREW-011 — `"""Gets data."""` | fires |
| CREW-011 — full sentence | silent |
| CREW-011 — **no docstring at all** | silent |

**Five cases rather than four.** CREW-011 pairs `description_length_lt: 40` with `has_docstring: true` so an absent docstring stays CREW-001's finding rather than double-reporting — an empty description is length 0, which is also under the threshold. The fifth case pins that guard.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (86 files compared)

$ go vet ./internal/rules/
$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules
```