### PR TITLE
test(langchain): cover missing network timeout rule

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -230,6 +230,50 @@ def f(x: str) -> str:
     return x
 `, toolConfig: map[string]string{}, wantFires: false},
 
+	// ─── LC-007 LangChain tool network call without timeout ──────────────────
+	{name: "LC-007 fires on requests.get without timeout", ruleID: "LC-007", kind: models.KindLangChainTool, src: `
+def fetch(q: str) -> str:
+    """Fetch."""
+    import requests
+    return requests.get("https://api.example.com/data").text
+`, wantFires: true},
+	{name: "LC-007 fires on requests.post without timeout", ruleID: "LC-007", kind: models.KindLangChainTool, src: `
+def create(q: str) -> str:
+    """Create."""
+    import requests
+    return requests.post("https://api.example.com/data", json={"q": q}).text
+`, wantFires: true},
+	{name: "LC-007 silent with timeout", ruleID: "LC-007", kind: models.KindLangChainTool, src: `
+def fetch(q: str) -> str:
+    """Fetch."""
+    import requests
+    return requests.get("https://api.example.com/data", timeout=10).text
+`, wantFires: false},
+	{name: "LC-007 fires on timeout=None", ruleID: "LC-007", kind: models.KindLangChainTool, src: `
+import requests
+def fetch(url: str) -> str:
+    """Fetch."""
+    return requests.get(url, timeout=None).text
+`, wantFires: true},
+	{name: "LC-007 silent on httpx.get without timeout", ruleID: "LC-007", kind: models.KindLangChainTool, src: `
+def fetch(q: str) -> str:
+    """Fetch."""
+    import httpx
+    return httpx.get("https://api.example.com/data").text
+`, wantFires: false},
+	{name: "LC-007 silent on non-network tool", ruleID: "LC-007", kind: models.KindLangChainTool, src: `
+def echo(q: str) -> str:
+    """Echo."""
+    return q
+`, wantFires: false},
+	{name: "LC-007 fires on session-alias get without timeout", ruleID: "LC-007", kind: models.KindLangChainTool, src: `
+import requests
+def fetch(url: str) -> str:
+    """Fetch."""
+    s = requests.Session()
+    return s.get(url).text
+`, wantFires: true},
+
 	// LangChain TypeScript tool rules — parseTSTool runs DiscoverTSLangChainTools,
 	// so each snippet must import from the langchain ecosystem to be discovered.
 	{name: "LC-010 fires on TS tool with no description", ruleID: "LC-010", kind: models.KindLangChainTool, lang: models.LanguageTypeScript, wantFires: true, src: `

--- a/testdata/rules-fixture/langchain/network.yaml
+++ b/testdata/rules-fixture/langchain/network.yaml
@@ -1,0 +1,43 @@
+policy:
+  id: langchain_network
+  name: LangChain tool network hygiene
+  category: langchain
+  description: >
+    Network-call hygiene inside LangChain tool functions. A tool that makes a
+    Requests HTTP call without a finite timeout can remain blocked when an
+    upstream service fails to respond, stalling the agent tool invocation.
+
+rules:
+  - id: LC-007
+    title: LangChain tool network call has no timeout
+    severity: high
+    confidence: 0.85
+    language: python
+    applies_to:
+      - langchain_tool
+    scope: tool
+    match:
+      call_without_kwarg:
+        callees:
+          - requests.get
+          - requests.post
+          - requests.put
+          - requests.delete
+          - requests.patch
+          - requests.head
+          - requests.request
+          - requests.Session.get
+          - requests.Session.post
+        missing: timeout
+    explanation: >
+      This LangChain tool performs a Requests HTTP call without a finite
+      timeout, so it can remain blocked when an upstream service or network
+      fails to respond. The tool invocation cannot complete while the request
+      waits, which consumes worker and runtime resources and prevents the
+      agent step from finishing. A kwarg present with literal None counts as
+      missing.
+    fix: >
+      Configure an explicit finite Requests timeout appropriate to the
+      upstream service's latency and SLA, and handle timeout failures as a
+      structured tool error the model can react to rather than letting the
+      call remain blocked.


### PR DESCRIPTION
## Summary

Adds the engine fixture and regression coverage for the new LangChain `LC-007` network-timeout rule.

The canonical rule uses Trustabl's existing `call_without_kwarg` predicate, so no production engine changes are required.

## Coverage

### Fire cases

- `requests.get(...)` without timeout
- `requests.post(...)` without timeout
- `requests.get(..., timeout=None)`
- `requests.Session().get(...)` without timeout

### Silent cases

- `requests.get(..., timeout=10)`
- bare `httpx.get(...)`
- LangChain tool with no network call

The HTTPX silent case deliberately guards against treating HTTP clients with different timeout defaults as equivalent to Requests.

## Validation

Passed:

- targeted policy-rule tests
- all 7 LC-007 regression cases
- `TestPolicyRules_AllRulesCovered`
- `go vet ./...`
- `go build ./cmd/trustabl`
- canonical/fixture byte-sync
- `git diff --check`

`go test ./...` has an existing environment-dependent failure under `internal/enrichment` when the expected Python runtime is unavailable. The same failure was independently reproduced from a clean upstream worktree without LC-007; the LC-007 policy tests pass.

## Companion PRs

- Rule definition: https://github.com/trustabl/trustabl-rules/pull/115
- Rulebook rationale: https://github.com/trustabl/trustabl-rulebook/pull/107