### PR TITLE
fix(cli): llm help still described enrichment as a future path

### DIFF
--- a/cmd/trustabl/llm.go
+++ b/cmd/trustabl/llm.go
@@ -18,12 +18,12 @@ func newLLMCommand() *cobra.Command {
 		Use:   "llm",
 		Short: "Manage LLM provider configuration",
 		Long: `Manage the optional LLM provider configuration (provider, model, and API key)
-used for bring-your-own-key enrichment. Configuration is stored in your user
-config directory with 0600 permissions.
+used by "trustabl enrich" for bring-your-own-key enrichment. Configuration is
+stored in your user config directory with 0600 permissions.
 
-NOTE: LLM enrichment is not wired into the scan yet. These commands only store
-the provider, model, and key for that future path — no scan makes an LLM call
-today, with or without a key configured.`,
+"trustabl scan" never calls an LLM. Enrichment is a separate post-scan command
+that uses this stored provider, or ANTHROPIC_API_KEY / OPENAI_API_KEY /
+GOOGLE_API_KEY from the environment.`,
 		Example: `  # One-time setup
   trustabl llm provider set anthropic
   trustabl llm key set

--- a/cmd/trustabl/llm_test.go
+++ b/cmd/trustabl/llm_test.go
@@ -462,3 +462,16 @@ func TestLLMProviderList_WithConfig(t *testing.T) {
 		t.Errorf("providers not sorted: anthropic at %d, openai at %d", anthPos, openaiPos)
 	}
 }
+
+func TestLLMCommand_HelpDescribesEnrichment(t *testing.T) {
+	cmd := newLLMCommand()
+	if strings.Contains(cmd.Long, "future path") || strings.Contains(cmd.Long, "not wired") {
+		t.Errorf("llm help still describes enrichment as unwired:\n%s", cmd.Long)
+	}
+	if !strings.Contains(cmd.Long, "trustabl enrich") {
+		t.Errorf("llm help must mention trustabl enrich:\n%s", cmd.Long)
+	}
+	if !strings.Contains(cmd.Long, "trustabl scan") {
+		t.Errorf("llm help must still say scan itself does not call an LLM:\n%s", cmd.Long)
+	}
+}


### PR DESCRIPTION
## Summary
- `trustabl llm --help` still said keys were only stored for a **future path** and that enrichment was not wired.
- `trustabl enrich` already uses that BYOK config. Scan still never calls an LLM — the help now says that without pretending enrich does not exist.

Independent of the root-help PR. No rule IDs.

## Test plan
- [x] `go test ./cmd/trustabl/ -run TestLLMCommand_HelpDescribesEnrichment`
- [ ] `trustabl llm --help` mentions `trustabl enrich` and does not say "future path"


Made with [Cursor](https://cursor.com)