### PR TITLE
test(rules): mirror and cover MCP-024

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -1986,6 +1986,38 @@ def fetch_data(x: str) -> dict:
     return {}
 `,
 		toolConfig: nil, wantFires: false},
+
+	// ─── MCP-024: TS MCP tool HTTP call without a timeout ───────────────────
+	{
+		name: "MCP-024 fires on TS fetch with no AbortSignal", ruleID: "MCP-024",
+		kind: models.KindMCPTool, lang: models.LanguageTypeScript, wantFires: true,
+		src: "import { McpServer } from \"@modelcontextprotocol/sdk/server/mcp.js\";\n" +
+			"const s = new McpServer({ name: \"orders\", version: \"1.0.0\" });\n" +
+			"s.tool(\"fetch_report\", \"Fetch a report.\", {}, async () => {\n" +
+			"  const r = await fetch(\"https://reports.internal/x\");\n" +
+			"  return { content: [{ type: \"text\", text: await r.text() }] };\n" +
+			"});\n",
+	},
+	{
+		name: "MCP-024 silent when AbortSignal present", ruleID: "MCP-024",
+		kind: models.KindMCPTool, lang: models.LanguageTypeScript, wantFires: false,
+		src: "import { McpServer } from \"@modelcontextprotocol/sdk/server/mcp.js\";\n" +
+			"const s = new McpServer({ name: \"orders\", version: \"1.0.0\" });\n" +
+			"s.tool(\"fetch_report\", \"Fetch a report.\", {}, async () => {\n" +
+			"  const r = await fetch(\"https://reports.internal/x\", { signal: AbortSignal.timeout(15000) });\n" +
+			"  return { content: [{ type: \"text\", text: await r.text() }] };\n" +
+			"});\n",
+	},
+	{
+		name: "MCP-024 fires when fetch options omit any timeout", ruleID: "MCP-024",
+		kind: models.KindMCPTool, lang: models.LanguageTypeScript, wantFires: true,
+		src: "import { McpServer } from \"@modelcontextprotocol/sdk/server/mcp.js\";\n" +
+			"const s = new McpServer({ name: \"orders\", version: \"1.0.0\" });\n" +
+			"s.tool(\"fetch_report\", \"Fetch a report.\", {}, async () => {\n" +
+			"  const r = await fetch(\"https://reports.internal/x\", { method: \"POST\" });\n" +
+			"  return { content: [{ type: \"text\", text: await r.text() }] };\n" +
+			"});\n",
+	},
 }
 
 // policyRepoRuleCases covers repo-scoped rules.
@@ -2246,7 +2278,6 @@ var policyRepoRuleCases = []policyRepoCase{
 		},
 		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKOpenAIAgents}},
 		false},
-
 }
 
 // optionsWithPermissionMode builds a ClaudeAgentOptionsDef whose captured

--- a/testdata/rules-fixture/mcp/network.yaml
+++ b/testdata/rules-fixture/mcp/network.yaml
@@ -51,3 +51,36 @@ rules:
       Pass timeout= (typically 5-30 seconds depending on the endpoint) to every
       outbound call. Return the timeout to the client as a structured tool error
       rather than letting the handler block.
+
+  - id: MCP-024
+    title: TypeScript MCP tool HTTP call has no timeout
+    severity: high
+    confidence: 0.6
+    language: typescript
+    applies_to:
+      - mcp_tool
+    scope: tool
+    match:
+      has_http_call_without_timeout: true
+    explanation: >
+      This TypeScript MCP tool handler makes an outbound HTTP call (fetch /
+      axios / got / undici) with no deadline — no signal, timeout, or
+      abortSignal option. Node's fetch has no implicit deadline, so a slow or
+      unresponsive upstream blocks the handler until the socket eventually
+      dies. The stall crosses the server's trust boundary rather than staying
+      local: the connecting client is waiting on a JSON-RPC response that never
+      arrives, and because MCP gives it no way to cancel an in-flight tool call,
+      the client is left to its own timeout, an abandoned request, or a hung
+      session. Nothing in the response says why. On a stdio server the effect is
+      worse than one slow tool, since a single process serves the connection and
+      a handler parked on a dead socket is holding it. The exposure compounds
+      with MCP-013: a handler that fetches a caller-controlled URL and cannot
+      time out can be steered at an internal host that never answers.
+    fix: >
+      Attach a deadline. On modern runtimes,
+      await fetch(url, { signal: AbortSignal.timeout(15_000) }); on older ones,
+      create an AbortController, abort it from a setTimeout, pass
+      controller.signal, and clear the timer in a finally. axios and got take a
+      timeout option directly. Return the abort as a structured tool result the
+      model can act on, so the client learns the upstream was unreachable rather
+      than waiting on a response that is not coming.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **trustabl/trustabl-rules#85**, on a branch of the **same name**, so the `rules-sync` job resolves the matching pack rather than `main`. Neither half should merge alone — `check-rules-sync.sh` fails if they do.

## What the pair adds

MCP-004 covers the Python side of network timeouts; the TypeScript half was missing, even though the pack ships TS rules (MCP-011, MCP-013).

**What makes the MCP case its own is that the stall crosses the server's trust boundary.** The connecting client waits on a JSON-RPC response that never arrives, and MCP gives it no way to cancel an in-flight tool call — so it's left to its own timeout, an abandoned request, or a hung session, with nothing saying why. The server author never sees the symptom; the client's users do. On a stdio server a handler parked on a dead socket is also holding the single process that serves the connection.

## What this PR does

1. Mirrors `mcp/network.yaml` into `testdata/rules-fixture/`.
2. Adds cases to `policyRuleCases`, as `TestPolicyRules_AllRulesCovered` requires.

| case | expectation |
|---|---|
| bare `await fetch(url)` | fires |
| `{ signal: AbortSignal.timeout(15000) }` | silent |
| `{ method: "POST" }` — options present, no deadline | fires |

Three cases, following OAI-016's own table. The third pins that the predicate checks for a **deadline**, not merely for an options argument.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (86 files compared)

$ go vet ./internal/rules/
$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules
```