### PR TITLE
feat(rules): add CSKILL-087 fixture and fire/silent cases

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -2461,6 +2461,13 @@ var policySkillRuleCases = []policySkillCase{
 		models.SkillDef{Name: "helper",
 			Location: models.Location{FilePath: ".claude/skills/helper/SKILL.md"},
 			Body:     "# Helper\n\nSummarises the current git diff."}, models.RepoInventory{}, false},
+
+	{"CSKILL-087 fires when the description is a placeholder", "CSKILL-087",
+		models.SkillDef{Name: "helper", Description: "TODO: describe this skill.",
+			Location: models.Location{FilePath: ".claude/skills/helper/SKILL.md"}}, models.RepoInventory{}, true},
+	{"CSKILL-087 silent when the description is real content", "CSKILL-087",
+		models.SkillDef{Name: "helper", Description: "Summarises the current git diff.",
+			Location: models.Location{FilePath: ".claude/skills/helper/SKILL.md"}}, models.RepoInventory{}, false},
 }
 
 // policyAgentRuleCases covers agent-scoped rules.

--- a/testdata/rules-fixture/claude_skill/skill_quality_text.yaml
+++ b/testdata/rules-fixture/claude_skill/skill_quality_text.yaml
@@ -6,7 +6,8 @@ policy:
     Quality and data-governance signals in Claude Code Agent Skills (SKILL.md)
     detected via free-text matching over the skill's name, description, and
     body — claimed crypto/security purpose, sensitive-data handling, missing
-    error-handling or purpose language, and broad-access or retention phrasing.
+    error-handling or purpose language, placeholder descriptions, and
+    broad-access or retention phrasing.
     Skill rules audit SKILL.md frontmatter + body and are language-agnostic
     (markdown), so they carry no language: field.
 
@@ -258,3 +259,34 @@ rules:
       hours, to support debugging"). If the skill doesn't need to persist
       anything beyond the current turn, say so explicitly instead of leaving
       it to be inferred.
+
+  - id: CSKILL-087
+    title: Skill description is a placeholder
+    severity: low
+    confidence: 0.85
+    applies_to:
+      - claude_skill
+    scope: skill
+    match:
+      skill_description_has_text:
+        - todo
+        - tbd
+        - fixme
+        - placeholder
+        - no description
+        - does stuff
+    explanation: >
+      This skill's description is present, so it passes the empty-description
+      check, but the text is a placeholder stub ("TODO", "TBD", "FIXME",
+      "placeholder", "no description", "does stuff") rather than a real
+      account of what the skill does. Claude Code always loads the description
+      into context and uses it to decide whether to auto-invoke the skill; a
+      stub gives the model no selection signal and a reviewer no basis for
+      judging the skill's tool grants — functionally the same as no
+      description at all, except CSKILL-070 never sees it.
+    fix: >
+      Replace the placeholder in the SKILL.md `description:` field with a
+      real one-to-two-sentence summary of what the skill does, which tools it
+      uses, and any side effects it may have. For example: "Summarises the
+      current git diff and posts a draft PR description. Uses Bash
+      (read-only git commands) and WebFetch."


### PR DESCRIPTION
## Summary
- Mirrors **CSKILL-087** into `testdata/rules-fixture/claude_skill/skill_quality_text.yaml`.
- Adds fire + silent cases in `policySkillRuleCases` so `TestPolicyRules_AllRulesCovered` stays green.

Paired with https://github.com/trustabl/trustabl-rules/pull/116 on the same branch name (`feat/cskill-087-placeholder-description`) so `rules-sync` can resolve the matching pack. That branch currently lives on the `kureen-cyber` fork; until it exists on `trustabl/trustabl-rules`, this job falls back to `main` and will report fixture drift. Merge or copy the rules branch first.

## Test plan
- [ ] `go test ./internal/rules/` — CSKILL-087 fire + silent pass
- [ ] `TestPolicyRules_AllRulesCovered` green
- [ ] `scripts/check-rules-sync.sh` against the matching rules branch
