### PR TITLE
docs(skill): list every --detectors category the CLI accepts

### DIFF
--- a/skills/trustabl-scan/SKILL.md
+++ b/skills/trustabl-scan/SKILL.md
@@ -74,7 +74,7 @@ on `PATH`:
 ```bash
 "$TRUSTABL_BIN" scan . --format json          # JSON, same shape the tool returns
 "$TRUSTABL_BIN" scan . --strict               # exit 1 on low+ findings (info/META never fail)
-"$TRUSTABL_BIN" scan . --detectors claude_sdk # narrow to one SDK: claude_sdk|openai_sdk|google_adk|openshell
+"$TRUSTABL_BIN" scan . --detectors claude_sdk # claude_sdk|openai_sdk|google_adk|openshell|mcp|langchain|crewai|pydantic_ai|vercel_ai|autogen|claude_skill
 "$TRUSTABL_BIN" scan . --vuln-scan            # also match declared deps against OSV → CVE findings
 "$TRUSTABL_BIN" scan . --bom-out bom.json     # write a CycloneDX SBOM (+ VEX vulnerabilities under --vuln-scan)
 ```


### PR DESCRIPTION
## Summary
\`skills/trustabl-scan/SKILL.md\` still told the CLI-fallback that \`--detectors\` is \`claude_sdk|openai_sdk|google_adk|openshell\`. The flag accepts every \`models.AllCategories\` value, including \`mcp\`, \`langchain\`, \`crewai\`, \`pydantic_ai\`, \`vercel_ai\`, \`autogen\`, and \`claude_skill\`.

One comment. No rule IDs. Independent of the CLI-help PRs.

## Test plan
- [ ] \`trustabl scan --help\` \`--detectors\` line matches the updated comment


Made with [Cursor](https://cursor.com)