### PR TITLE
test(rules): mirror and cover VAI-013, VAI-014

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -1986,6 +1986,40 @@ def fetch_data(x: str) -> dict:
     return {}
 `,
 		toolConfig: nil, wantFires: false},
+
+	// ─── VAI-013 / VAI-014: Vercel AI description quality (typescript) ──────
+	// has_description_text and description_length_lt both read
+	// ToolDef.Description, which for TS is the explicit `description` field.
+	{
+		name: "VAI-013 fires on placeholder description", ruleID: "VAI-013",
+		kind: models.KindVercelAITool, lang: models.LanguageTypeScript, wantFires: true,
+		src: "import { tool } from \"ai\";\n" +
+			"export const t = tool({ description: \"TODO: describe this tool.\", inputSchema: {}, execute: async () => \"x\" });\n",
+	},
+	{
+		name: "VAI-013 silent on a real description", ruleID: "VAI-013",
+		kind: models.KindVercelAITool, lang: models.LanguageTypeScript, wantFires: false,
+		src: "import { tool } from \"ai\";\n" +
+			"export const t = tool({ description: \"Look up a single order by its identifier and return its status.\", inputSchema: {}, execute: async () => \"x\" });\n",
+	},
+	{
+		name: "VAI-014 fires on a too-short description", ruleID: "VAI-014",
+		kind: models.KindVercelAITool, lang: models.LanguageTypeScript, wantFires: true,
+		src: "import { tool } from \"ai\";\n" +
+			"export const t = tool({ description: \"Gets data.\", inputSchema: {}, execute: async () => \"x\" });\n",
+	},
+	{
+		name: "VAI-014 silent on a full description", ruleID: "VAI-014",
+		kind: models.KindVercelAITool, lang: models.LanguageTypeScript, wantFires: false,
+		src: "import { tool } from \"ai\";\n" +
+			"export const t = tool({ description: \"List every order belonging to one customer, most recent first.\", inputSchema: {}, execute: async () => \"x\" });\n",
+	},
+	{
+		name: "VAI-014 silent when the description is absent (VAI-004's case)", ruleID: "VAI-014",
+		kind: models.KindVercelAITool, lang: models.LanguageTypeScript, wantFires: false,
+		src: "import { tool } from \"ai\";\n" +
+			"export const t = tool({ inputSchema: {}, execute: async () => \"x\" });\n",
+	},
 }
 
 // policyRepoRuleCases covers repo-scoped rules.
@@ -2246,7 +2280,6 @@ var policyRepoRuleCases = []policyRepoCase{
 		},
 		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKOpenAIAgents}},
 		false},
-
 }
 
 // optionsWithPermissionMode builds a ClaudeAgentOptionsDef whose captured

--- a/testdata/rules-fixture/vercel_ai/tool_definition.yaml
+++ b/testdata/rules-fixture/vercel_ai/tool_definition.yaml
@@ -58,3 +58,60 @@ rules:
       field per argument (z.object({ city: z.string(), units: z.enum([...]) })).
       Reserve dynamicTool for the rare case where the input genuinely cannot be
       typed, and even then validate the shape inside execute() before using it.
+
+  - id: VAI-013
+    title: Vercel AI tool description is a placeholder
+    severity: low
+    confidence: 0.85
+    language: typescript
+    applies_to:
+      - vercel_ai_tool
+    scope: tool
+    match:
+      has_description_text:
+        - todo
+        - tbd
+        - fixme
+        - placeholder
+        - no description
+        - does stuff
+    explanation: >
+      The tool sets a description, so it passes VAI-004, but the string is a
+      placeholder rather than real content. That leaves the tool in exactly the
+      state VAI-004 exists to prevent: the Vercel AI SDK has no docstring
+      fallback, so this string is the entire account of the tool in the prompt,
+      and "TODO: describe this tool" tells the model nothing the function name
+      did not. The model skips the tool or calls it with the wrong arguments,
+      and nothing in the SDK reports that the description was a stub — the only
+      symptom is a tool the model uses badly or not at all.
+    fix: >
+      Replace the placeholder with a real description covering what the tool
+      does, what it returns, and when the model should call it rather than a
+      neighboring tool. The SDK passes the string to the model verbatim, so
+      write it for the model rather than a human maintainer.
+
+  - id: VAI-014
+    title: Vercel AI tool description is too short to guide model selection
+    severity: low
+    confidence: 0.8
+    language: typescript
+    applies_to:
+      - vercel_ai_tool
+    scope: tool
+    match:
+      all:
+        - has_docstring: true
+        - description_length_lt: 40
+    explanation: >
+      A description under 40 characters is rarely enough to convey what a tool
+      does, what it returns, and when to call it rather than a similarly named
+      neighbor. With no docstring fallback in this SDK, a stub like "Gets data."
+      is the whole prompt-side account of the tool, so scope and preconditions
+      are left to guesswork. Each mis-selected call also consumes a step against
+      the VAI-007 tool-loop bound, so a thin description spends the loop budget
+      instead of the run producing an answer.
+    fix: >
+      Expand the description to at least a full sentence covering inputs,
+      outputs, and the situation in which this tool should be used over the
+      alternatives. Where two tools are easy to confuse, say in each which one
+      the other case belongs to.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **trustabl/trustabl-rules#69**, on a branch of the **same name**, so the `rules-sync` job resolves the matching pack rather than `main`. Neither half should merge alone — `check-rules-sync.sh` fails if they do.

## What the pair adds

Ports the CSDK-017/018 description-quality pair to the Vercel AI SDK. VAI-004 only checks that a `description` *exists*, so `"TODO: describe this tool."` and `"Gets data."` pass today — while leaving the tool in exactly the state VAI-004 exists to prevent. **VAI-004's own text says why this matters more here:** the SDK has no docstring fallback, so the description string is the entire prompt-side account of the tool.

## What this PR does

1. Mirrors `vercel_ai/tool_definition.yaml` into `testdata/rules-fixture/`.
2. Adds cases to `policyRuleCases`, as `TestPolicyRules_AllRulesCovered` requires.

| case | expectation |
|---|---|
| VAI-013 — `description: "TODO: describe this tool."` | fires |
| VAI-013 — real description | silent |
| VAI-014 — `description: "Gets data."` | fires |
| VAI-014 — full sentence | silent |
| VAI-014 — **no `description` field at all** | silent |

**Five cases rather than four.** VAI-014 pairs `description_length_lt: 40` with `has_docstring: true` so an absent description stays VAI-004's finding rather than double-reporting — an empty description is length 0, which is also under the threshold. The fifth case pins that guard.

Both predicates read `ToolDef.Description`, which for TypeScript is the explicit `description` field — confirmed firing against TS tools rather than assumed.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (86 files compared)

$ go vet ./internal/rules/
$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules
```