### PR TITLE
test(rules): mirror and cover MCP-201

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -2247,6 +2247,25 @@ var policyRepoRuleCases = []policyRepoCase{
 		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKOpenAIAgents}},
 		false},
 
+	// ─── MCP-201: MCP server repo with no agent-guidance doc ────────────────
+	// Same shape as CSDK-203 / ADK-201 / OAI-202: repo_has_sdk_in_code reads
+	// inv.SDKsDetected, repo_component_present reads
+	// profile.Manifest.Components. Either AGENTS.md or CLAUDE.md silences it.
+	{"MCP-201 fires when MCP server code has no agent-guidance doc", "MCP-201",
+		models.RepoProfile{Languages: []models.Language{models.LanguagePython}},
+		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKMCP}},
+		true},
+	{"MCP-201 silent when AGENTS.md is present", "MCP-201",
+		models.RepoProfile{
+			Languages: []models.Language{models.LanguagePython},
+			Manifest:  models.ScanManifest{Components: []models.AgentComponent{{Kind: models.ComponentAgentsMd}}},
+		},
+		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKMCP}},
+		false},
+	{"MCP-201 silent when the repo has no MCP code", "MCP-201",
+		models.RepoProfile{Languages: []models.Language{models.LanguagePython}},
+		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKLangChain}},
+		false},
 }
 
 // optionsWithPermissionMode builds a ClaudeAgentOptionsDef whose captured

--- a/testdata/rules-fixture/mcp/repo_hygiene.yaml
+++ b/testdata/rules-fixture/mcp/repo_hygiene.yaml
@@ -1,0 +1,45 @@
+policy:
+  id: mcp_repo_hygiene
+  name: MCP server repo hygiene
+  category: mcp
+  description: >
+    Repo-scoped hygiene rules for projects that implement an MCP server. Fire
+    once per scan against the repo manifest and inventory rather than per tool.
+
+rules:
+  - id: MCP-201
+    title: MCP server project ships no agent-guidance doc (AGENTS.md/CLAUDE.md)
+    severity: low
+    confidence: 0.9
+    applies_to:
+      - mcp
+    scope: repo
+    match:
+      all:
+        - repo_has_sdk_in_code:
+            - mcp
+        - not:
+            repo_component_present:
+              - agents_md
+              - claude_md
+    explanation: >
+      The project implements an MCP server in code but ships no agent-guidance
+      doc (AGENTS.md or CLAUDE.md) at the repo root. AGENTS.md is the
+      cross-vendor convention an editing coding agent reads before it acts, so
+      with neither file present any agent that opens this repo has no
+      project-specific guidance on how tools must be registered, named,
+      described, and schema-typed. That matters more in an MCP server than in
+      most projects: everything this repo exports crosses a trust boundary to
+      whatever client and model connect to it, and the tool name, description,
+      and input schema are the entire contract those consumers see. A tool added
+      without the local conventions does not fail here — it degrades tool
+      selection in every downstream client, and the server's authors are not the
+      ones who observe it.
+    fix: >
+      Add an AGENTS.md at the repo root (a CLAUDE.md also satisfies this rule).
+      State the tool naming convention and namespace prefix, what a description
+      must cover for a client that has no other context about this server, how
+      input schemas must be typed, which operations are destructive and what
+      gates them, and the exact test, lint, and build commands. Keep it short
+      and concrete so an editing agent can act on it without re-deriving the
+      conventions.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **trustabl/trustabl-rules#78**, on a branch of the **same name**, so the `rules-sync` job resolves the matching pack rather than `main`. Neither half should merge alone — `check-rules-sync.sh` fails if they do.

## What the pair adds

**MCP was the only pack with no repo-scope rule at all** — the `mcp` `applies_to` token was valid in `appliesToByScope` but no shipped rule used it. Every other pack ships the agent-guidance check (CSDK-203, OAI-202, ADK-201, LC-201, CREW-201, AG2-201, PYD-201, VAI-012).

The framing is MCP's own: everything the repo exports crosses a trust boundary, so a tool added without the local conventions doesn't fail *there* — it degrades tool selection in every downstream client, and the server's authors aren't the ones who observe it.

## What this PR does

1. Mirrors `mcp/repo_hygiene.yaml` into `testdata/rules-fixture/`.
2. Adds cases to `policyRepoRuleCases`, as `TestPolicyRules_AllRulesCovered` requires.

| case | expectation |
|---|---|
| MCP code detected, no AGENTS.md or CLAUDE.md | fires |
| same, with an AGENTS.md component | silent |
| **LangChain detected instead of MCP** | silent |

Three cases, matching the CSDK-203 / ADK-201 / OAI-202 group this rule joins. The third pins that the `repo_has_sdk_in_code` gate actually gates — a repo-scope rule with an over-broad match fires once per scan on *every* repo, so that case is the one keeping it honest.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (87 files compared)

$ go vet ./internal/rules/
$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules	3.082s
```