### PR TITLE
test(rules): mirror and cover CREW-012

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -1986,6 +1986,27 @@ def fetch_data(x: str) -> dict:
     return {}
 `,
 		toolConfig: nil, wantFires: false},
+	{name: "CREW-012 fires on print() in the tool body", ruleID: "CREW-012", kind: models.KindCrewAITool, src: `
+def lookup_order(order_id: str) -> str:
+    """Look up an order."""
+    print("looking up " + order_id)
+    return order_id
+`, wantFires: true},
+	{name: "CREW-012 silent when logging instead of printing", ruleID: "CREW-012", kind: models.KindCrewAITool, src: `
+import logging
+logger = logging.getLogger(__name__)
+def lookup_order(order_id: str) -> str:
+    """Look up an order."""
+    logger.info("looking up %s", order_id)
+    return order_id
+`, wantFires: false},
+	{name: "CREW-012 silent on pprint (bare-callee guard)", ruleID: "CREW-012", kind: models.KindCrewAITool, src: `
+from pprint import pprint
+def lookup_order(order_id: str) -> str:
+    """Look up an order."""
+    pprint({"order_id": order_id})
+    return order_id
+`, wantFires: false},
 }
 
 // policyRepoRuleCases covers repo-scoped rules.
@@ -2246,7 +2267,6 @@ var policyRepoRuleCases = []policyRepoCase{
 		},
 		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKOpenAIAgents}},
 		false},
-
 }
 
 // optionsWithPermissionMode builds a ClaudeAgentOptionsDef whose captured

--- a/testdata/rules-fixture/crewai/observability.yaml
+++ b/testdata/rules-fixture/crewai/observability.yaml
@@ -1,0 +1,37 @@
+policy:
+  id: crewai_observability
+  name: CrewAI tool observability hygiene
+  category: crewai
+  description: >
+    Rules covering how a CrewAI tool emits diagnostics. A tool body that prints
+    to stdout writes into the same channel the crew's own verbose narration uses,
+    so the record is neither visible to the agent nor separable from the run
+    commentary around it.
+
+rules:
+  - id: CREW-012
+    title: CrewAI tool prints to stdout for diagnostics
+    severity: low
+    confidence: 0.65
+    language: python
+    applies_to:
+      - crewai_tool
+    scope: tool
+    match:
+      has_print_call: true
+    explanation: >
+      The tool body calls print(), which writes to the process's stdout. The
+      agent never sees it — only the return value becomes the observation it
+      reasons over — so the output silently disappears in any deployment that
+      captures structured records rather than raw stdout. CrewAI makes it worse
+      than a lost log line: a crew running with verbose=True is already writing
+      its own narration to that same stream, so a tool print is interleaved into
+      run commentary from several agents at once with nothing marking which
+      agent, task, or tool call emitted it. What looks like working diagnostics
+      in a terminal is unattributable the moment the crew runs anywhere else.
+    fix: >
+      Remove the print(). For operator diagnostics, emit through a module logger
+      (logging.getLogger(__name__).info(...)) so the record carries its own
+      module and level and lands in the application's log sink rather than the
+      crew's narration stream. If the information needs to reach the agent,
+      return it as part of the tool's result instead.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **trustabl/trustabl-rules#73**, on a branch of the **same name**, so the `rules-sync` job resolves the matching pack rather than `main`. Neither half should merge alone — `check-rules-sync.sh` fails if they do.

## What the pair adds

CrewAI had no observability rule; OpenAI ships OAI-010 and ADK ships ADK-009 for the same `print()` pattern. The framing is CrewAI's own rather than a port: A crew running with verbose=True is already writing its own narration to stdout, so a tool print is interleaved into commentary from several agents at once with nothing marking which agent, task, or tool call emitted it.

## What this PR does

1. Mirrors the new `observability.yaml` into `testdata/rules-fixture/`.
2. Adds cases to `policyRuleCases`, as `TestPolicyRules_AllRulesCovered` requires.

| case | expectation |
|---|---|
| `print("looking up " + order_id)` | fires |
| `logger.info("looking up %s", order_id)` | silent |
| `pprint({...})` | silent |

**Three cases rather than two.** The `pprint` case pins `has_print_call`'s bare-callee behavior — the rule must not regress into substring matching that sweeps in `pprint` and every other callee whose name merely contains "print". The schema calls that out explicitly as the trap `has_body_text` falls into, so it's worth a standing test rather than a comment.

The silent case applies the remediation the `fix` text prescribes (a module logger) rather than deleting the call.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (87 files compared)

$ go vet ./internal/rules/
$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules
```