### PR TITLE
feat(rules): VarName name match; cover VAI-010 and VAI-016

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -362,6 +362,18 @@ import { z } from "zod";
 export const t = tool({ description: "x", inputSchema: z.object({ city: z.string() }), execute: async ({ city }) => city });
 `},
 
+	// VAI-016: ambiguous binding name (VarName) — Name is empty for Vercel tools.
+	{name: "VAI-016 fires on process binding", ruleID: "VAI-016", kind: models.KindVercelAITool, lang: models.LanguageTypeScript, wantFires: true, src: `
+import { tool } from "ai";
+import { z } from "zod";
+export const process = tool({ description: "x", inputSchema: z.object({ q: z.string() }), execute: async ({ q }) => q });
+`},
+	{name: "VAI-016 silent on descriptive binding", ruleID: "VAI-016", kind: models.KindVercelAITool, lang: models.LanguageTypeScript, wantFires: false, src: `
+import { tool } from "ai";
+import { z } from "zod";
+export const fetchWeather = tool({ description: "x", inputSchema: z.object({ city: z.string() }), execute: async ({ city }) => city });
+`},
+
 	// ─── CrewAI tool rules (CREW-*) ─────────────────────────────────────────
 	{name: "CREW-001 fires on tool with no docstring", ruleID: "CREW-001", kind: models.KindCrewAITool, src: `
 def search(q: str) -> str:

--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -1688,6 +1688,30 @@ def calc(expr: str) -> int:
 			"} });\n",
 	},
 
+	// ── VAI-010: mutating Vercel tool VarName without idempotency marker ──
+	// Name is empty for Vercel tools; name_has_prefix matches VarName.
+	{
+		name: "VAI-010 fires on createCharge binding", ruleID: "VAI-010",
+		kind: models.KindVercelAITool, lang: models.LanguageTypeScript, wantFires: true,
+		src: "import { tool } from \"ai\";\n" +
+			"import { z } from \"zod\";\n" +
+			"export const createCharge = tool({ description: \"bill\", inputSchema: z.object({ cents: z.number() }), execute: async ({ cents }) => cents });\n",
+	},
+	{
+		name: "VAI-010 silent on read binding", ruleID: "VAI-010",
+		kind: models.KindVercelAITool, lang: models.LanguageTypeScript, wantFires: false,
+		src: "import { tool } from \"ai\";\n" +
+			"import { z } from \"zod\";\n" +
+			"export const getStatus = tool({ description: \"status\", inputSchema: z.object({ id: z.string() }), execute: async ({ id }) => id });\n",
+	},
+	{
+		name: "VAI-010 silent when idempotencyKey in schema", ruleID: "VAI-010",
+		kind: models.KindVercelAITool, lang: models.LanguageTypeScript, wantFires: false,
+		src: "import { tool } from \"ai\";\n" +
+			"import { z } from \"zod\";\n" +
+			"export const createCharge = tool({ description: \"bill\", inputSchema: z.object({ cents: z.number(), idempotencyKey: z.string() }), execute: async ({ cents, idempotencyKey }) => cents });\n",
+	},
+
 	// ── OAI-017: TS eval / new Function (has_body_text) ──
 	{
 		name: "OAI-017 fires on TS eval", ruleID: "OAI-017",

--- a/internal/rules/predicates.go
+++ b/internal/rules/predicates.go
@@ -255,8 +255,21 @@ func PredHasHTTPCallWithoutTimeout(t models.ToolDef) bool {
 
 // ─── string-list predicates ───────────────────────────────────────────────────
 
+// toolNameForMatch returns the name predicates should match against.
+// Prefer ToolDef.Name when set (OpenAI / Claude / most Python tools). When
+// Name is empty — Vercel AI tools leave it blank because the model-facing
+// name is the agent's tools-record key — fall back to VarName (the binding
+// identifier, e.g. createCharge). Without this, name_has_prefix / name_in
+// never fire on Vercel tools.
+func toolNameForMatch(t models.ToolDef) string {
+	if t.Name != "" {
+		return t.Name
+	}
+	return t.VarName
+}
+
 func PredNameIn(names []string, t models.ToolDef) bool {
-	lower := strings.ToLower(t.Name)
+	lower := strings.ToLower(toolNameForMatch(t))
 	for _, n := range names {
 		if lower == strings.ToLower(n) {
 			return true
@@ -266,7 +279,7 @@ func PredNameIn(names []string, t models.ToolDef) bool {
 }
 
 func PredNameHasPrefix(prefixes []string, t models.ToolDef) bool {
-	lower := strings.ToLower(t.Name)
+	lower := strings.ToLower(toolNameForMatch(t))
 	for _, p := range prefixes {
 		if strings.HasPrefix(lower, strings.ToLower(p)) {
 			return true

--- a/internal/rules/predicates_test.go
+++ b/internal/rules/predicates_test.go
@@ -413,6 +413,19 @@ func TestPred_NameHasPrefix_Miss(t *testing.T) {
 	}
 }
 
+func TestPred_NameHasPrefix_FallsBackToVarName(t *testing.T) {
+	// Vercel AI tools leave Name empty; the binding identifier is VarName.
+	tool := models.ToolDef{VarName: "createCharge"}
+	if !rules.PredNameHasPrefix([]string{"create", "send"}, tool) {
+		t.Error("expected NameHasPrefix hit via VarName when Name is empty")
+	}
+	tool.Name = "get_order"
+	tool.VarName = "createCharge"
+	if rules.PredNameHasPrefix([]string{"create", "send"}, tool) {
+		t.Error("Name must win over VarName when both are set")
+	}
+}
+
 // ─── param_name_matches ───────────────────────────────────────────────────────
 
 func TestPred_ParamNameMatches_ExactHit(t *testing.T) {

--- a/testdata/rules-fixture/vercel_ai/idempotency.yaml
+++ b/testdata/rules-fixture/vercel_ai/idempotency.yaml
@@ -1,0 +1,56 @@
+policy:
+  id: vercel_ai_idempotency
+  name: Vercel AI SDK mutating-tool idempotency
+  category: vercel_ai
+  description: >
+    Rules that flag mutating Vercel AI SDK tools without an idempotency key.
+    Agents retry tool calls under timeouts and ambiguous failures; without a
+    key the same side-effecting action can fire more than once. Vercel tools
+    leave ToolDef.Name empty (the model-facing name is the agent's tools-record
+    key), so matching uses the binding identifier (VarName) via name_has_prefix.
+
+rules:
+  - id: VAI-010
+    title: TypeScript mutating Vercel AI tool has no idempotency key
+    severity: medium
+    confidence: 0.5
+    language: typescript
+    applies_to:
+      - vercel_ai_tool
+    scope: tool
+    match:
+      all:
+        - name_has_prefix:
+            - create
+            - send
+            - delete
+            - post
+            - update
+            - refund
+            - charge
+            - issue
+        - not:
+            has_body_text:
+              - idempot
+              - request_id
+              - requestId
+              - txn_id
+              - txnId
+              - correlation_id
+              - correlationId
+    explanation: >
+      A Vercel AI SDK tool whose binding name implies a side effect
+      (create/send/delete/refund/…) has no idempotency token visible in its
+      definition. The SDK does not retry tool calls for you by default, but
+      retries still happen — the model re-invokes the tool when a result reads
+      as inconclusive, and an orchestrator, your own retry policy, or a lost
+      response (at-least-once delivery) can re-issue the call; without a key
+      threaded through to the backing API the same action fires twice. Prefixes
+      are underscore-free so both `create_charge` and `createCharge` bindings
+      match. Detection keys off VarName because Vercel leaves ToolDef.Name empty.
+    fix: >
+      Add an `idempotencyKey: z.string()` field to the tool's inputSchema and
+      forward it to the underlying API (Stripe `Idempotency-Key` header,
+      REST `X-Request-ID`, GraphQL `clientMutationId`, etc.). If the backing
+      service does not honor idempotency keys, document the gap and dedupe in
+      your own store keyed by the token before issuing the call.

--- a/testdata/rules-fixture/vercel_ai/tool_definition.yaml
+++ b/testdata/rules-fixture/vercel_ai/tool_definition.yaml
@@ -58,3 +58,36 @@ rules:
       field per argument (z.object({ city: z.string(), units: z.enum([...]) })).
       Reserve dynamicTool for the rare case where the input genuinely cannot be
       typed, and even then validate the shape inside execute() before using it.
+
+  - id: VAI-016
+    title: Ambiguous Vercel AI tool binding name
+    severity: low
+    confidence: 0.85
+    language: typescript
+    applies_to:
+      - vercel_ai_tool
+    scope: tool
+    match:
+      name_in:
+        - process
+        - handle
+        - run
+        - do
+        - execute
+        - perform
+        - work
+        - go
+        - thing
+        - stuff
+    explanation: >
+      A Vercel AI SDK tool whose binding identifier is a generic name like
+      `process`, `handle`, or `run` gives the model no signal about intent once
+      that binding is registered under the agent's tools record. Vercel leaves
+      ToolDef.Name empty (the model-facing name is the record key), so this rule
+      matches the binding identifier (VarName). Authors often register
+      `tools: { process }` or reuse a throwaway binding that later becomes the
+      public name — the model then mis-routes or under-calls the tool.
+    fix: >
+      Rename the binding to a verb-object form (e.g. `summarizeInvoice`,
+      `fetchWeather`) and use that same identifier as the agent's tools-record
+      key so the model-facing name stays descriptive.


### PR DESCRIPTION
## Summary
- `name_has_prefix` / `name_in` fall back to `VarName` when `ToolDef.Name` is empty (required for Vercel AI tools).
- Mirror + fire/silent coverage for **VAI-010** (mutating tool idempotency) and **VAI-016** (ambiguous binding name).

## Why
Vercel discovery leaves `Name` blank and puts the binding identifier in `VarName`. Without the fallback, every name-based Vercel rule is a no-op. The rulebook's Vercel tool-definition doc even called name-based rules a deliberate coverage gap — this closes it.

## Paired PRs
- Rules VAI-010: trustabl-rules#109
- Rules VAI-016: (new)
- Rulebook VAI-010: trustabl-rulebook#94
- Rulebook VAI-016: (new)

## Test plan
- [ ] `go test ./internal/rules/ -run 'NameHasPrefix|VAI-010|VAI-016|AllRulesCovered'`
- [ ] Full `go test ./...` in CI

Made with [Cursor](https://cursor.com)