### PR TITLE
test(langchain): add LC-103 fixture and regression cases

### DIFF
--- a/internal/rules/lc103_test.go
+++ b/internal/rules/lc103_test.go
@@ -1,0 +1,117 @@
+package rules_test
+
+import (
+	"testing"
+
+	"github.com/trustabl/trustabl/internal/models"
+)
+
+func TestLC103LangChainHumanReviewGate(t *testing.T) {
+	d := loadAgentRule(t, "LC-103")
+
+	cases := []struct {
+		name      string
+		agent     models.AgentDef
+		wantFires bool
+	}{
+		{
+			name: "fires when CreateAgent wires PythonREPLTool without HITL prerequisites",
+			agent: models.AgentDef{
+				SDK:            models.SDKLangChain,
+				Class:          "CreateAgent",
+				Language:       models.LanguagePython,
+				HostedToolRefs: []models.HostedToolRef{{Class: "PythonREPLTool"}},
+			},
+			wantFires: true,
+		},
+		{
+			name: "silent when middleware and checkpointer are configured",
+			agent: models.AgentDef{
+				SDK:            models.SDKLangChain,
+				Class:          "CreateAgent",
+				Language:       models.LanguagePython,
+				HostedToolRefs: []models.HostedToolRef{{Class: "PythonREPLTool"}},
+				Kwargs: &models.KwargTree{Children: map[string]*models.KwargTree{
+					"middleware": {
+						Value: &models.Expr{
+							Kind: models.ExprList,
+							Text: "[HumanInTheLoopMiddleware(...)]",
+							List: []models.Expr{{Kind: models.ExprCall, Text: "HumanInTheLoopMiddleware(...)"}},
+						},
+					},
+					"checkpointer": {
+						Value: &models.Expr{Kind: models.ExprCall, Text: "InMemorySaver()"},
+					},
+				}},
+			},
+			wantFires: false,
+		},
+		{
+			name: "fires when middleware is empty even with a checkpointer",
+			agent: models.AgentDef{
+				SDK:            models.SDKLangChain,
+				Class:          "CreateAgent",
+				Language:       models.LanguagePython,
+				HostedToolRefs: []models.HostedToolRef{{Class: "ShellTool"}},
+				Kwargs: &models.KwargTree{Children: map[string]*models.KwargTree{
+					"middleware": {
+						Value: &models.Expr{Kind: models.ExprList, Text: "[]", List: []models.Expr{}},
+					},
+					"checkpointer": {
+						Value: &models.Expr{Kind: models.ExprCall, Text: "InMemorySaver()"},
+					},
+				}},
+			},
+			wantFires: true,
+		},
+		{
+			name: "fires when checkpointer is missing despite middleware",
+			agent: models.AgentDef{
+				SDK:            models.SDKLangChain,
+				Class:          "CreateAgent",
+				Language:       models.LanguagePython,
+				HostedToolRefs: []models.HostedToolRef{{Class: "PythonAstREPLTool"}},
+				Kwargs: &models.KwargTree{Children: map[string]*models.KwargTree{
+					"middleware": {
+						Value: &models.Expr{
+							Kind: models.ExprList,
+							Text: "[HumanInTheLoopMiddleware(...)]",
+							List: []models.Expr{{Kind: models.ExprCall, Text: "HumanInTheLoopMiddleware(...)"}},
+						},
+					},
+				}},
+			},
+			wantFires: true,
+		},
+		{
+			name: "silent when CreateAgent has no dangerous hosted tool",
+			agent: models.AgentDef{
+				SDK:      models.SDKLangChain,
+				Class:    "CreateAgent",
+				Language: models.LanguagePython,
+			},
+			wantFires: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !d.Applies(tc.agent) {
+				if tc.wantFires {
+					t.Fatalf("LC-103 does not apply to CreateAgent")
+				}
+				return
+			}
+			fired := false
+			for _, finding := range d.Detect(tc.agent, models.RepoInventory{}) {
+				if finding.RuleID == "LC-103" {
+					fired = true
+					break
+				}
+			}
+			if fired != tc.wantFires {
+				t.Fatalf("LC-103 fired=%v, want %v", fired, tc.wantFires)
+			}
+		})
+	}
+}

--- a/testdata/rules-fixture/langchain/approvals.yaml
+++ b/testdata/rules-fixture/langchain/approvals.yaml
@@ -1,0 +1,44 @@
+policy:
+  id: langchain_approvals
+  name: LangChain tool approval gates
+  category: langchain
+  description: >
+    Rules covering explicit human-review prerequisites around
+    high-impact LangChain agent tool calls.
+
+rules:
+  - id: LC-103
+    title: Dangerous LangChain create_agent lacks a resumable human-review gate
+    severity: high
+    confidence: 0.65
+    language: python
+    applies_to:
+      - langchain_agent
+    scope: agent
+    match:
+      all:
+        - agent_class:
+            - CreateAgent
+        - agent_uses_hosted_tool_class:
+            - PythonREPLTool
+            - PythonAstREPLTool
+            - ShellTool
+        - any:
+            - agent_kwarg_list_empty:
+                - middleware
+            - agent_kwarg_missing:
+                - checkpointer
+    explanation: >
+      This LangChain create_agent wires a Python or shell execution tool but
+      lacks one or more visible prerequisites for LangChain's resumable
+      human-review flow: a non-empty middleware configuration and an effective
+      checkpointer. Without a visible pause/review boundary, model-selected
+      Python or shell actions may proceed directly to execution. This is a
+      structural static-analysis signal only: middleware presence does not prove
+      that HumanInTheLoopMiddleware is configured, that interrupt_on covers the
+      dangerous tool, or that a human meaningfully reviews the requested action.
+    fix: >
+      Configure HumanInTheLoopMiddleware with an interrupt_on policy covering
+      each high-impact execution tool, and configure a checkpointer so the
+      agent can pause and resume around the human decision. Pair approval with
+      sandboxing, least privilege, restricted credentials, and execution timeouts.


### PR DESCRIPTION
Fork of the Trustabl core scanner, updated with the mirrored LC-103 rule fixture and regression tests covering unsafe and human-review-configured LangChain agents.