### PR TITLE
test(rules): mirror and cover ADK-112

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -2246,7 +2246,6 @@ var policyRepoRuleCases = []policyRepoCase{
 		},
 		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKOpenAIAgents}},
 		false},
-
 }
 
 // optionsWithPermissionMode builds a ClaudeAgentOptionsDef whose captured
@@ -3950,6 +3949,54 @@ var policyAgentRuleCases = []policyAgentCase{
 		parseTSVercelAgentInline("import { generateText } from \"ai\";\n" +
 			"import { openai } from \"@ai-sdk/openai\";\n" +
 			"const r = await generateText({ model: openai(\"gpt-5\"), tools: { weather: weatherTool } });\n"),
+		models.RepoInventory{},
+		false},
+
+	// ─── ADK-112 workflow agent without a description ────────────────────────
+	// ADK-101 makes this check for LlmAgent; the workflow classes were
+	// uncovered — adk_sequential_agent / adk_parallel_agent had no rule at all.
+	// One fire case per class in applies_to, so all three are exercised rather
+	// than assumed to behave alike.
+	{"ADK-112 fires when SequentialAgent has no description", "ADK-112",
+		models.AgentDef{
+			SDK: models.SDKGoogleADK, Class: "SequentialAgent",
+			Language: models.LanguagePython, Name: "pipeline",
+			Kwargs: &models.KwargTree{Children: map[string]*models.KwargTree{
+				"name": {Value: &models.Expr{Kind: models.ExprLiteralString, Text: `"pipeline"`}},
+			}},
+		},
+		models.RepoInventory{},
+		true},
+	{"ADK-112 fires when ParallelAgent has no description", "ADK-112",
+		models.AgentDef{
+			SDK: models.SDKGoogleADK, Class: "ParallelAgent",
+			Language: models.LanguagePython, Name: "fanout",
+			Kwargs: &models.KwargTree{Children: map[string]*models.KwargTree{
+				"name": {Value: &models.Expr{Kind: models.ExprLiteralString, Text: `"fanout"`}},
+			}},
+		},
+		models.RepoInventory{},
+		true},
+	{"ADK-112 fires when LoopAgent has no description", "ADK-112",
+		models.AgentDef{
+			SDK: models.SDKGoogleADK, Class: "LoopAgent",
+			Language: models.LanguagePython, Name: "refine",
+			Kwargs: &models.KwargTree{Children: map[string]*models.KwargTree{
+				"name":           {Value: &models.Expr{Kind: models.ExprLiteralString, Text: `"refine"`}},
+				"max_iterations": {Value: &models.Expr{Kind: models.ExprLiteralInt, Text: "3"}},
+			}},
+		},
+		models.RepoInventory{},
+		true},
+	{"ADK-112 silent when the workflow agent has a description", "ADK-112",
+		models.AgentDef{
+			SDK: models.SDKGoogleADK, Class: "SequentialAgent",
+			Language: models.LanguagePython, Name: "pipeline",
+			Kwargs: &models.KwargTree{Children: map[string]*models.KwargTree{
+				"name":        {Value: &models.Expr{Kind: models.ExprLiteralString, Text: `"pipeline"`}},
+				"description": {Value: &models.Expr{Kind: models.ExprLiteralString, Text: `"Drafts, reviews, and revises a support reply before it is sent."`}},
+			}},
+		},
 		models.RepoInventory{},
 		false},
 }

--- a/testdata/rules-fixture/google_adk/agent_safety.yaml
+++ b/testdata/rules-fixture/google_adk/agent_safety.yaml
@@ -282,3 +282,39 @@ rules:
       Pass a `description` in the `new LlmAgent({...})` options that names this
       agent's role and the kind of input it handles. One sentence is enough; treat
       it as documentation the parent agent's model reads to route.
+
+  - id: ADK-112
+    title: Workflow agent has no description
+    severity: medium
+    confidence: 0.85
+    language: python
+    applies_to:
+      - adk_sequential_agent
+      - adk_parallel_agent
+      - adk_loop_agent
+    scope: agent
+    match:
+      all:
+        - agent_class: [SequentialAgent, ParallelAgent, LoopAgent]
+        - agent_kwarg_missing: [description]
+    explanation: >
+      Google ADK routes delegation using the description= field on each agent in
+      a sub_agents tree, and a workflow agent is routed to exactly like an
+      LlmAgent is: when the parent decides whether to hand off, the model sees
+      only the child's description. A SequentialAgent, ParallelAgent, or
+      LoopAgent with no description sits in the tree but gives the parent's model
+      no signal to pick it, so it is effectively unreachable through delegation
+      — a silent routing bug, not an error. It is easier to miss on a workflow
+      agent than on an LlmAgent: a workflow agent has no instruction= and no
+      model= of its own, so nothing else about its construction reads as
+      model-facing text and the missing description does not look like an
+      omission. What the agent orchestrates is also invisible from the outside —
+      the parent cannot infer "runs these three steps in order" from the class
+      name alone.
+    fix: >
+      Add a description= kwarg naming what the workflow accomplishes and the
+      kind of input it expects, not its mechanics — the parent's model is
+      choosing whether this branch is the right one, so "drafts, reviews, and
+      revises a support reply" routes correctly where "sequential agent" does
+      not. One sentence is usually enough. Treat it as documentation for the
+      parent agent's model.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **trustabl/trustabl-rules#79**, on a branch of the **same name**, so the `rules-sync` job resolves the matching pack rather than `main`. Neither half should merge alone — `check-rules-sync.sh` fails if they do.

## What the pair adds

`adk_sequential_agent`, `adk_parallel_agent`, and `adk_langgraph_agent` are valid `applies_to` tokens the engine discovers but **no shipped rule used any of them** — every ADK agent-scope rule targets `adk_llm_agent`, except ADK-108 for `LoopAgent`. I found this auditing which engine capabilities have zero rule coverage.

ADK-112 extends ADK-101's routing check to the workflow classes: a workflow agent is routed to exactly like an LlmAgent (the parent's model sees only the child's `description`), but it's easier to miss because a workflow agent has no `instruction=` or `model=` of its own, so nothing else about its construction reads as model-facing text.

## What this PR does

1. Mirrors `google_adk/agent_safety.yaml` into `testdata/rules-fixture/`.
2. Adds cases to `policyAgentRuleCases`, as `TestPolicyRules_AllRulesCovered` requires.

| case | expectation |
|---|---|
| `SequentialAgent` with no `description` | fires |
| `ParallelAgent` with no `description` | fires |
| `LoopAgent` with no `description` | fires |
| `SequentialAgent` with a `description` | silent |

**One fire case per class rather than a single representative.** The three reach the rule through different `applies_to` tokens sharing one match, so the per-class cases are what would catch a token being dropped from the list — a single case would leave two thirds of the rule's reach untested.

`adk_langgraph_agent` is deliberately excluded from the rule: `LanggraphAgent` takes a compiled graph rather than an ADK `sub_agents` tree, so the delegation-routing argument doesn't obviously transfer. Noted in the rules PR.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (86 files compared)

$ go vet ./internal/rules/
$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules	3.019s
```