### PR TITLE
test(rules): mirror and cover LC-020

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -1986,6 +1986,27 @@ def fetch_data(x: str) -> dict:
     return {}
 `,
 		toolConfig: nil, wantFires: false},
+	{name: "LC-020 fires on print() in the tool body", ruleID: "LC-020", kind: models.KindLangChainTool, src: `
+def lookup_order(order_id: str) -> str:
+    """Look up an order."""
+    print("looking up " + order_id)
+    return order_id
+`, wantFires: true},
+	{name: "LC-020 silent when logging instead of printing", ruleID: "LC-020", kind: models.KindLangChainTool, src: `
+import logging
+logger = logging.getLogger(__name__)
+def lookup_order(order_id: str) -> str:
+    """Look up an order."""
+    logger.info("looking up %s", order_id)
+    return order_id
+`, wantFires: false},
+	{name: "LC-020 silent on pprint (bare-callee guard)", ruleID: "LC-020", kind: models.KindLangChainTool, src: `
+from pprint import pprint
+def lookup_order(order_id: str) -> str:
+    """Look up an order."""
+    pprint({"order_id": order_id})
+    return order_id
+`, wantFires: false},
 }
 
 // policyRepoRuleCases covers repo-scoped rules.
@@ -2246,7 +2267,6 @@ var policyRepoRuleCases = []policyRepoCase{
 		},
 		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKOpenAIAgents}},
 		false},
-
 }
 
 // optionsWithPermissionMode builds a ClaudeAgentOptionsDef whose captured

--- a/testdata/rules-fixture/langchain/observability.yaml
+++ b/testdata/rules-fixture/langchain/observability.yaml
@@ -1,0 +1,38 @@
+policy:
+  id: langchain_observability
+  name: LangChain tool observability hygiene
+  category: langchain
+  description: >
+    Rules covering how a LangChain tool emits diagnostics. A tool body that
+    prints to stdout writes outside the callback system the rest of the run is
+    recorded through, so the record reaches neither the model nor the trace.
+
+rules:
+  - id: LC-020
+    title: LangChain tool prints to stdout for diagnostics
+    severity: low
+    confidence: 0.65
+    language: python
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      has_print_call: true
+    explanation: >
+      The tool body calls print(), which writes to the process's stdout. The
+      model never sees it — only the return value flows back into the executor
+      loop — so the output silently disappears in any deployment that captures
+      structured records rather than raw stdout. It is a bigger loss in this SDK
+      than in most, because LangChain already threads every tool start, end, and
+      error through its callback system into LangSmith or whatever tracer is
+      configured. A bare print is the one diagnostic that lands outside that,
+      detached from the run and the step that produced it, so the moment anyone
+      debugs from a trace rather than a terminal it is simply not there. If the
+      same tool is ever served over an MCP stdio transport, the loose print
+      frames interleave with JSON-RPC messages and corrupt the stream.
+    fix: >
+      Remove the print(). For operator diagnostics, emit through a module logger
+      (logging.getLogger(__name__).info(...)) so it lands in the application's
+      log sink, or attach the detail to the run through the callback system so
+      it is correlated with the step that produced it. If the information needs
+      to reach the model, return it as part of the tool's result instead.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **trustabl/trustabl-rules#72**, on a branch of the **same name**, so the `rules-sync` job resolves the matching pack rather than `main`. Neither half should merge alone — `check-rules-sync.sh` fails if they do.

## What the pair adds

LangChain had no observability rule; OpenAI ships OAI-010 and ADK ships ADK-009 for the same `print()` pattern. The framing is LangChain's own rather than a port: LangChain already threads every tool start, end, and error through its callback system into LangSmith or whichever tracer is configured, so a bare print is the one diagnostic landing outside that — absent the moment anyone debugs from a trace rather than a terminal.

## What this PR does

1. Mirrors the new `observability.yaml` into `testdata/rules-fixture/`.
2. Adds cases to `policyRuleCases`, as `TestPolicyRules_AllRulesCovered` requires.

| case | expectation |
|---|---|
| `print("looking up " + order_id)` | fires |
| `logger.info("looking up %s", order_id)` | silent |
| `pprint({...})` | silent |

**Three cases rather than two.** The `pprint` case pins `has_print_call`'s bare-callee behavior — the rule must not regress into substring matching that sweeps in `pprint` and every other callee whose name merely contains "print". The schema calls that out explicitly as the trap `has_body_text` falls into, so it's worth a standing test rather than a comment.

The silent case applies the remediation the `fix` text prescribes (a module logger) rather than deleting the call.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (87 files compared)

$ go vet ./internal/rules/
$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules
```