### PR TITLE
test(rules): mirror and cover LC-021, LC-022

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -1986,6 +1986,38 @@ def fetch_data(x: str) -> dict:
     return {}
 `,
 		toolConfig: nil, wantFires: false},
+
+	// ─── LC-021 / LC-022: TS LangChain description quality ──────────────────
+	{
+		name: "LC-021 fires on placeholder description", ruleID: "LC-021",
+		kind: models.KindLangChainTool, lang: models.LanguageTypeScript, wantFires: true,
+		src: "import { tool } from \"@langchain/core/tools\";\n" +
+			"export const t = tool(async () => \"x\", { name: \"lookup_order\", description: \"TODO: describe this tool.\", schema: {} });\n",
+	},
+	{
+		name: "LC-021 silent on a real description", ruleID: "LC-021",
+		kind: models.KindLangChainTool, lang: models.LanguageTypeScript, wantFires: false,
+		src: "import { tool } from \"@langchain/core/tools\";\n" +
+			"export const t = tool(async () => \"x\", { name: \"lookup_order\", description: \"Look up one order by its number and return its fulfillment status.\", schema: {} });\n",
+	},
+	{
+		name: "LC-022 fires on a too-short description", ruleID: "LC-022",
+		kind: models.KindLangChainTool, lang: models.LanguageTypeScript, wantFires: true,
+		src: "import { tool } from \"@langchain/core/tools\";\n" +
+			"export const t = tool(async () => \"x\", { name: \"list_orders\", description: \"Gets data.\", schema: {} });\n",
+	},
+	{
+		name: "LC-022 silent on a full description", ruleID: "LC-022",
+		kind: models.KindLangChainTool, lang: models.LanguageTypeScript, wantFires: false,
+		src: "import { tool } from \"@langchain/core/tools\";\n" +
+			"export const t = tool(async () => \"x\", { name: \"list_orders\", description: \"List every order belonging to one customer, most recent first.\", schema: {} });\n",
+	},
+	{
+		name: "LC-022 silent when the description is absent (LC-010's case)", ruleID: "LC-022",
+		kind: models.KindLangChainTool, lang: models.LanguageTypeScript, wantFires: false,
+		src: "import { tool } from \"@langchain/core/tools\";\n" +
+			"export const t = tool(async () => \"x\", { name: \"list_orders\", schema: {} });\n",
+	},
 }
 
 // policyRepoRuleCases covers repo-scoped rules.
@@ -2246,7 +2278,6 @@ var policyRepoRuleCases = []policyRepoCase{
 		},
 		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKOpenAIAgents}},
 		false},
-
 }
 
 // optionsWithPermissionMode builds a ClaudeAgentOptionsDef whose captured

--- a/testdata/rules-fixture/langchain/tool_definition.yaml
+++ b/testdata/rules-fixture/langchain/tool_definition.yaml
@@ -77,3 +77,63 @@ rules:
       Pass a one-sentence description in the tool() config (or the
       DynamicStructuredTool options) naming what the tool does, the inputs it
       expects, and what it returns. Write it for the model, not a human reader.
+
+  - id: LC-021
+    title: TypeScript LangChain tool description is a placeholder
+    severity: low
+    confidence: 0.85
+    language: typescript
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      has_description_text:
+        - todo
+        - tbd
+        - fixme
+        - placeholder
+        - no description
+        - does stuff
+    explanation: >
+      The tool sets a description, so it passes LC-010, but the string is a
+      placeholder rather than real content. LangChain.js has no docstring to
+      fall back on — the description field is the entire account of the tool the
+      model sees — so "TODO: describe this tool" leaves the model guessing from
+      the tool name. The Zod schema does not compensate: it constrains the shape
+      of the arguments once the model has chosen this tool, never whether
+      choosing it was right. Mis-selection scales badly here because a
+      LangChain agent is routinely handed a dozen or more tools at once, and
+      each wrong pick consumes an iteration against the executor's maxIterations
+      budget, so a run can exhaust its steps and return nothing useful.
+    fix: >
+      Replace the placeholder with a real description covering what the tool
+      does, what it returns, and when the model should call it rather than a
+      neighboring tool. The string is passed to the model verbatim, so write it
+      for the model rather than a human maintainer.
+
+  - id: LC-022
+    title: TypeScript LangChain tool description is too short to guide model selection
+    severity: low
+    confidence: 0.8
+    language: typescript
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      all:
+        - has_docstring: true
+        - description_length_lt: 40
+    explanation: >
+      A description under 40 characters is rarely enough to convey what a tool
+      does, what it returns, and when to call it rather than a similarly named
+      neighbor. With no docstring fallback in LangChain.js, a stub like "Gets
+      data." is the whole prompt-side account of the tool, so scope and
+      preconditions are left to guesswork. The cost compounds in the executor
+      loop: each mis-selected call spends an iteration against the
+      maxIterations bound LC-111 checks for, so a thin description can burn the
+      run's step budget rather than the run producing an answer.
+    fix: >
+      Expand the description to at least a full sentence covering inputs,
+      outputs, and the situation in which this tool should be used over the
+      alternatives. Where two tools are easy to confuse, say in each which one
+      the other case belongs to.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **trustabl/trustabl-rules#93**, on a branch of the **same name**, so the `rules-sync` job resolves the matching pack rather than `main`. Neither half should merge alone — `check-rules-sync.sh` fails if they do.

## What the pair adds

The TypeScript counterpart to LC-018/019. LC-010 only checks that a description *exists*, so `"TODO: describe this tool."` and `"Gets data."` pass today. Three points, in the order they bite:

- **No docstring fallback** in LangChain.js — the `description` field is the entire account of the tool the model sees.
- **The Zod schema doesn't compensate** — it constrains the arguments once the model has chosen this tool, not whether choosing it was right.
- **Mis-selection scales badly and costs the run** — agents are routinely handed a dozen or more tools at once, and each wrong pick spends an iteration against the `maxIterations` bound LC-111 checks for.

## What this PR does

1. Mirrors `langchain/tool_definition.yaml` into `testdata/rules-fixture/`.
2. Adds cases to `policyRuleCases`, as `TestPolicyRules_AllRulesCovered` requires.

| case | expectation |
|---|---|
| LC-021 — `"TODO: describe this tool."` | fires |
| LC-021 — real description | silent |
| LC-022 — `"Gets data."` | fires |
| LC-022 — full sentence | silent |
| LC-022 — **no `description` field at all** | silent |

**Five cases rather than four.** LC-022 pairs `description_length_lt: 40` with `has_docstring: true` so an absent description stays LC-010's finding rather than double-reporting. The fifth case pins that guard.

**Sequencing note:** rules#66 / this repo's #145 (the LC-018/019 Python pair) append to the same two files, so whichever pair lands second needs a trivial rebase in both repos — resolution is "keep both." Happy to rebase on request.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (86 files compared)

$ go vet ./internal/rules/
$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules
```