### PR TITLE
test(rules): mirror and cover ADK-115, ADK-116

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -1986,6 +1986,30 @@ def fetch_data(x: str) -> dict:
     return {}
 `,
 		toolConfig: nil, wantFires: false},
+	{name: "ADK-115 fires on placeholder description", ruleID: "ADK-115", kind: models.KindADKFunctionTool, src: `
+def lookup_order(order_id: str) -> str:
+    """TODO: describe this tool."""
+    return order_id
+`, wantFires: true},
+	{name: "ADK-115 silent on a real description", ruleID: "ADK-115", kind: models.KindADKFunctionTool, src: `
+def lookup_order(order_id: str) -> str:
+    """Look up a single order by its identifier and return its current status."""
+    return order_id
+`, wantFires: false},
+	{name: "ADK-116 fires on a too-short description", ruleID: "ADK-116", kind: models.KindADKFunctionTool, src: `
+def list_orders(customer_id: str) -> str:
+    """Gets data."""
+    return customer_id
+`, wantFires: true},
+	{name: "ADK-116 silent on a full description", ruleID: "ADK-116", kind: models.KindADKFunctionTool, src: `
+def list_orders(customer_id: str) -> str:
+    """List every order belonging to one customer, most recent first."""
+    return customer_id
+`, wantFires: false},
+	{name: "ADK-116 silent when the docstring is absent (ADK-001's case)", ruleID: "ADK-116", kind: models.KindADKFunctionTool, src: `
+def list_orders(customer_id: str) -> str:
+    return customer_id
+`, wantFires: false},
 }
 
 // policyRepoRuleCases covers repo-scoped rules.
@@ -2246,7 +2270,6 @@ var policyRepoRuleCases = []policyRepoCase{
 		},
 		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKOpenAIAgents}},
 		false},
-
 }
 
 // optionsWithPermissionMode builds a ClaudeAgentOptionsDef whose captured

--- a/testdata/rules-fixture/google_adk/tool_definition.yaml
+++ b/testdata/rules-fixture/google_adk/tool_definition.yaml
@@ -127,3 +127,67 @@ rules:
       Pass a one-sentence `description` in the `new FunctionTool({...})` options
       that names what the tool does, the inputs it expects, and what it returns.
       Write it for the model, not for a human reader.
+
+  - id: ADK-115
+    title: FunctionTool description is a placeholder
+    severity: low
+    confidence: 0.85
+    language: python
+    applies_to:
+      - adk_function_tool
+    scope: tool
+    match:
+      has_description_text:
+        - todo
+        - tbd
+        - fixme
+        - placeholder
+        - no description
+        - does stuff
+    explanation: >
+      The docstring passes the ADK-001 has-a-docstring check but carries a
+      placeholder marker instead of real content. The ADK builds the tool
+      declaration it sends to the model from this docstring, so a stub like
+      "TODO: describe this tool" is functionally indistinguishable from no
+      docstring at all and the model still has to guess from the function name.
+      The ADK also parses the docstring for the per-parameter descriptions that
+      accompany the generated schema, so a placeholder body strips the
+      argument-level guidance at the same time as the tool-level guidance. In an
+      agent tree the mis-selection does not stay local: a tool picked wrongly
+      inside one branch produces output the following agents treat as
+      established fact, so the error is laundered into the shared session state
+      rather than surfacing where it began.
+    fix: >
+      Replace the placeholder with a real description covering what the tool
+      does, what it returns, and when the model should call it rather than a
+      neighboring tool, and document each parameter so the ADK can carry those
+      descriptions into the generated declaration.
+
+  - id: ADK-116
+    title: FunctionTool description is too short to guide model selection
+    severity: low
+    confidence: 0.8
+    language: python
+    applies_to:
+      - adk_function_tool
+    scope: tool
+    match:
+      all:
+        - has_docstring: true
+        - description_length_lt: 40
+    explanation: >
+      A docstring under 40 characters is rarely enough to convey what a tool
+      does, what it returns, and when to call it rather than a similarly named
+      neighbor. The ADK passes it to the model as the tool's only selection
+      signal, so a stub like "Gets data." leaves scope and preconditions to
+      guesswork. A docstring this short also has no room for the per-parameter
+      descriptions the ADK reads into the tool declaration, so the arguments
+      reach the model undescribed as well. ADK-102 and ADK-107's
+      before_tool_callback gate can block a call it recognizes as wrong, but it
+      cannot supply the judgment the description was meant to provide, so a thin
+      description is not something a callback compensates for.
+    fix: >
+      Expand the docstring to at least a full sentence covering inputs, outputs,
+      and the situation in which this tool should be used over the alternatives,
+      and document each parameter so those descriptions reach the model with the
+      generated schema.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **trustabl/trustabl-rules#89**, on a branch of the **same name**, so the `rules-sync` job resolves the matching pack rather than `main`. Neither half should merge alone — `check-rules-sync.sh` fails if they do.

## What the pair adds

Ports the CSDK-017/018 description-quality pair to the Google ADK. ADK-001 only checks that a docstring *exists*, so `"""TODO: describe this tool."""` and `"""Gets data."""` pass today. Two ADK-specific points:

- **The docstring does double duty** — the ADK parses it for the per-parameter descriptions accompanying the generated schema, so a placeholder strips argument-level guidance too.
- **In an agent tree, mis-selection doesn't stay local** — a tool picked wrongly in one branch produces output the following agents treat as established fact.

ADK-116 also names the mitigation that isn't one: **ADK-102/107's `before_tool_callback` can block a call it recognizes as wrong, but can't supply the judgment the description was meant to provide.**

## What this PR does

1. Mirrors `google_adk/tool_definition.yaml` into `testdata/rules-fixture/`.
2. Adds cases to `policyRuleCases`, as `TestPolicyRules_AllRulesCovered` requires.

| case | expectation |
|---|---|
| ADK-115 — `"""TODO: describe this tool."""` | fires |
| ADK-115 — real description | silent |
| ADK-116 — `"""Gets data."""` | fires |
| ADK-116 — full sentence | silent |
| ADK-116 — **no docstring at all** | silent |

**Five cases rather than four.** ADK-116 pairs `description_length_lt: 40` with `has_docstring: true` so an absent docstring stays ADK-001's finding rather than double-reporting. The fifth case pins that guard.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (86 files compared)

$ go vet ./internal/rules/
$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules
```