### PR TITLE
fix(scanner): count all source languages in recon summary

### DIFF
--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -293,6 +293,16 @@ type ScanManifest struct {
 	Components             []AgentComponent `json:"components,omitempty"`
 }
 
+// SourceFileCount returns the number of source files across every language the
+// inventory step parses (Python, TypeScript, JavaScript, Go, C#, PHP, Rust).
+// This is the count that pairs with the detected-languages label — using a
+// single language's bucket would undercount any multi-language repo. Data files
+// (YAML/JSON/Markdown) are intentionally excluded: they are not AST-parsed.
+func (m ScanManifest) SourceFileCount() int {
+	return len(m.PythonFiles) + len(m.TypeScriptFiles) + len(m.JavaScriptFiles) +
+		len(m.GoFiles) + len(m.CSharpFiles) + len(m.PHPFiles) + len(m.RustFiles)
+}
+
 // SDK identifies a tool/agent SDK we know about.
 type SDK string
 

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -96,3 +96,34 @@ func TestGuardrailDef_VarName_OmitEmpty(t *testing.T) {
 		t.Errorf("var_name should be present when set, got: %s", b)
 	}
 }
+
+func TestScanManifest_SourceFileCount(t *testing.T) {
+	// Empty manifest counts zero.
+	if got := (models.ScanManifest{}).SourceFileCount(); got != 0 {
+		t.Errorf("empty manifest: got %d, want 0", got)
+	}
+
+	// Every source-language bucket is summed; data files are excluded.
+	m := models.ScanManifest{
+		PythonFiles:     []string{"a.py"},
+		TypeScriptFiles: []string{"a.ts", "b.ts"},
+		JavaScriptFiles: []string{"a.js"},
+		GoFiles:         []string{"a.go"},
+		CSharpFiles:     []string{"a.cs"},
+		PHPFiles:        []string{"a.php"},
+		RustFiles:       []string{"a.rs"},
+		// Data files must NOT be counted.
+		YAMLFiles:     []string{"a.yaml", "b.yaml"},
+		JSONFiles:     []string{"a.json"},
+		MarkdownFiles: []string{"a.md"},
+	}
+	if got, want := m.SourceFileCount(), 8; got != want {
+		t.Errorf("SourceFileCount: got %d, want %d", got, want)
+	}
+
+	// Regression: a non-Python repo must not report zero source files.
+	tsOnly := models.ScanManifest{TypeScriptFiles: []string{"a.ts", "b.ts", "c.ts"}}
+	if got, want := tsOnly.SourceFileCount(), 3; got != want {
+		t.Errorf("TypeScript-only SourceFileCount: got %d, want %d", got, want)
+	}
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -179,7 +179,7 @@ func Run(cfg Config) (models.ScanResult, error) {
 		rep.Fatal(err)
 		return models.ScanResult{}, fmt.Errorf("recon: %w", err)
 	}
-	rep.EndPhase(fmt.Sprintf("%d files · %s", len(profile.Manifest.PythonFiles), languagesLabel(profile.Languages)))
+	rep.EndPhase(fmt.Sprintf("%d files · %s", profile.Manifest.SourceFileCount(), languagesLabel(profile.Languages)))
 	reconStop()
 	log.Verbosef("recon: languages %s · %d SDK deps declared", languagesLabel(profile.Languages), len(profile.SDKDeps))
 	if log.Enabled(logx.LevelDebug) {
@@ -194,7 +194,7 @@ func Run(cfg Config) (models.ScanResult, error) {
 	// Step 2: inventory (per-language AST; Python only for now)
 	rep.StartPhase("inventory", "Inventory")
 	inventoryStop := log.Timer("inventory")
-	rep.SetTotal(len(profile.Manifest.PythonFiles) + len(profile.Manifest.TypeScriptFiles) + len(profile.Manifest.JavaScriptFiles) + len(profile.Manifest.GoFiles) + len(profile.Manifest.CSharpFiles) + len(profile.Manifest.PHPFiles) + len(profile.Manifest.RustFiles))
+	rep.SetTotal(profile.Manifest.SourceFileCount())
 	tools, parsed, pySkipped, err := analysis.DiscoverTools(ctx, profile.Manifest, func(path string) {
 		rep.Advance(path)
 	})


### PR DESCRIPTION
## What

The recon-phase summary line pairs a file count with the **full** detected-languages label, but only counted Python files:

```go
// internal/scanner/scanner.go
rep.EndPhase(fmt.Sprintf("%d files · %s",
    len(profile.Manifest.PythonFiles), languagesLabel(profile.Languages)))
```

So a TypeScript-only repo prints `0 files · typescript`, and any multi-language repo undercounts. The inventory `SetTotal` on the very next lines already summed **all seven** source-file buckets (Python, TypeScript, JavaScript, Go, C#, PHP, Rust), so this label was the odd one out.

## Change

- Add `ScanManifest.SourceFileCount()` — sums every language the inventory step parses; data files (YAML/JSON/Markdown) are excluded since they are not AST-parsed.
- Use it in both the recon summary label (the fix) and the inventory `SetTotal` (removes the duplicated seven-term sum).
- Add a unit test covering the empty case, the all-buckets case (data files excluded), and a TypeScript-only regression.

## Impact

This is **stderr-only progress output** (`internal/progress`). Per the determinism contract, it never touches the byte-stable report or `ScanID`, so no report changes and no doc updates are required.

## Testing

- `go build ./...`
- `go vet ./internal/models/ ./internal/scanner/`
- `go test ./...` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)