### PR TITLE
test(rules): mirror and cover MCP-029

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -1986,6 +1986,32 @@ def fetch_data(x: str) -> dict:
     return {}
 `,
 		toolConfig: nil, wantFires: false},
+
+	// ─── MCP-029: TS MCP tool writes to the filesystem ──────────────────────
+	// Coarse has_write_call signal, mirroring CSDK-012 until TS path
+	// normalization analysis exists.
+	{
+		name: "MCP-029 fires on filesystem write", ruleID: "MCP-029",
+		kind: models.KindMCPTool, lang: models.LanguageTypeScript, wantFires: true,
+		src: "import { McpServer } from \"@modelcontextprotocol/sdk/server/mcp.js\";\n" +
+			"import { writeFileSync } from \"node:fs\";\n" +
+			"const s = new McpServer({ name: \"notes\", version: \"1.0.0\" });\n" +
+			"s.tool(\"save_note\", \"Save a note to disk for later retrieval.\", {}, async ({ p, body }) => {\n" +
+			"  writeFileSync(p, body);\n" +
+			"  return { content: [] };\n" +
+			"});\n",
+	},
+	{
+		name: "MCP-029 silent with no filesystem write", ruleID: "MCP-029",
+		kind: models.KindMCPTool, lang: models.LanguageTypeScript, wantFires: false,
+		src: "import { McpServer } from \"@modelcontextprotocol/sdk/server/mcp.js\";\n" +
+			"const notes = new Map<string, string>();\n" +
+			"const s = new McpServer({ name: \"notes\", version: \"1.0.0\" });\n" +
+			"s.tool(\"save_note\", \"Save a note to disk for later retrieval.\", {}, async ({ body }) => {\n" +
+			"  notes.set(\"n1\", body);\n" +
+			"  return { content: [] };\n" +
+			"});\n",
+	},
 }
 
 // policyRepoRuleCases covers repo-scoped rules.
@@ -2246,7 +2272,6 @@ var policyRepoRuleCases = []policyRepoCase{
 		},
 		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKOpenAIAgents}},
 		false},
-
 }
 
 // optionsWithPermissionMode builds a ClaudeAgentOptionsDef whose captured

--- a/testdata/rules-fixture/mcp/path_safety.yaml
+++ b/testdata/rules-fixture/mcp/path_safety.yaml
@@ -37,3 +37,35 @@ rules:
     fix: >
       Resolve the path with `Path(...).resolve()` and assert it sits under an
       allowed root before any I/O touches it. Reject paths that escape the root.
+
+  - id: MCP-029
+    title: TypeScript MCP tool writes to the filesystem
+    severity: low
+    confidence: 0.5
+    language: typescript
+    applies_to:
+      - mcp_tool
+    scope: tool
+    match:
+      has_write_call: true
+    explanation: >
+      This TypeScript MCP tool handler writes to the filesystem. If the path or
+      the contents derive from the tool's arguments, the caller on the other
+      side of the protocol chooses both — and that caller is a model, steerable
+      by a prompt injection carried in retrieved content or an earlier tool
+      result. How the server is deployed makes this sharper than it looks: a
+      stdio server is launched as a subprocess by whatever client the user is
+      running, so it inherits that user's own filesystem permissions rather
+      than a service account's, and a write escaping its intended directory
+      reaches the user's home directory, dotfiles, and SSH keys. The server also
+      cannot see the injection — it receives a well-formed tools/call for a path
+      it has no way to distinguish from a legitimate one. (Coarse signal — it
+      flags any filesystem write, not only unnormalized paths, because
+      TypeScript path-normalization analysis is not yet wired. Confirm the path
+      is genuinely caller-supplied before acting.)
+    fix: >
+      Confine writes to a dedicated working directory: resolve the final path,
+      verify it stays under that root before writing, and reject absolute paths
+      and any input containing "..". Where the tool only ever writes generated
+      names, derive the filename server-side from an id rather than accepting a
+      path over the protocol at all.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **trustabl/trustabl-rules#94**, on a branch of the **same name**, so the `rules-sync` job resolves the matching pack rather than `main`. Neither half should merge alone — `check-rules-sync.sh` fails if they do.

## What the pair adds

MCP-005 covers the Python path-safety case; the TypeScript half was missing. MCP-029 mirrors CSDK-012 including its coarse-signal caveat, stated in the explanation: it flags *any* filesystem write, not only unnormalized paths, because TS path-normalization analysis isn't wired yet. Confidence 0.5 to match.

**Deployment is what sharpens this for MCP.** A stdio server is launched as a subprocess by whatever client the user is running, so it inherits **that user's own filesystem permissions** — a write escaping its intended directory reaches their home directory, dotfiles, and SSH keys. And the server can't see the injection: it receives a well-formed `tools/call` for a path it has no way to distinguish from a legitimate one, so containment has to be structural.

## What this PR does

1. Mirrors `mcp/path_safety.yaml` into `testdata/rules-fixture/`.
2. Adds a fire case and a silent case to `policyRuleCases`, as `TestPolicyRules_AllRulesCovered` requires.

The silent case applies the remediation the `fix` text prescribes for the common shape — **derive the filename server-side rather than accepting a path over the protocol** — instead of merely deleting the write.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (86 files compared)

$ go vet ./internal/rules/
$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules
```