### PR TITLE
fix: repair the broken rule-count badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ CrewAI, and MCP agents — before production.
   <a href="https://github.com/trustabl/trustabl/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/trustabl/trustabl/test.yml?branch=main&amp;label=tests" alt="Tests"></a>
   <a href="go.mod"><img src="https://img.shields.io/github/go-mod/go-version/trustabl/trustabl" alt="Go version"></a>
   <br>
-  <a href="https://github.com/trustabl/trustabl-rules"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftrustabl%2Ftrustabl-rules%2Fmain%2Fbadges%2Frules.json" alt="Detection rule count"></a>
+  <a href="https://github.com/trustabl/trustabl-rules"><img src="https://img.shields.io/badge/rules-204-brightgreen" alt="Detection rule count"></a>
   <a href="COVERAGE.md"><img src="https://img.shields.io/badge/SDKs-9-blue" alt="9 SDKs supported"></a>
   <a href="COVERAGE.md"><img src="https://img.shields.io/badge/languages-7-blue" alt="7 languages supported"></a>
   <a href="COVERAGE.md"><img src="https://img.shields.io/badge/scopes-5-blue" alt="5 detection scopes"></a>


### PR DESCRIPTION
The badge pointed at an endpoint JSON in trustabl-rules that is not on main - it is still sitting on an unmerged branch - so shields rendered 'resource not found' on the README, which is also the profile page.

Back to a static badge at the verified count of 204. Once badges/rules.json is on trustabl-rules main, this can go back to the generated endpoint.