### PR TITLE
Hackathon/langchain hitl approval

### DIFF
--- a/internal/rules/lc112_policy_test.go
+++ b/internal/rules/lc112_policy_test.go
@@ -1,0 +1,101 @@
+package rules_test
+
+import (
+	"testing"
+
+	"github.com/trustabl/trustabl/internal/models"
+)
+
+func TestLC112HumanApprovalPrerequisites(t *testing.T) {
+	middleware := func(items ...models.Expr) *models.KwargTree {
+		return &models.KwargTree{
+			Value: &models.Expr{
+				Kind: models.ExprList,
+				List: items,
+			},
+		}
+	}
+	checkpointer := &models.KwargTree{
+		Value: &models.Expr{Kind: models.ExprCall, Text: "InMemorySaver()"},
+	}
+
+	cases := []struct {
+		name      string
+		agent     models.AgentDef
+		wantFires bool
+	}{
+		{
+			name: "fires with privileged tool and no approval prerequisites",
+			agent: models.AgentDef{
+				SDK: models.SDKLangChain, Class: "CreateAgent", Language: models.LanguagePython,
+				HostedToolRefs: []models.HostedToolRef{{Class: "ShellTool"}},
+			},
+			wantFires: true,
+		},
+		{
+			name: "fires with middleware but no checkpointer",
+			agent: models.AgentDef{
+				SDK: models.SDKLangChain, Class: "CreateAgent", Language: models.LanguagePython,
+				HostedToolRefs: []models.HostedToolRef{{Class: "ShellTool"}},
+				Kwargs: &models.KwargTree{Children: map[string]*models.KwargTree{
+					"middleware": middleware(models.Expr{Kind: models.ExprCall, Text: "HumanInTheLoopMiddleware(...)"}),
+				}},
+			},
+			wantFires: true,
+		},
+		{
+			name: "fires with empty middleware even when checkpointer is present",
+			agent: models.AgentDef{
+				SDK: models.SDKLangChain, Class: "CreateAgent", Language: models.LanguagePython,
+				HostedToolRefs: []models.HostedToolRef{{Class: "PythonREPLTool"}},
+				Kwargs: &models.KwargTree{Children: map[string]*models.KwargTree{
+					"middleware":   middleware(),
+					"checkpointer": checkpointer,
+				}},
+			},
+			wantFires: true,
+		},
+		{
+			name: "silent with middleware and checkpointer",
+			agent: models.AgentDef{
+				SDK: models.SDKLangChain, Class: "CreateAgent", Language: models.LanguagePython,
+				HostedToolRefs: []models.HostedToolRef{{Class: "ShellTool"}},
+				Kwargs: &models.KwargTree{Children: map[string]*models.KwargTree{
+					"middleware":   middleware(models.Expr{Kind: models.ExprCall, Text: "HumanInTheLoopMiddleware(...)"}),
+					"checkpointer": checkpointer,
+				}},
+			},
+			wantFires: false,
+		},
+		{
+			name: "silent without a privileged execution tool",
+			agent: models.AgentDef{
+				SDK: models.SDKLangChain, Class: "CreateAgent", Language: models.LanguagePython,
+			},
+			wantFires: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := loadAgentRule(t, "LC-112")
+			if !d.Applies(tc.agent) {
+				if tc.wantFires {
+					t.Fatalf("LC-112 does not apply to %s/%s", tc.agent.SDK, tc.agent.Class)
+				}
+				return
+			}
+
+			fired := false
+			for _, f := range d.Detect(tc.agent, models.RepoInventory{}) {
+				if f.RuleID == "LC-112" {
+					fired = true
+					break
+				}
+			}
+			if fired != tc.wantFires {
+				t.Fatalf("LC-112 fired=%v, want %v", fired, tc.wantFires)
+			}
+		})
+	}
+}

--- a/testdata/rules-fixture/langchain/agent_safety.yaml
+++ b/testdata/rules-fixture/langchain/agent_safety.yaml
@@ -83,3 +83,37 @@ rules:
       Pass maxIterations to the AgentExecutor options, sized to the task, and set
       handleParsingErrors so a malformed step is surfaced rather than retried
       indefinitely.
+
+  - id: LC-112
+    title: LangChain privileged create_agent lacks human-approval prerequisites
+    severity: high
+    confidence: 0.7
+    language: python
+    applies_to:
+      - langchain_agent
+    scope: agent
+    match:
+      all:
+        - agent_class:
+            - CreateAgent
+        - agent_uses_hosted_tool_class:
+            - PythonREPLTool
+            - PythonAstREPLTool
+            - ShellTool
+        - any:
+            - agent_kwarg_list_empty:
+                - middleware
+            - agent_kwarg_missing:
+                - checkpointer
+    explanation: >
+      This LangChain v1 create_agent exposes a built-in that can execute arbitrary
+      Python or shell commands, but it lacks middleware and/or checkpoint state
+      needed to support a resumable human approval boundary. Without those
+      structural prerequisites, the model can reach a high-impact execution tool
+      without an explicit interrupt/resume control point that Trustabl can verify.
+    fix: >
+      Add human-in-the-loop approval middleware for the privileged tool and pass a
+      checkpointer so interrupted execution can be persisted and resumed after the
+      decision. Keep the REPL/shell tool sandboxed and narrowly scoped. This rule
+      only verifies the structural prerequisites; review that the middleware is in
+      fact configured to require approval for the privileged tool.


### PR DESCRIPTION
Mirrors LC-112 into the engine rule fixture and adds focused fire/silent regression tests. Coverage includes missing approval prerequisites, middleware without a checkpointer, an empty middleware list, the structurally safe case, and agents without privileged execution tools.
This does not change LangChain discovery, predicate semantics, or evaluator behavior; it exercises existing machinery against the new rule.