### PR TITLE
test(rules): mirror and cover VAI-015

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -1986,6 +1986,30 @@ def fetch_data(x: str) -> dict:
     return {}
 `,
 		toolConfig: nil, wantFires: false},
+
+	// ─── VAI-015: Vercel AI tool writes to the filesystem (typescript) ──────
+	// Coarse has_write_call signal, mirroring CSDK-012 until TS path
+	// normalization analysis exists.
+	{
+		name: "VAI-015 fires on filesystem write", ruleID: "VAI-015",
+		kind: models.KindVercelAITool, lang: models.LanguageTypeScript, wantFires: true,
+		src: "import { tool } from \"ai\";\n" +
+			"import { writeFileSync } from \"node:fs\";\n" +
+			"export const t = tool({ description: \"Save a note to disk for later retrieval.\", inputSchema: {}, execute: async ({ p, body }) => {\n" +
+			"  writeFileSync(p, body);\n" +
+			"  return \"saved\";\n" +
+			"} });\n",
+	},
+	{
+		name: "VAI-015 silent with no filesystem write", ruleID: "VAI-015",
+		kind: models.KindVercelAITool, lang: models.LanguageTypeScript, wantFires: false,
+		src: "import { tool } from \"ai\";\n" +
+			"const notes = new Map<string, string>();\n" +
+			"export const t = tool({ description: \"Save a note to disk for later retrieval.\", inputSchema: {}, execute: async ({ body }) => {\n" +
+			"  notes.set(\"n1\", body);\n" +
+			"  return \"n1\";\n" +
+			"} });\n",
+	},
 }
 
 // policyRepoRuleCases covers repo-scoped rules.
@@ -2246,7 +2270,6 @@ var policyRepoRuleCases = []policyRepoCase{
 		},
 		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKOpenAIAgents}},
 		false},
-
 }
 
 // optionsWithPermissionMode builds a ClaudeAgentOptionsDef whose captured

--- a/testdata/rules-fixture/vercel_ai/path_safety.yaml
+++ b/testdata/rules-fixture/vercel_ai/path_safety.yaml
@@ -1,0 +1,38 @@
+policy:
+  id: vercel_ai_path_safety
+  name: Vercel AI SDK filesystem path safety
+  category: vercel_ai
+  description: >
+    Flags Vercel AI SDK tools whose execute() handler writes to the filesystem.
+    A write whose path or contents derive from model-supplied arguments lets a
+    prompt-injected agent overwrite anything the host process can reach.
+
+rules:
+  - id: VAI-015
+    title: Vercel AI tool writes to the filesystem
+    severity: low
+    confidence: 0.5
+    language: typescript
+    applies_to:
+      - vercel_ai_tool
+    scope: tool
+    match:
+      has_write_call: true
+    explanation: >
+      This tool's execute() handler writes to the filesystem. If the path or the
+      contents derive from the tool's arguments, the model chooses both, and a
+      prompt injection carried in retrieved content or an earlier tool result can
+      steer the write at any file the host process can reach — a config file, a
+      build artifact, source in the deployed bundle. The usual deployment shape
+      makes this worse than it looks: Vercel AI tools typically run inside the
+      same server process as the request handler, not in a sandbox, so the write
+      inherits the application's own filesystem permissions rather than a
+      restricted set. (Coarse signal — it flags any filesystem write, not only
+      unnormalized paths, because TypeScript path-normalization analysis is not
+      yet wired. Confirm the path is genuinely model-supplied before acting.)
+    fix: >
+      Confine writes to a dedicated working directory: resolve the final path,
+      verify it stays under that root before writing, and reject absolute paths
+      and any input containing "..". Where the tool only ever writes to
+      generated names, derive the filename server-side from an id rather than
+      accepting a path from the model at all.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **trustabl/trustabl-rules#70**, on a branch of the **same name**, so the `rules-sync` job resolves the matching pack rather than `main`. Neither half should merge alone — `check-rules-sync.sh` fails if they do.

## What the pair adds

The Vercel AI pack had no path-safety rule (CSDK-004/012, OAI-006, ADK-004, MCP-005 all exist). VAI-015 mirrors CSDK-012, including its coarse-signal caveat stated in the explanation: it flags *any* filesystem write, not only unnormalized paths, because TS path-normalization analysis isn't wired yet. Confidence 0.5 to match.

What makes it worth flagging in this pack is the deployment shape — Vercel AI tools typically run inside the same server process as the request handler rather than a sandbox, so a model-steered write inherits the application's own filesystem permissions.

## What this PR does

1. Mirrors `vercel_ai/path_safety.yaml` into `testdata/rules-fixture/`.
2. Adds a fire case and a silent case to `policyRuleCases`, as `TestPolicyRules_AllRulesCovered` requires.

The silent case applies the remediation the `fix` text prescribes for the common shape — **derive the filename server-side rather than accepting a path from the model** — instead of merely deleting the write. So it demonstrates the prescribed fix clears the finding, not just that the predicate is satisfiable.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (87 files compared)

$ go vet ./internal/rules/
$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules
```