### PR TITLE
feat(vercel_ai): TS has_print_call + VAI-017 fixture

### DIFF
--- a/internal/analysis/ts_handler_facts.go
+++ b/internal/analysis/ts_handler_facts.go
@@ -64,6 +64,13 @@ func tsHandlerFacts(handler *sitter.Node, src []byte) map[string]string {
 			"fs.appendFileSync", "fs.createWriteStream",
 			"fsPromises.writeFile", "fsPromises.appendFile":
 			out["writes_fs"] = "true"
+		case "console.log", "console.info", "console.debug", "process.stdout.write":
+			// STDOUT ONLY. console.warn/console.error and process.stderr.write
+			// are deliberately absent: Node routes them to stderr, which is the
+			// correct destination for diagnostics and — on an MCP stdio server —
+			// the only safe one, since stdout carries the JSON-RPC frames.
+			// Flagging them would report the remediation as the defect.
+			out["prints_stdout"] = "true"
 		case "eval":
 			// Bare `eval` callee only — callee text for `retrieval(x)` is
 			// "retrieval", so this exact-match eliminates the false-positive.

--- a/internal/analysis/ts_handler_facts_test.go
+++ b/internal/analysis/ts_handler_facts_test.go
@@ -140,3 +140,77 @@ export const t = tool("f", "f", {}, async () => {
 		t.Error("the Vercel-style abortSignal key must count as a timeout bound")
 	}
 }
+
+// ─── prints_stdout ──────────────────────────────────────────────────────────
+// stdout writes only. The stderr counterparts are the remediation, not the
+// defect, and must never set the fact — on an MCP stdio server stderr is the
+// only safe destination, since stdout carries the JSON-RPC frames.
+
+func TestTSHandlerFacts_PrintsStdout_ConsoleLogHits(t *testing.T) {
+	src := `
+import { tool } from "@anthropic-ai/claude-agent-sdk";
+export const t = tool("f", "f", {}, async () => {
+  console.log("looking up order");
+  return { content: [] };
+});
+`
+	if tsToolFacts(t, src)["prints_stdout"] != "true" {
+		t.Error("expected prints_stdout=true for console.log")
+	}
+}
+
+func TestTSHandlerFacts_PrintsStdout_ProcessStdoutWriteHits(t *testing.T) {
+	src := `
+import { tool } from "@anthropic-ai/claude-agent-sdk";
+export const t = tool("f", "f", {}, async () => {
+  process.stdout.write("looking up order\n");
+  return { content: [] };
+});
+`
+	if tsToolFacts(t, src)["prints_stdout"] != "true" {
+		t.Error("expected prints_stdout=true for process.stdout.write")
+	}
+}
+
+func TestTSHandlerFacts_PrintsStdout_ConsoleInfoAndDebugHit(t *testing.T) {
+	for _, callee := range []string{"console.info", "console.debug"} {
+		src := `
+import { tool } from "@anthropic-ai/claude-agent-sdk";
+export const t = tool("f", "f", {}, async () => {
+  ` + callee + `("looking up order");
+  return { content: [] };
+});
+`
+		if tsToolFacts(t, src)["prints_stdout"] != "true" {
+			t.Errorf("expected prints_stdout=true for %s (Node routes it to stdout)", callee)
+		}
+	}
+}
+
+func TestTSHandlerFacts_PrintsStdout_StderrIsSilent(t *testing.T) {
+	for _, callee := range []string{"console.warn", "console.error", "process.stderr.write"} {
+		src := `
+import { tool } from "@anthropic-ai/claude-agent-sdk";
+export const t = tool("f", "f", {}, async () => {
+  ` + callee + `("looking up order");
+  return { content: [] };
+});
+`
+		if tsToolFacts(t, src)["prints_stdout"] == "true" {
+			t.Errorf("%s writes to stderr and must NOT set prints_stdout: it is the remediation, not the defect", callee)
+		}
+	}
+}
+
+func TestTSHandlerFacts_PrintsStdout_UnrelatedCalleeIsSilent(t *testing.T) {
+	src := `
+import { tool } from "@anthropic-ai/claude-agent-sdk";
+export const t = tool("f", "f", {}, async () => {
+  logger.log("looking up order");
+  return { content: [] };
+});
+`
+	if tsToolFacts(t, src)["prints_stdout"] == "true" {
+		t.Error("expected no prints_stdout for logger.log: only the console.* / process.stdout.write callees count")
+	}
+}

--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -362,6 +362,29 @@ import { z } from "zod";
 export const t = tool({ description: "x", inputSchema: z.object({ city: z.string() }), execute: async ({ city }) => city });
 `},
 
+	// VAI-017: TS stdout diagnostics (prints_stdout → has_print_call)
+	{name: "VAI-017 fires on console.log", ruleID: "VAI-017", kind: models.KindVercelAITool, lang: models.LanguageTypeScript, wantFires: true, src: `
+import { tool } from "ai";
+import { z } from "zod";
+export const t = tool({ description: "lookup", inputSchema: z.object({ id: z.string() }), execute: async ({ id }) => {
+  console.log("looking up", id);
+  return id;
+} });
+`},
+	{name: "VAI-017 silent without stdout write", ruleID: "VAI-017", kind: models.KindVercelAITool, lang: models.LanguageTypeScript, wantFires: false, src: `
+import { tool } from "ai";
+import { z } from "zod";
+export const t = tool({ description: "lookup", inputSchema: z.object({ id: z.string() }), execute: async ({ id }) => id });
+`},
+	{name: "VAI-017 silent on console.error (stderr)", ruleID: "VAI-017", kind: models.KindVercelAITool, lang: models.LanguageTypeScript, wantFires: false, src: `
+import { tool } from "ai";
+import { z } from "zod";
+export const t = tool({ description: "lookup", inputSchema: z.object({ id: z.string() }), execute: async ({ id }) => {
+  console.error("looking up", id);
+  return id;
+} });
+`},
+
 	// ─── CrewAI tool rules (CREW-*) ─────────────────────────────────────────
 	{name: "CREW-001 fires on tool with no docstring", ruleID: "CREW-001", kind: models.KindCrewAITool, src: `
 def search(q: str) -> str:

--- a/internal/rules/predicates.go
+++ b/internal/rules/predicates.go
@@ -116,11 +116,23 @@ func PredHasCodeExecCall(t models.ToolDef, pf analysis.ParsedFile) bool {
 	return found
 }
 
-// PredHasPrintCall reports whether the tool body calls the print builtin. It
-// matches the bare `print` callee only, so pprint() and other callees whose
-// text merely contains "print(" are not flagged — the false positive that
-// substring matching cannot avoid.
+// PredHasPrintCall reports whether the tool body writes diagnostics to stdout.
+// For Python it matches the bare `print` callee only, so pprint() and other
+// callees whose text merely contains "print(" are not flagged — the false
+// positive that substring matching cannot avoid.
+//
+// TypeScript tools carry the signal as a discovery-computed fact (set by
+// tsHandlerFacts for console.log / console.info / console.debug /
+// process.stdout.write). The Python AST walk below looks for the "call"
+// node type, which does not exist in the TS grammar — it uses
+// "call_expression" — so without this branch the predicate was structurally
+// always false for TS and any typescript rule using it could never fire.
+// Branch on language so the Python path stays byte-identical, mirroring
+// PredHasShellCall / PredHasWriteCall.
 func PredHasPrintCall(t models.ToolDef, pf analysis.ParsedFile) bool {
+	if models.IsTSOrJS(t.Language) {
+		return t.Facts["prints_stdout"] == "true"
+	}
 	root := analysis.FindFunctionNode(t, pf)
 	if root == nil {
 		return false

--- a/internal/rules/schema.yaml
+++ b/internal/rules/schema.yaml
@@ -171,8 +171,11 @@ rules:
 #   has_shell_call:         body calls subprocess.* / os.system / os.popen / os.spawn*
 #   has_code_exec_call:     body calls the eval/exec/compile builtins (bare callee,
 #                           so re.compile and other attribute calls are not flagged)
-#   has_print_call:         body calls the print builtin (bare callee, so pprint and
-#                           other callees containing "print" are not flagged)
+#   has_print_call:         Python: body calls the print builtin (bare callee, so
+#                           pprint and other callees containing "print" are not
+#                           flagged). TypeScript: Facts["prints_stdout"] from
+#                           console.log / console.info / console.debug /
+#                           process.stdout.write (stderr counterparts are silent).
 #   has_write_call:         body opens a file 'w'/'a'/'x', or shutil.copy/copy2/move/rmtree
 #   has_dynamic_url_call:   HTTP call where the URL is a non-literal (param/f-string)
 #   has_http_call_without_timeout: (TypeScript only) a fetch/axios/got/undici call

--- a/testdata/rules-fixture/vercel_ai/observability.yaml
+++ b/testdata/rules-fixture/vercel_ai/observability.yaml
@@ -1,0 +1,37 @@
+policy:
+  id: vercel_ai_observability
+  name: Vercel AI SDK tool observability hygiene
+  category: vercel_ai
+  description: >
+    Rules covering how a Vercel AI SDK tool emits diagnostics. Tool execute()
+    bodies that write to stdout are invisible to the model and can corrupt
+    stdio-based transports (MCP) that share the channel.
+
+rules:
+  - id: VAI-017
+    title: Vercel AI tool execute() writes diagnostics to stdout
+    severity: low
+    confidence: 0.65
+    language: typescript
+    applies_to:
+      - vercel_ai_tool
+    scope: tool
+    match:
+      has_print_call: true
+    explanation: >
+      This Vercel AI SDK tool's execute() handler writes to the process's
+      stdout (console.log / console.info / console.debug / process.stdout.write).
+      The model never sees that output — only the return value flows back into
+      the agent loop — so the diagnostic silently disappears in production
+      logs that capture structured records but not raw stdout. If the same
+      tool is ever exposed over an MCP stdio server (or any transport that
+      uses stdout as a protocol channel), the loose frames will interleave
+      with JSON-RPC messages and corrupt the stream. stderr counterparts
+      (console.warn / console.error / process.stderr.write) are the
+      remediation and do not fire.
+    fix: >
+      Remove the stdout write. If the information is needed for ops, emit it
+      through a structured logger that lands in the application's log sink, or
+      use console.error / process.stderr.write so diagnostics stay off the
+      protocol channel. If the information needs to reach the model, include
+      it in the tool's return value instead.


### PR DESCRIPTION
## Summary
- Teach `PredHasPrintCall` to read the TypeScript `prints_stdout` discovery fact (`console.log` / `console.info` / `console.debug` / `process.stdout.write`; stderr callees stay silent), mirroring `has_write_call` / `has_shell_call`.
- Add unit coverage for the fact and fire/silent cases for **VAI-017** (Vercel AI tool stdout diagnostics).
- Ship the matching rules-fixture so engine CI can evaluate the new rule.

## Overlap
Same `prints_stdout` / `PredHasPrintCall` TS branch as #180. If that lands first, I will rebase and drop the overlapping hunks, keeping only the VAI-017 fixture + policy tests. #180 telegraphed MCP follow-up; this claims the Vercel observability rule.

## Companion PRs
- Rules: https://github.com/trustabl/trustabl-rules/pull/114
- Rulebook: https://github.com/trustabl/trustabl-rulebook/pull/102

## Test plan
- [ ] `go test ./internal/analysis/ -run PrintsStdout`
- [ ] `go test ./internal/rules/ -run 'VAI-017|OAI-010'`