### PR TITLE
test(rules): mirror and cover AG2-016, AG2-017

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -1986,6 +1986,32 @@ def fetch_data(x: str) -> dict:
     return {}
 `,
 		toolConfig: nil, wantFires: false},
+
+	// ─── AG2-016 / AG2-017: AutoGen description quality ─────────────────────
+	{name: "AG2-016 fires on placeholder description", ruleID: "AG2-016", kind: models.KindAutoGenTool, src: `
+def lookup_order(order_id: str) -> str:
+    """TODO: describe this tool."""
+    return order_id
+`, wantFires: true},
+	{name: "AG2-016 silent on a real description", ruleID: "AG2-016", kind: models.KindAutoGenTool, src: `
+def lookup_order(order_id: str) -> str:
+    """Look up a single order by its identifier and return its current status."""
+    return order_id
+`, wantFires: false},
+	{name: "AG2-017 fires on a too-short description", ruleID: "AG2-017", kind: models.KindAutoGenTool, src: `
+def list_orders(customer_id: str) -> str:
+    """Gets data."""
+    return customer_id
+`, wantFires: true},
+	{name: "AG2-017 silent on a full description", ruleID: "AG2-017", kind: models.KindAutoGenTool, src: `
+def list_orders(customer_id: str) -> str:
+    """List every order belonging to one customer, most recent first."""
+    return customer_id
+`, wantFires: false},
+	{name: "AG2-017 silent when the docstring is absent (AG2-007's case)", ruleID: "AG2-017", kind: models.KindAutoGenTool, src: `
+def list_orders(customer_id: str) -> str:
+    return customer_id
+`, wantFires: false},
 }
 
 // policyRepoRuleCases covers repo-scoped rules.
@@ -2246,7 +2272,6 @@ var policyRepoRuleCases = []policyRepoCase{
 		},
 		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKOpenAIAgents}},
 		false},
-
 }
 
 // optionsWithPermissionMode builds a ClaudeAgentOptionsDef whose captured

--- a/testdata/rules-fixture/autogen/tool_definition.yaml
+++ b/testdata/rules-fixture/autogen/tool_definition.yaml
@@ -54,3 +54,64 @@ rules:
       Annotate every parameter with a concrete type (str, int, list[str], a
       typing.Annotated description, etc.). AutoGen propagates these annotations into
       the schema the model sees, so the model emits correctly-shaped arguments.
+
+  - id: AG2-016
+    title: AutoGen tool description is a placeholder
+    severity: low
+    confidence: 0.85
+    language: python
+    applies_to:
+      - autogen_tool
+    scope: tool
+    match:
+      has_description_text:
+        - todo
+        - tbd
+        - fixme
+        - placeholder
+        - no description
+        - does stuff
+    explanation: >
+      The docstring passes the AG2-007 has-a-description check but carries a
+      placeholder marker instead of real content. AutoGen advertises the tool to
+      the assistant through this text, so a stub like "TODO: describe this tool"
+      is functionally indistinguishable from no description at all and the
+      assistant has to guess from the function name. The way AutoGen fails on a
+      bad guess is what makes this expensive: a wrongly chosen tool returns
+      something that does not answer the assistant's intent, the assistant reads
+      that as an inconclusive step and proposes another call, and the pair
+      trades rounds until AG2-004's max_round or AG2-006's auto-reply cap ends
+      the chat — burning the conversation budget on a selection problem no error
+      message points at.
+    fix: >
+      Replace the placeholder with a real description covering what the tool
+      does, what it returns, and when the assistant should call it rather than a
+      neighboring tool. Passing an explicit description= to register_for_llm
+      overrides the docstring and is the clearer place to say it.
+
+  - id: AG2-017
+    title: AutoGen tool description is too short to guide model selection
+    severity: low
+    confidence: 0.8
+    language: python
+    applies_to:
+      - autogen_tool
+    scope: tool
+    match:
+      all:
+        - has_docstring: true
+        - description_length_lt: 40
+    explanation: >
+      A description under 40 characters is rarely enough to convey what a tool
+      does, what it returns, and when to call it rather than a similarly named
+      neighbor. AutoGen passes this text to the assistant as its only selection
+      signal, so a stub like "Gets data." leaves scope and preconditions to
+      guesswork. Each mis-selected call costs a full round of the conversation —
+      the assistant proposes, the executor runs, the result comes back unhelpful
+      — so a thin description spends the max_round budget rather than the run
+      producing an answer.
+    fix: >
+      Expand the description to at least a full sentence covering inputs,
+      outputs, and the situation in which this tool should be used over the
+      alternatives, either in the docstring or via register_for_llm's
+      description= argument.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **trustabl/trustabl-rules#68**, on a branch of the **same name**, so the `rules-sync` job resolves the matching pack rather than `main`. Neither half should merge alone — `check-rules-sync.sh` fails if they do.

## What the pair adds

Ports the CSDK-017/018 description-quality pair to AutoGen. AG2-007 only checks that a docstring *exists*, so `"""TODO: describe this tool."""` and `"""Gets data."""` pass today. **How AutoGen fails on a bad guess is what makes it expensive**: a wrongly chosen tool returns something that doesn't answer the assistant's intent, the assistant reads that as inconclusive and proposes another call, and the pair trades rounds until AG2-004's `max_round` or AG2-006's auto-reply cap ends the chat — with nothing in the transcript naming the stub description as the cause.

## What this PR does

1. Mirrors `autogen/tool_definition.yaml` into `testdata/rules-fixture/`.
2. Adds cases to `policyRuleCases`, as `TestPolicyRules_AllRulesCovered` requires.

| case | expectation |
|---|---|
| AG2-016 — `"""TODO: describe this tool."""` | fires |
| AG2-016 — real description | silent |
| AG2-017 — `"""Gets data."""` | fires |
| AG2-017 — full sentence | silent |
| AG2-017 — **no docstring at all** | silent |

**Five cases rather than four.** AG2-017 pairs `description_length_lt: 40` with `has_docstring: true` so an absent docstring stays AG2-007's finding rather than double-reporting — an empty description is length 0, which is also under the threshold. The fifth case pins that guard.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (86 files compared)

$ go vet ./internal/rules/
$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules
```