### PR TITLE
docs: add a sample output block to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,51 @@ matrix.
 Scanning needs no key and no network. Applying fixes uses your own Anthropic,
 OpenAI, or Google key.
 
+## What a scan looks like
+
+Real output, scanning an agent repo that ships a Claude Agent SDK client, an MCP
+server, a subagent, and two skills:
+
+```console
+$ trustabl scan .
+
+Scan summary
+  Languages:          typescript, javascript
+  SDKs:               claude_agent_sdk
+  Tool definitions:   2    (custom tools with function bodies)
+  Agent tool grants:  14   (tool names the agent may call)
+  MCP servers:        1    (createSdkMcpServer)
+  Subagents:          1    (inbox-searcher)
+  Skills:             2    (action-creator, listener-creator)
+  Findings:           14
+  Overall score:      66%
+
+Surface readiness
+  skill:action-creator          45%  (5 findings)
+  skill:listener-creator        54%  (4 findings)
+  agent:AIClient.queryStream    64%  (2 findings)
+  subagent:inbox-searcher       79%  (1 finding)
+  tool:search_inbox             98%  (1 finding)
+  tool:read_emails             100%  (0 findings)
+
+Findings
+  inbox-searcher
+    [CSDK-201]  HIGH  Subagent is granted Bash  (agent/.claude/agents/inbox-searcher.md:1-5)
+        A subagent with shell access can run arbitrary commands if it is
+        compromised or misdirected.
+        fix: Remove `Bash` from the subagent's `tools:` list unless shell access
+        is essential. Prefer specific tools (Read, Grep, Glob) for read-only roles.
+```
+
+Three things worth noticing:
+
+- **It scores each surface separately.** A repo-wide number hides the problem;
+  `skill:action-creator` at 45% tells you where to look first.
+- **Every finding carries a fix**, not just a complaint — and
+  `trustabl enrich --apply` writes those fixes to source.
+- **The exit code is the CI gate.** `0` when nothing reaches medium severity,
+  `1` when something does, so a pipeline can stop a bad agent from shipping.
+
 ## AI agents pass their demo and fail in production
 
 The failures are rarely exotic. They are the same handful of gaps, over and over:


### PR DESCRIPTION
Punchlist item 35. The README described what the tool does without ever showing what it returns, so the first thing a reader wanted - what do I actually get - was missing.

Real output from a scan of an agent repo with a Claude Agent SDK client, an MCP server, a subagent and two skills. Not a mock-up: fourteen findings, sixty six percent, and a real CSDK-201 on a subagent granted Bash.

Placed before the problem section so it lands while the reader still has the install commands in view.

Calls out the three things the output shows that prose does not: per-surface scoring rather than one repo-wide number, a fix attached to every finding, and the exit code being the CI gate.