### PR TITLE
test(rules): mirror and cover MCP-023

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -1986,6 +1986,27 @@ def fetch_data(x: str) -> dict:
     return {}
 `,
 		toolConfig: nil, wantFires: false},
+	{name: "MCP-023 fires on print() in the tool body", ruleID: "MCP-023", kind: models.KindMCPTool, src: `
+def lookup_order(order_id: str) -> str:
+    """Look up an order."""
+    print("looking up " + order_id)
+    return order_id
+`, wantFires: true},
+	{name: "MCP-023 silent when logging to stderr instead", ruleID: "MCP-023", kind: models.KindMCPTool, src: `
+import logging
+logger = logging.getLogger(__name__)
+def lookup_order(order_id: str) -> str:
+    """Look up an order."""
+    logger.info("looking up %s", order_id)
+    return order_id
+`, wantFires: false},
+	{name: "MCP-023 silent on pprint (bare-callee guard)", ruleID: "MCP-023", kind: models.KindMCPTool, src: `
+from pprint import pprint
+def lookup_order(order_id: str) -> str:
+    """Look up an order."""
+    pprint({"order_id": order_id})
+    return order_id
+`, wantFires: false},
 }
 
 // policyRepoRuleCases covers repo-scoped rules.
@@ -2246,7 +2267,6 @@ var policyRepoRuleCases = []policyRepoCase{
 		},
 		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKOpenAIAgents}},
 		false},
-
 }
 
 // optionsWithPermissionMode builds a ClaudeAgentOptionsDef whose captured

--- a/testdata/rules-fixture/mcp/observability.yaml
+++ b/testdata/rules-fixture/mcp/observability.yaml
@@ -1,0 +1,41 @@
+policy:
+  id: mcp_observability
+  name: MCP tool observability hygiene
+  category: mcp
+  description: >
+    Rules covering how an MCP tool handler emits diagnostics. On a stdio
+    server — the default transport — stdout is the protocol channel, so a
+    handler that prints to it is not writing a log line, it is writing into the
+    JSON-RPC frame stream.
+
+rules:
+  - id: MCP-023
+    title: MCP tool prints to stdout, corrupting a stdio transport
+    severity: medium
+    confidence: 0.7
+    language: python
+    applies_to:
+      - mcp_tool
+    scope: tool
+    match:
+      has_print_call: true
+    explanation: >
+      The tool handler calls print(), which writes to the process's stdout. On
+      an MCP server using the stdio transport — the default for FastMCP and the
+      usual way an editor or desktop client launches a server — stdout is not a
+      log sink, it is the protocol channel: the client reads newline-delimited
+      JSON-RPC messages from it. A loose print interleaves with those frames, so
+      the client hits a parse error on a line that is not JSON and, depending on
+      the client, drops the response, logs a protocol error, or tears down the
+      connection. The failure does not look like the cause: the symptom is a
+      tool call that returns nothing or a server that disconnects mid-session,
+      while the print that broke it reads like harmless debugging. A server run
+      over HTTP or SSE instead escapes the corruption, but the diagnostic is
+      still lost — the model never sees stdout, only the return value.
+    fix: >
+      Remove the print(). Diagnostics from an MCP server belong on stderr, which
+      the transport leaves alone and clients typically capture as server logs —
+      emit through a module logger (logging.getLogger(__name__)) configured with
+      a StreamHandler on sys.stderr, and make sure nothing in the process
+      reconfigures logging onto stdout. If the information needs to reach the
+      model, return it as part of the tool's result instead.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **trustabl/trustabl-rules#82**, on a branch of the **same name**, so the `rules-sync` job resolves the matching pack rather than `main`. Neither half should merge alone — `check-rules-sync.sh` fails if they do.

## What the pair adds

MCP had no observability rule. OpenAI ships OAI-010 and ADK ships ADK-009 for the same `print()` pattern — both at `low`, framed as a lost-diagnostic problem.

**It isn't a lost-diagnostic problem here, which is why MCP-023 ships at `medium`.** On a stdio server — the FastMCP default, and how an editor or desktop client launches one — stdout *is* the protocol channel. A loose print interleaves with the newline-delimited JSON-RPC frames, so the client hits a parse error on a line that isn't JSON and drops the response or tears down the session. The symptom doesn't resemble the cause: a tool call that returns nothing, traced back to a print that reads like harmless debugging.

OAI-010's explanation already anticipates exactly this case as a footnote; MCP-023 makes it the primary reading. Confidence 0.7 because HTTP/SSE transports escape the corruption (though still lose the diagnostic).

## What this PR does

1. Mirrors `mcp/observability.yaml` into `testdata/rules-fixture/`.
2. Adds cases to `policyRuleCases`, as `TestPolicyRules_AllRulesCovered` requires.

| case | expectation |
|---|---|
| `print("looking up " + order_id)` | fires |
| `logger.info(...)` (stderr handler) | silent |
| `pprint({...})` | silent |

The `pprint` case pins `has_print_call`'s bare-callee behavior — the rule must not regress into substring matching that sweeps in `pprint` and every other callee whose name merely contains "print". The schema calls that out as the trap `has_body_text` falls into, so it's worth a standing test rather than a comment.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (87 files compared)

$ go vet ./internal/rules/
$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules	3.525s
```