### PR TITLE
test(rules): mirror and cover PYD-012

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -1986,6 +1986,27 @@ def fetch_data(x: str) -> dict:
     return {}
 `,
 		toolConfig: nil, wantFires: false},
+	{name: "PYD-012 fires on print() in the tool body", ruleID: "PYD-012", kind: models.KindPydanticAITool, src: `
+def lookup_order(order_id: str) -> str:
+    """Look up an order."""
+    print("looking up " + order_id)
+    return order_id
+`, wantFires: true},
+	{name: "PYD-012 silent when logging instead of printing", ruleID: "PYD-012", kind: models.KindPydanticAITool, src: `
+import logging
+logger = logging.getLogger(__name__)
+def lookup_order(order_id: str) -> str:
+    """Look up an order."""
+    logger.info("looking up %s", order_id)
+    return order_id
+`, wantFires: false},
+	{name: "PYD-012 silent on pprint (bare-callee guard)", ruleID: "PYD-012", kind: models.KindPydanticAITool, src: `
+from pprint import pprint
+def lookup_order(order_id: str) -> str:
+    """Look up an order."""
+    pprint({"order_id": order_id})
+    return order_id
+`, wantFires: false},
 }
 
 // policyRepoRuleCases covers repo-scoped rules.
@@ -2246,7 +2267,6 @@ var policyRepoRuleCases = []policyRepoCase{
 		},
 		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKOpenAIAgents}},
 		false},
-
 }
 
 // optionsWithPermissionMode builds a ClaudeAgentOptionsDef whose captured

--- a/testdata/rules-fixture/pydantic_ai/observability.yaml
+++ b/testdata/rules-fixture/pydantic_ai/observability.yaml
@@ -1,0 +1,37 @@
+policy:
+  id: pydantic_ai_observability
+  name: Pydantic AI tool observability hygiene
+  category: pydantic_ai
+  description: >
+    Rules covering how a Pydantic AI tool emits diagnostics. A tool body that
+    prints to stdout writes outside the SDK's instrumentation, so the record
+    reaches neither the model nor the trace the rest of the run is captured in.
+
+rules:
+  - id: PYD-012
+    title: Pydantic AI tool prints to stdout for diagnostics
+    severity: low
+    confidence: 0.65
+    language: python
+    applies_to:
+      - pydantic_ai_tool
+    scope: tool
+    match:
+      has_print_call: true
+    explanation: >
+      The tool body calls print(), which writes to the process's stdout. The
+      model never sees it — only the return value flows back into the agent run
+      — so the output silently disappears in any deployment that captures
+      structured records rather than raw stdout. It is a bigger loss in this SDK
+      than in most: Pydantic AI emits OpenTelemetry spans for each run and tool
+      call, so everything around this print is already correlated to a trace,
+      and a bare print is the one diagnostic that lands outside it, unattached
+      to the run that produced it. If the tool is ever also served over an MCP
+      stdio transport, the loose print frames interleave with JSON-RPC messages
+      and corrupt the stream.
+    fix: >
+      Remove the print(). For operator diagnostics, emit through a module logger
+      (logging.getLogger(__name__).info(...)), or attach the detail to the
+      current span via Logfire or the OpenTelemetry API so it is correlated with
+      the run that produced it. If the information needs to reach the model,
+      return it as part of the tool's result instead.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **trustabl/trustabl-rules#71**, on a branch of the **same name**, so the `rules-sync` job resolves the matching pack rather than `main`. Neither half should merge alone — `check-rules-sync.sh` fails if they do.

## What the pair adds

Pydantic AI had no observability rule; OpenAI ships OAI-010 and ADK ships ADK-009 for the same `print()` pattern. The framing is Pydantic AI's own rather than a port: Pydantic AI emits OpenTelemetry spans for each run and tool call, so everything around this print is already correlated to a trace — the bare print is the one diagnostic landing outside it, unattached to the run that produced it.

## What this PR does

1. Mirrors the new `observability.yaml` into `testdata/rules-fixture/`.
2. Adds cases to `policyRuleCases`, as `TestPolicyRules_AllRulesCovered` requires.

| case | expectation |
|---|---|
| `print("looking up " + order_id)` | fires |
| `logger.info("looking up %s", order_id)` | silent |
| `pprint({...})` | silent |

**Three cases rather than two.** The `pprint` case pins `has_print_call`'s bare-callee behavior — the rule must not regress into substring matching that sweeps in `pprint` and every other callee whose name merely contains "print". The schema calls that out explicitly as the trap `has_body_text` falls into, so it's worth a standing test rather than a comment.

The silent case applies the remediation the `fix` text prescribes (a module logger) rather than deleting the call.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (87 files compared)

$ go vet ./internal/rules/
$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules
```