### PR TITLE
fix: read the rule count from the generated endpoint again

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ CrewAI, and MCP agents — before production.
   <a href="https://github.com/trustabl/trustabl/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/trustabl/trustabl/test.yml?branch=main&amp;label=tests" alt="Tests"></a>
   <a href="go.mod"><img src="https://img.shields.io/github/go-mod/go-version/trustabl/trustabl" alt="Go version"></a>
   <br>
-  <a href="https://github.com/trustabl/trustabl-rules"><img src="https://img.shields.io/badge/rules-204-brightgreen" alt="Detection rule count"></a>
+  <a href="https://github.com/trustabl/trustabl-rules"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftrustabl%2Ftrustabl-rules%2Fmain%2Fbadges%2Frules.json" alt="Detection rule count"></a>
   <a href="COVERAGE.md"><img src="https://img.shields.io/badge/SDKs-9-blue" alt="9 SDKs supported"></a>
   <a href="COVERAGE.md"><img src="https://img.shields.io/badge/languages-7-blue" alt="7 languages supported"></a>
   <a href="COVERAGE.md"><img src="https://img.shields.io/badge/scopes-5-blue" alt="5 detection scopes"></a>


### PR DESCRIPTION
badges/rules.json is now on trustabl-rules main, so the endpoint resolves. The static badge was only ever a stopgap for the window where the consumer had merged and the producer had not.

Back to the generated value, which is what punchlist item 56 asked for: the count comes from what 'trustabl rules validate' reports, and validate.yml refreshes it on every push to main. No number in the README to go stale at the next rules release.