### PR TITLE
test(langchain): add LC-103 fixture coverage

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -2505,6 +2505,25 @@ var policyAgentRuleCases = []policyAgentCase{
 			}}},
 		models.RepoInventory{}, false},
 
+	{"LC-103 fires when agent wires RequestsGetTool", "LC-103",
+		models.AgentDef{
+			SDK: models.SDKLangChain, Class: "ReactAgent", Language: models.LanguagePython,
+			HostedToolRefs: []models.HostedToolRef{{Class: "RequestsGetTool"}},
+		},
+		models.RepoInventory{}, true},
+	{"LC-103 fires when an AgentExecutor wires RequestsPostTool", "LC-103",
+		models.AgentDef{
+			SDK: models.SDKLangChain, Class: "AgentExecutor", Language: models.LanguagePython,
+			HostedToolRefs: []models.HostedToolRef{{Class: "RequestsPostTool"}},
+		},
+		models.RepoInventory{}, true},
+	{"LC-103 silent on a benign hosted tool", "LC-103",
+		models.AgentDef{
+			SDK: models.SDKLangChain, Class: "ReactAgent", Language: models.LanguagePython,
+			HostedToolRefs: []models.HostedToolRef{{Class: "TavilySearchResults"}},
+		},
+		models.RepoInventory{}, false},
+
 	// ─── CrewAI agent rules (CREW-*) ────────────────────────────────────────
 	{"CREW-101 fires when allow_code_execution=True", "CREW-101",
 		models.AgentDef{

--- a/testdata/rules-fixture/langchain/agent_safety.yaml
+++ b/testdata/rules-fixture/langchain/agent_safety.yaml
@@ -83,3 +83,44 @@ rules:
       Pass maxIterations to the AgentExecutor options, sized to the task, and set
       handleParsingErrors so a malformed step is surfaced rather than retried
       indefinitely.
+
+  - id: LC-103
+    title: LangChain agent wires a raw HTTP Requests built-in tool
+    severity: medium
+    confidence: 0.75
+    language: python
+    applies_to:
+      - langchain_agent
+      - langchain_agent_executor
+      - langchain_state_graph
+    scope: agent
+    match:
+      agent_uses_hosted_tool_class:
+        - RequestsGetTool
+        - RequestsPostTool
+        - RequestsPutTool
+        - RequestsPatchTool
+        - RequestsDeleteTool
+    explanation: >
+      This agent's tools list includes a langchain_community Requests built-in
+      (RequestsGetTool / RequestsPostTool / RequestsPutTool / RequestsPatchTool /
+      RequestsDeleteTool). These tools issue an outbound HTTP request to a URL the
+      model supplies; only the method is fixed by the class. Because the
+      destination is model-chosen rather than pinned by the tool, a prompt
+      injection in content the agent has already read can steer the request at
+      whatever the agent host can reach — the cloud metadata endpoint
+      (169.254.169.254), a localhost admin port, or an internal service no
+      external caller could address. The write-method variants can mutate those
+      services rather than only read them, and each response body returns into the
+      conversation as untrusted text that may carry a further injection. LangChain
+      gates this family behind allow_dangerous_requests=True precisely because it
+      hands the model an unconstrained fetch.
+    fix: >
+      Prefer a purpose-built tool that pins the base URL and accepts only a path
+      or query from the model over the generic Requests built-in. Where open HTTP
+      is genuinely required, constrain the destination: allow-list the permitted
+      hosts, reject private and link-local ranges, re-validate the destination
+      after every redirect, and route the agent's egress through a proxy that
+      refuses internal addresses. Treat each response body as untrusted input —
+      keep it out of the system prompt and do not let it widen the agent's tool
+      permissions.


### PR DESCRIPTION
## Summary

Adds the engine-side fixture and test coverage for LC-103, which detects LangChain agents that wire `langchain_community`'s `Requests*` built-in HTTP tools.

## What changed

- Mirrored LC-103 into:
  - `testdata/rules-fixture/langchain/agent_safety.yaml`
- Added three agent-rule test cases in:
  - `internal/rules/policies_test.go`

Coverage includes:

- FIRE: `ReactAgent` with `RequestsGetTool`
- FIRE: `AgentExecutor` with `RequestsPostTool`
- SILENT: `ReactAgent` with `TavilySearchResults`

Every `AgentDef` sets `Language`.

No analyzer changes were required because the existing LangChain hosted-tool discovery already recognizes all five `Requests*` classes.

## Validation

- `go vet ./...` — pass
- `go test -race ./internal/rules/...` — pass
- `go test -race ./...` — 26 packages passed, 0 failures
- `go build -o /tmp/trustabl ./cmd/trustabl` — pass
- `check-rules-sync.sh` — in sync with production

The fixture is byte-identical to the corresponding rule definition in `trustabl-rules`.

## Paired changes

- trustabl/trustabl-rules#103 — LC-103 rule definition
- trustabl/trustabl-rulebook#79 — LC-103 rationale documentation

All coordinated changes use the shared branch:

`feat/langchain-requests-builtin-tool`