### PR TITLE
test(rules): mirror and cover OAI-029

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -1986,6 +1986,28 @@ def fetch_data(x: str) -> dict:
     return {}
 `,
 		toolConfig: nil, wantFires: false},
+
+	// ─── OAI-029: TS OpenAI Agents tool writes to the filesystem ────────────
+	{
+		name: "OAI-029 fires on filesystem write", ruleID: "OAI-029",
+		kind: models.KindOpenAITool, lang: models.LanguageTypeScript, wantFires: true,
+		src: "import { tool } from \"@openai/agents\";\n" +
+			"import { writeFileSync } from \"node:fs\";\n" +
+			"export const t = tool({ name: \"save_note\", description: \"Save a note to disk for later retrieval.\", parameters: {}, execute: async ({ p, body }) => {\n" +
+			"  writeFileSync(p, body);\n" +
+			"  return \"saved\";\n" +
+			"} });\n",
+	},
+	{
+		name: "OAI-029 silent with no filesystem write", ruleID: "OAI-029",
+		kind: models.KindOpenAITool, lang: models.LanguageTypeScript, wantFires: false,
+		src: "import { tool } from \"@openai/agents\";\n" +
+			"const notes = new Map<string, string>();\n" +
+			"export const t = tool({ name: \"save_note\", description: \"Save a note to disk for later retrieval.\", parameters: {}, execute: async ({ body }) => {\n" +
+			"  notes.set(\"n1\", body);\n" +
+			"  return \"n1\";\n" +
+			"} });\n",
+	},
 }
 
 // policyRepoRuleCases covers repo-scoped rules.
@@ -2246,7 +2268,6 @@ var policyRepoRuleCases = []policyRepoCase{
 		},
 		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKOpenAIAgents}},
 		false},
-
 }
 
 // optionsWithPermissionMode builds a ClaudeAgentOptionsDef whose captured

--- a/testdata/rules-fixture/openai_sdk/path_safety.yaml
+++ b/testdata/rules-fixture/openai_sdk/path_safety.yaml
@@ -29,3 +29,35 @@ rules:
       Normalize the path before use: p = Path(file_path).resolve(). Then
       check that the resolved path is inside an explicit allowed-root
       directory before opening.
+
+  - id: OAI-029
+    title: TypeScript tool writes to the filesystem
+    severity: low
+    confidence: 0.5
+    language: typescript
+    applies_to:
+      - openai_tool
+    scope: tool
+    match:
+      has_write_call: true
+    explanation: >
+      This TypeScript Agents SDK tool writes to the filesystem. If the path or
+      the contents derive from the tool's arguments, the model chooses both, and
+      a prompt injection carried in retrieved content or an earlier tool result
+      can steer the write at any file the host process can reach. The guardrail
+      story does not cover it: OAI-101 is about input guardrails on the agent,
+      which screen what enters the conversation, not what a tool does with an
+      argument once the model has produced it — and a tool call that reaches
+      execute() has already passed whatever guardrails were configured. Tools
+      here also typically run in the same server process as the request handler
+      rather than a sandbox, so the write inherits the application's own
+      filesystem permissions. (Coarse signal — it flags any filesystem write,
+      not only unnormalized paths, because TypeScript path-normalization
+      analysis is not yet wired. Confirm the path is genuinely model-supplied
+      before acting.)
+    fix: >
+      Confine writes to a dedicated working directory: resolve the final path,
+      verify it stays under that root before writing, and reject absolute paths
+      and any input containing "..". Where the tool only ever writes generated
+      names, derive the filename server-side from an id rather than accepting a
+      path from the model at all.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **trustabl/trustabl-rules#95**, on a branch of the **same name**, so the `rules-sync` job resolves the matching pack rather than `main`. Neither half should merge alone — `check-rules-sync.sh` fails if they do.

## What the pair adds

OAI-006 covers the Python path-safety case; the TypeScript half was missing. OAI-029 mirrors CSDK-012 including its coarse-signal caveat, stated in the explanation: it flags *any* filesystem write, not only unnormalized paths, because TS path-normalization analysis isn't wired yet. Confidence 0.5 to match.

**In an SDK built around guardrails, the point worth stating is that the guardrail story doesn't cover this.** OAI-101 concerns *input* guardrails on the agent — they screen what enters the conversation, not what a tool does with an argument once the model has produced it. A call that reaches `execute()` has already passed whatever guardrails were configured, so "we have guardrails" isn't an answer to this finding. The rule says so directly.

## What this PR does

1. Mirrors `openai_sdk/path_safety.yaml` into `testdata/rules-fixture/`.
2. Adds a fire case and a silent case to `policyRuleCases`, as `TestPolicyRules_AllRulesCovered` requires.

The silent case applies the remediation the `fix` text prescribes for the common shape — **derive the filename server-side rather than accepting a path from the model** — instead of merely deleting the write.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (86 files compared)

$ go vet ./internal/rules/
$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules
```