### PR TITLE
docs(rules): correct RuleDef language-default comment

### DIFF
--- a/internal/rules/schema.go
+++ b/internal/rules/schema.go
@@ -18,7 +18,9 @@ type PolicyMeta struct {
 
 // RuleDef is one rule entry inside a policy file.
 // Category is not in YAML — the loader copies it from PolicyMeta.Category.
-// Language defaults to "python" if absent in YAML — the loader fills it in.
+// Language defaults to "python" for tool/agent scope if absent in YAML — the
+// loader fills it in. Subagent, skill, and repo rules do not gate on language,
+// so an omitted language stays empty for those scopes.
 type RuleDef struct {
 	ID          string                  `yaml:"id"`
 	Title       string                  `yaml:"title"`


### PR DESCRIPTION
## What

The `RuleDef` doc comment claims the language default applies unconditionally:

```go
// Language defaults to "python" if absent in YAML — the loader fills it in.
```

But the loader only fills it in for **tool** and **agent** scope:

```go
// internal/rules/loader.go
if pf.Rules[i].Language == "" &&
    (pf.Rules[i].Scope == models.ScopeTool || pf.Rules[i].Scope == models.ScopeAgent) {
    pf.Rules[i].Language = models.LanguagePython
}
```

Subagent, skill, and repo rules do not gate on language (markdown frontmatter / inventory scopes), so an omitted language stays empty for them — which matches the loader's own comment and `CLAUDE.md`.

## Change

Doc-only: qualify the comment so it matches the code. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)