### PR TITLE
test(rules): mirror and cover ADK-117

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -1986,6 +1986,28 @@ def fetch_data(x: str) -> dict:
     return {}
 `,
 		toolConfig: nil, wantFires: false},
+
+	// ─── ADK-117: TS ADK FunctionTool writes to the filesystem ──────────────
+	{
+		name: "ADK-117 fires on filesystem write", ruleID: "ADK-117",
+		kind: models.KindADKFunctionTool, lang: models.LanguageTypeScript, wantFires: true,
+		src: "import { FunctionTool } from \"@google/adk\";\n" +
+			"import { writeFileSync } from \"node:fs\";\n" +
+			"const t = new FunctionTool({ name: \"save_note\", description: \"Save a note to disk for later retrieval.\", parameters: {}, execute: async ({ p, body }) => {\n" +
+			"  writeFileSync(p, body);\n" +
+			"  return \"saved\";\n" +
+			"} });\n",
+	},
+	{
+		name: "ADK-117 silent with no filesystem write", ruleID: "ADK-117",
+		kind: models.KindADKFunctionTool, lang: models.LanguageTypeScript, wantFires: false,
+		src: "import { FunctionTool } from \"@google/adk\";\n" +
+			"const notes = new Map<string, string>();\n" +
+			"const t = new FunctionTool({ name: \"save_note\", description: \"Save a note to disk for later retrieval.\", parameters: {}, execute: async ({ body }) => {\n" +
+			"  notes.set(\"n1\", body);\n" +
+			"  return \"n1\";\n" +
+			"} });\n",
+	},
 }
 
 // policyRepoRuleCases covers repo-scoped rules.
@@ -2246,7 +2268,6 @@ var policyRepoRuleCases = []policyRepoCase{
 		},
 		models.RepoInventory{SDKsDetected: []models.SDK{models.SDKOpenAIAgents}},
 		false},
-
 }
 
 // optionsWithPermissionMode builds a ClaudeAgentOptionsDef whose captured

--- a/testdata/rules-fixture/google_adk/path_safety.yaml
+++ b/testdata/rules-fixture/google_adk/path_safety.yaml
@@ -32,3 +32,36 @@ rules:
     fix: >
       Resolve the path with `Path(...).resolve()` and assert it sits under an
       allowed root before opening.
+
+  - id: ADK-117
+    title: TypeScript FunctionTool writes to the filesystem
+    severity: low
+    confidence: 0.5
+    language: typescript
+    applies_to:
+      - adk_function_tool
+    scope: tool
+    match:
+      has_write_call: true
+    explanation: >
+      This TypeScript ADK FunctionTool writes to the filesystem. If the path or
+      the contents derive from the tool's arguments, the model chooses both, and
+      a prompt injection carried in retrieved content or an earlier tool result
+      can steer the write at any file the host process can reach. The callback
+      gate the ADK offers does not close this by default: ADK-102 and ADK-107
+      are about before_tool_callback being present at all, and a callback that
+      is present still has to inspect the path itself and know which root is
+      allowed — being wired up is not the same as containing anything. Agent
+      composition widens the reach too, since any branch of the tree that lists
+      this tool can reach it, and a write performed in one branch is visible to
+      every agent that reads the shared session state afterward. (Coarse signal
+      — it flags any filesystem write, not only unnormalized paths, because
+      TypeScript path-normalization analysis is not yet wired. Confirm the path
+      is genuinely model-supplied before acting.)
+    fix: >
+      Confine writes to a dedicated working directory: resolve the final path,
+      verify it stays under that root before writing, and reject absolute paths
+      and any input containing "..". Put the check inside the tool rather than
+      relying on a before_tool_callback, so it holds for every agent in the tree
+      that lists the tool. Where the tool only ever writes generated names,
+      derive the filename from an id rather than accepting a path from the model.


### PR DESCRIPTION
> Engine half of a coordinated pair. Rules half: **trustabl/trustabl-rules#96**, on a branch of the **same name**, so the `rules-sync` job resolves the matching pack rather than `main`. Neither half should merge alone — `check-rules-sync.sh` fails if they do.

## What the pair adds

ADK-004 covers the Python path-safety case; the TypeScript half was missing. ADK-117 mirrors CSDK-012 including its coarse-signal caveat, stated in the explanation: it flags *any* filesystem write, not only unnormalized paths, because TS path-normalization analysis isn't wired yet. Confidence 0.5 to match.

**The callback gate doesn't close this, and that's the mitigation an ADK author would reach for.** ADK-102 and ADK-107 check that `before_tool_callback` is *present at all* — a callback that exists still has to inspect the path and know which root is allowed. Being wired up isn't the same as containing anything. That's why the `fix` puts the check **inside the tool**: it then holds for every agent in the tree that lists it, rather than only those whose callback was configured.

## What this PR does

1. Mirrors `google_adk/path_safety.yaml` into `testdata/rules-fixture/`.
2. Adds a fire case and a silent case to `policyRuleCases`, as `TestPolicyRules_AllRulesCovered` requires.

Snippets use adk-js's options-object form (`new FunctionTool({ ..., execute })`) rather than the Python `FunctionTool(fn)` wrapper shape, which doesn't discover in TS — same fixture-shape note as #160.

## Verification

```
$ RULES_REPO=../trustabl-rules scripts/check-rules-sync.sh
rules fixture is in sync with production (86 files compared)

$ go vet ./internal/rules/
$ go test ./internal/rules/
ok  	github.com/trustabl/trustabl/internal/rules
```