### PR TITLE
test(rules): mirror and cover OAI-025, OAI-026

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -1986,6 +1986,30 @@ def fetch_data(x: str) -> dict:
     return {}
 `,
 		toolConfig: nil, wantFires: false},
+	{name: "OAI-025 fires on placeholder description", ruleID: "OAI-025", kind: models.KindOpenAITool, src: `
+def lookup_order(order_id: str) -> str:
+    """TODO: describe this tool."""
+    return order_id
+`, wantFires: true},
+	{name: "OAI-025 silent on a real description", ruleID: "OAI-025", kind: models.KindOpenAITool, src: `
+def lookup_order(order_id: str) -> str:
+    """Look up a single order by its identifier and return its current status."""
+    return order_id
+`, wantFires: false},
+	{name: "OAI-026 fires on a too-short description", ruleID: "OAI-026", kind: models.KindOpenAITool, src: `
+def list_orders(customer_id: str) -> str:
+    """Gets data."""
+    return customer_id
+`, wantFires: true},
+	{name: "OAI-026 silent on a full description", ruleID: "OAI-026", kind: models.KindOpenAITool, src: `
+def list_orders(customer_id: str) -> str:
+    """List every order belonging to one customer, most recent first."""
+    return customer_id
+`, wantFires: false},
+	{name: "OAI-026 silent when the docstring is absent (OAI-001's case)", ruleID: "OAI-026", kind: models.KindOpenAITool, src: `
+def list_orders(customer_id: str) -> str:
+    return customer_id
+`, wantFires: false},
 }
 
 // policyRepoRuleCases covers repo-scoped rules.
@@ -2246,7 +2270,6 @@ var policyRepoRuleCases = []policyRepoCase{
 		},
 		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKOpenAIAgents}},
 		false},
-
 }
 
 // optionsWithPermissionMode builds a ClaudeAgentOptionsDef whose captured

--- a/testdata/rules-fixture/openai_sdk/tool_definition.yaml
+++ b/testdata/rules-fixture/openai_sdk/tool_definition.yaml
@@ -95,3 +95,65 @@ rules:
       Provide a concise `description` string in the `tool({...})` options stating
       what the tool does and when the model should call it. The description is the
       model's primary routing signal alongside the tool name.
+
+  - id: OAI-025
+    title: Tool description is a placeholder
+    severity: low
+    confidence: 0.85
+    language: python
+    applies_to:
+      - openai_tool
+    scope: tool
+    match:
+      has_description_text:
+        - todo
+        - tbd
+        - fixme
+        - placeholder
+        - no description
+        - does stuff
+    explanation: >
+      The docstring passes the OAI-001 has-a-description check but carries a
+      placeholder marker instead of real content. The Agents SDK forwards this
+      text to the model verbatim as the tool's selection signal, so a stub like
+      "TODO: describe this tool" is functionally indistinguishable from no
+      description at all and the model still has to guess from the function
+      name. Strict schemas do not compensate: OAI-003's strict_mode constrains
+      the shape of the arguments, never whether calling this tool was the right
+      move, so a placeholder description produces a well-formed call to the
+      wrong tool. Mis-selection also spends a turn against the OAI-112 max_turns
+      budget, and nothing in a trace attributes the wasted turn to the
+      description that caused it.
+    fix: >
+      Replace the placeholder with a real description covering what the tool
+      does, what it returns, and when the model should call it rather than a
+      neighboring tool. Where the function name cannot carry that, pass an
+      explicit description_override to @function_tool instead of relying on the
+      docstring.
+
+  - id: OAI-026
+    title: Tool description is too short to guide model selection
+    severity: low
+    confidence: 0.8
+    language: python
+    applies_to:
+      - openai_tool
+    scope: tool
+    match:
+      all:
+        - has_docstring: true
+        - description_length_lt: 40
+    explanation: >
+      A description under 40 characters is rarely enough to convey what a tool
+      does, what it returns, and when to call it rather than a similarly named
+      neighbor. The Agents SDK passes this text to the model as its only
+      selection signal, so a stub like "Gets data." leaves scope and
+      preconditions to guesswork. The cost lands where it is hardest to see: an
+      agent with handoffs picks between its own tools and its peers' on the
+      strength of these strings, so a thin description does not just cause a
+      wrong call, it can route the whole conversation to the wrong agent.
+    fix: >
+      Expand the description to at least a full sentence covering inputs,
+      outputs, and the situation in which this tool should be used over the
+      alternatives. Where two tools are easy to confuse, say in each which one
+      the other case belongs to.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **trustabl/trustabl-rules#87**, on a branch of the **same name**, so the `rules-sync` job resolves the matching pack rather than `main`. Neither half should merge alone — `check-rules-sync.sh` fails if they do.

## What the pair adds

Ports the CSDK-017/018 description-quality pair to the OpenAI Agents SDK. OAI-001 only checks that a docstring *exists*, so `"""TODO: describe this tool."""` and `"""Gets data."""` pass today. Two OpenAI-specific points, both aimed at mitigations people assume already cover this:

- **Strict schemas don't compensate.** OAI-003's `strict_mode` constrains the shape of the arguments, never whether calling this tool was the right move — a placeholder description yields a well-formed call to the wrong tool.
- **With handoffs, the blast radius is the whole conversation.** An agent picks between its own tools and its peers' from these strings, so it can route to the wrong *agent*, not just the wrong function.

## What this PR does

1. Mirrors `openai_sdk/tool_definition.yaml` into `testdata/rules-fixture/`.
2. Adds cases to `policyRuleCases`, as `TestPolicyRules_AllRulesCovered` requires.

| case | expectation |
|---|---|
| OAI-025 — `"""TODO: describe this tool."""` | fires |
| OAI-025 — real description | silent |
| OAI-026 — `"""Gets data."""` | fires |
| OAI-026 — full sentence | silent |
| OAI-026 — **no docstring at all** | silent |

**Five cases rather than four.** OAI-026 pairs `description_length_lt: 40` with `has_docstring: true` so an absent docstring stays OAI-001's finding rather than double-reporting — an empty description is length 0, which is also under the threshold. The fifth case pins that guard.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (86 files compared)

$ go vet ./internal/rules/
$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules
```