### PR TITLE
test(rules): mirror and cover CSDK-020

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -1986,6 +1986,37 @@ def fetch_data(x: str) -> dict:
     return {}
 `,
 		toolConfig: nil, wantFires: false},
+
+	// ─── CSDK-020: TS Claude SDK tool HTTP call without a timeout ───────────
+	// Structural has_http_call_without_timeout, as OAI-016 uses. CSDK-003 is
+	// the Python half; this pack shipped TS rules but no TS timeout rule.
+	{
+		name: "CSDK-020 fires on TS fetch with no AbortSignal", ruleID: "CSDK-020",
+		kind: models.KindClaudeSDKTool, lang: models.LanguageTypeScript, wantFires: true,
+		src: "import { tool } from \"@anthropic-ai/claude-agent-sdk\";\n" +
+			"export const t = tool(\"fetch_report\", \"Fetch a report.\", {}, async () => {\n" +
+			"  const r = await fetch(\"https://reports.internal/x\");\n" +
+			"  return { content: [{ type: \"text\", text: await r.text() }] };\n" +
+			"});\n",
+	},
+	{
+		name: "CSDK-020 silent when AbortSignal present", ruleID: "CSDK-020",
+		kind: models.KindClaudeSDKTool, lang: models.LanguageTypeScript, wantFires: false,
+		src: "import { tool } from \"@anthropic-ai/claude-agent-sdk\";\n" +
+			"export const t = tool(\"fetch_report\", \"Fetch a report.\", {}, async () => {\n" +
+			"  const r = await fetch(\"https://reports.internal/x\", { signal: AbortSignal.timeout(15000) });\n" +
+			"  return { content: [{ type: \"text\", text: await r.text() }] };\n" +
+			"});\n",
+	},
+	{
+		name: "CSDK-020 fires when fetch options omit any timeout", ruleID: "CSDK-020",
+		kind: models.KindClaudeSDKTool, lang: models.LanguageTypeScript, wantFires: true,
+		src: "import { tool } from \"@anthropic-ai/claude-agent-sdk\";\n" +
+			"export const t = tool(\"fetch_report\", \"Fetch a report.\", {}, async () => {\n" +
+			"  const r = await fetch(\"https://reports.internal/x\", { method: \"POST\" });\n" +
+			"  return { content: [{ type: \"text\", text: await r.text() }] };\n" +
+			"});\n",
+	},
 }
 
 // policyRepoRuleCases covers repo-scoped rules.
@@ -2246,7 +2277,6 @@ var policyRepoRuleCases = []policyRepoCase{
 		},
 		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKOpenAIAgents}},
 		false},
-
 }
 
 // optionsWithPermissionMode builds a ClaudeAgentOptionsDef whose captured

--- a/testdata/rules-fixture/claude_sdk/network.yaml
+++ b/testdata/rules-fixture/claude_sdk/network.yaml
@@ -53,3 +53,34 @@ rules:
     fix: >
       Pass `timeout=` (typically 5–30s) to the request. Surface failures as a
       structured error the model can react to.
+
+  - id: CSDK-020
+    title: TypeScript Claude SDK tool HTTP call has no timeout
+    severity: high
+    confidence: 0.6
+    language: typescript
+    applies_to:
+      - claude_sdk_tool
+    scope: tool
+    match:
+      has_http_call_without_timeout: true
+    explanation: >
+      This TypeScript Claude SDK tool makes an outbound HTTP call (fetch /
+      axios / got / undici) with no deadline — no signal, timeout, or
+      abortSignal option. Node's fetch has no implicit deadline, so a slow or
+      unresponsive host blocks the tool callback until the socket eventually
+      dies. Because the call sits inside the agent's turn, that stalls the
+      conversation rather than failing it: the model gets no result and no
+      error, the turn cannot advance, and a max_turns cap does not help because
+      the run is stuck inside a single turn rather than taking too many. In a
+      server embedding the SDK it also holds the request worker for the
+      duration. The exposure compounds with CSDK-013: a tool that fetches a
+      model-controlled URL and cannot time out can be pointed at an internal
+      host that simply never answers.
+    fix: >
+      Attach a deadline. On modern runtimes,
+      await fetch(url, { signal: AbortSignal.timeout(15_000) }); on older ones,
+      create an AbortController, abort it from a setTimeout, pass
+      controller.signal, and clear the timer in a finally. axios and got take a
+      timeout option directly. Return the abort as a structured tool error so
+      the model can retry or route around it instead of the turn hanging.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **trustabl/trustabl-rules#84**, on a branch of the **same name**, so the `rules-sync` job resolves the matching pack rather than `main`. Neither half should merge alone — `check-rules-sync.sh` fails if they do.

## What the pair adds

CSDK-003 covers the Python side of network timeouts; the TypeScript half was missing, even though this pack ships TS rules throughout (CSDK-010..014, CSDK-120..131). OpenAI (OAI-016, OAI-024) and Vercel AI (VAI-011) already use `has_http_call_without_timeout` for exactly this.

The consequence framing is what makes it more than a port of VAI-011: **an unresponsive host stalls the conversation rather than failing it.** The model gets no result and no error, so the turn can't advance — and a `max_turns` cap doesn't help, because the run is stuck *inside* one turn rather than taking too many.

## What this PR does

1. Mirrors `claude_sdk/network.yaml` into `testdata/rules-fixture/`.
2. Adds cases to `policyRuleCases`, as `TestPolicyRules_AllRulesCovered` requires.

| case | expectation |
|---|---|
| bare `await fetch(url)` | fires |
| `{ signal: AbortSignal.timeout(15000) }` | silent |
| `{ method: "POST" }` — options present, no deadline | fires |

Three cases, following OAI-016's own table. The third is the one worth having: it pins that the predicate checks for a **deadline**, not merely for an options argument — the plausible regression is treating any second argument as "configured".

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (86 files compared)

$ go vet ./internal/rules/
$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules
```