### PR TITLE
test(rules): mirror and cover ADK-114

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -1986,6 +1986,37 @@ def fetch_data(x: str) -> dict:
     return {}
 `,
 		toolConfig: nil, wantFires: false},
+
+	// ─── ADK-114: TS ADK FunctionTool HTTP call without a timeout ───────────
+	// adk-js uses the options-object form (new FunctionTool({ ..., execute })),
+	// not the Python FunctionTool(fn) wrapper shape.
+	{
+		name: "ADK-114 fires on TS fetch with no AbortSignal", ruleID: "ADK-114",
+		kind: models.KindADKFunctionTool, lang: models.LanguageTypeScript, wantFires: true,
+		src: "import { FunctionTool } from \"@google/adk\";\n" +
+			"const t = new FunctionTool({ name: \"fetch_report\", description: \"Fetch a report.\", parameters: {}, execute: async () => {\n" +
+			"  const r = await fetch(\"https://reports.internal/x\");\n" +
+			"  return await r.text();\n" +
+			"} });\n",
+	},
+	{
+		name: "ADK-114 silent when AbortSignal present", ruleID: "ADK-114",
+		kind: models.KindADKFunctionTool, lang: models.LanguageTypeScript, wantFires: false,
+		src: "import { FunctionTool } from \"@google/adk\";\n" +
+			"const t = new FunctionTool({ name: \"fetch_report\", description: \"Fetch a report.\", parameters: {}, execute: async () => {\n" +
+			"  const r = await fetch(\"https://reports.internal/x\", { signal: AbortSignal.timeout(15000) });\n" +
+			"  return await r.text();\n" +
+			"} });\n",
+	},
+	{
+		name: "ADK-114 fires when fetch options omit any timeout", ruleID: "ADK-114",
+		kind: models.KindADKFunctionTool, lang: models.LanguageTypeScript, wantFires: true,
+		src: "import { FunctionTool } from \"@google/adk\";\n" +
+			"const t = new FunctionTool({ name: \"fetch_report\", description: \"Fetch a report.\", parameters: {}, execute: async () => {\n" +
+			"  const r = await fetch(\"https://reports.internal/x\", { method: \"POST\" });\n" +
+			"  return await r.text();\n" +
+			"} });\n",
+	},
 }
 
 // policyRepoRuleCases covers repo-scoped rules.
@@ -2246,7 +2277,6 @@ var policyRepoRuleCases = []policyRepoCase{
 		},
 		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKOpenAIAgents}},
 		false},
-
 }
 
 // optionsWithPermissionMode builds a ClaudeAgentOptionsDef whose captured

--- a/testdata/rules-fixture/google_adk/network.yaml
+++ b/testdata/rules-fixture/google_adk/network.yaml
@@ -51,3 +51,37 @@ rules:
       Pass `timeout=` (typically 5–30 seconds) to the request. Choose a
       value that's tight enough to fail fast and loose enough to allow
       legitimate slow responses for this endpoint.
+
+  - id: ADK-114
+    title: TypeScript FunctionTool HTTP call has no timeout
+    severity: high
+    confidence: 0.6
+    language: typescript
+    applies_to:
+      - adk_function_tool
+    scope: tool
+    match:
+      has_http_call_without_timeout: true
+    explanation: >
+      This TypeScript ADK FunctionTool makes an outbound HTTP call (fetch /
+      axios / got / undici) with no deadline — no signal, timeout, or
+      abortSignal option. Node's fetch has no implicit deadline, so a slow or
+      unresponsive host blocks the tool callback until the socket eventually
+      dies. What that costs depends on where the tool sits in the agent tree,
+      and the composition ADK encourages makes it worse rather than better: a
+      stalled tool inside a SequentialAgent blocks every step after it, and
+      inside a ParallelAgent the whole fan-out waits on its slowest branch, so
+      one unresponsive host stalls work that has nothing to do with it.
+      ADK-108's max_iterations bounds how many times a LoopAgent goes round, not
+      how long one tool call may run, so no configured limit breaks the stall.
+      The exposure compounds with ADK-016: a tool that fetches a
+      caller-controlled URL and cannot time out can be steered at an internal
+      host that never answers.
+    fix: >
+      Attach a deadline. On modern runtimes,
+      await fetch(url, { signal: AbortSignal.timeout(15_000) }); on older ones,
+      create an AbortController, abort it from a setTimeout, pass
+      controller.signal, and clear the timer in a finally. axios and got take a
+      timeout option directly. Return the abort as a structured tool result so
+      the agent can react to an unreachable upstream rather than the branch
+      hanging.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **trustabl/trustabl-rules#86**, on a branch of the **same name**, so the `rules-sync` job resolves the matching pack rather than `main`. Neither half should merge alone — `check-rules-sync.sh` fails if they do.

## What the pair adds

ADK-003 covers the Python side of network timeouts; the TypeScript half was missing, even though the pack ships TS rules (ADK-013, ADK-015, ADK-016, ADK-109).

**The composition ADK encourages makes the stall worse rather than better:** inside a `SequentialAgent` a stalled tool blocks every step after it, and inside a `ParallelAgent` the fan-out waits on its slowest branch. And the limit people reach for doesn't apply — ADK-108's `max_iterations` bounds how many times a `LoopAgent` goes round, not how long one tool call may run.

## What this PR does

1. Mirrors `google_adk/network.yaml` into `testdata/rules-fixture/`.
2. Adds cases to `policyRuleCases`, as `TestPolicyRules_AllRulesCovered` requires.

| case | expectation |
|---|---|
| bare `await fetch(url)` | fires |
| `{ signal: AbortSignal.timeout(15000) }` | silent |
| `{ method: "POST" }` — options present, no deadline | fires |

Three cases, following OAI-016's own table; the third pins that the predicate checks for a **deadline**, not merely for an options argument.

**One note on fixture shape.** The snippets use adk-js's options-object form (`new FunctionTool({ ..., execute })`). My first draft used the Python-style `new FunctionTool(fn, {...})` wrapper and *nothing* fired — including the pre-existing TS rules. Worth flagging because the Python `FunctionTool(fn)` shape reads as the obvious analogue and isn't what the TS SDK does.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (86 files compared)

$ go vet ./internal/rules/
$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules
```