### PR TITLE
test(rules): mirror and cover AG2-018

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -1986,6 +1986,27 @@ def fetch_data(x: str) -> dict:
     return {}
 `,
 		toolConfig: nil, wantFires: false},
+	{name: "AG2-018 fires on print() in the tool body", ruleID: "AG2-018", kind: models.KindAutoGenTool, src: `
+def lookup_order(order_id: str) -> str:
+    """Look up an order."""
+    print("looking up " + order_id)
+    return order_id
+`, wantFires: true},
+	{name: "AG2-018 silent when logging instead of printing", ruleID: "AG2-018", kind: models.KindAutoGenTool, src: `
+import logging
+logger = logging.getLogger(__name__)
+def lookup_order(order_id: str) -> str:
+    """Look up an order."""
+    logger.info("looking up %s", order_id)
+    return order_id
+`, wantFires: false},
+	{name: "AG2-018 silent on pprint (bare-callee guard)", ruleID: "AG2-018", kind: models.KindAutoGenTool, src: `
+from pprint import pprint
+def lookup_order(order_id: str) -> str:
+    """Look up an order."""
+    pprint({"order_id": order_id})
+    return order_id
+`, wantFires: false},
 }
 
 // policyRepoRuleCases covers repo-scoped rules.
@@ -2246,7 +2267,6 @@ var policyRepoRuleCases = []policyRepoCase{
 		},
 		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKOpenAIAgents}},
 		false},
-
 }
 
 // optionsWithPermissionMode builds a ClaudeAgentOptionsDef whose captured

--- a/testdata/rules-fixture/autogen/observability.yaml
+++ b/testdata/rules-fixture/autogen/observability.yaml
@@ -1,0 +1,39 @@
+policy:
+  id: autogen_observability
+  name: AutoGen tool observability hygiene
+  category: autogen
+  description: >
+    Rules covering how a registered AutoGen tool emits diagnostics. A tool body
+    that prints to stdout writes into the same stream the conversation itself is
+    narrated on, so the record is neither visible to the agents nor separable
+    from the transcript around it.
+
+rules:
+  - id: AG2-018
+    title: AutoGen tool prints to stdout for diagnostics
+    severity: low
+    confidence: 0.65
+    language: python
+    applies_to:
+      - autogen_tool
+    scope: tool
+    match:
+      has_print_call: true
+    explanation: >
+      The registered tool's body calls print(), which writes to the process's
+      stdout. Neither agent sees it — only the return value is posted back into
+      the conversation as the executor's reply — so the output silently
+      disappears in any deployment that captures structured records rather than
+      raw stdout. AutoGen makes that especially deceptive: the conversation
+      itself is narrated to stdout, so a tool print lands in the middle of the
+      transcript and reads as though it were part of the exchange, when in fact
+      it is invisible to the agents reasoning over it and carries no marker for
+      which round or which tool call produced it. Anyone reconstructing the run
+      from a log sink rather than a terminal loses it entirely.
+    fix: >
+      Remove the print(). For operator diagnostics, emit through a module logger
+      (logging.getLogger(__name__).info(...)) so the record carries its own
+      module and level and lands in the application's log sink rather than the
+      conversation narration. If the information needs to reach the assistant,
+      return it as part of the tool's result, which is the only channel the
+      agents actually read.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **trustabl/trustabl-rules#74**, on a branch of the **same name**, so the `rules-sync` job resolves the matching pack rather than `main`. Neither half should merge alone — `check-rules-sync.sh` fails if they do.

## What the pair adds

AutoGen had no observability rule; OpenAI ships OAI-010 and ADK ships ADK-009 for the same `print()` pattern. The framing is AutoGen's own rather than a port: The conversation itself is narrated to stdout, so a tool print lands mid-transcript and reads as though it were part of the exchange — when it is invisible to the agents reasoning over it.

## What this PR does

1. Mirrors the new `observability.yaml` into `testdata/rules-fixture/`.
2. Adds cases to `policyRuleCases`, as `TestPolicyRules_AllRulesCovered` requires.

| case | expectation |
|---|---|
| `print("looking up " + order_id)` | fires |
| `logger.info("looking up %s", order_id)` | silent |
| `pprint({...})` | silent |

**Three cases rather than two.** The `pprint` case pins `has_print_call`'s bare-callee behavior — the rule must not regress into substring matching that sweeps in `pprint` and every other callee whose name merely contains "print". The schema calls that out explicitly as the trap `has_body_text` falls into, so it's worth a standing test rather than a comment.

The silent case applies the remediation the `fix` text prescribes (a module logger) rather than deleting the call.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (87 files compared)

$ go vet ./internal/rules/
$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules
```