### PR TITLE
feat(openai_sdk): add OAI-115, HostedMCPTool with no allowed_tools

### DIFF
--- a/internal/rules/policies_test.go
+++ b/internal/rules/policies_test.go
@@ -2972,6 +2972,67 @@ var policyAgentRuleCases = []policyAgentCase{
 		models.RepoInventory{},
 		false},
 
+	// ─── OAI-115 HostedMCPTool without tool_config.allowed_tools (E1 hosted-kwarg) ─
+	{"OAI-115 fires when tool_config has no allowed_tools", "OAI-115",
+		models.AgentDef{
+			SDK:      models.SDKOpenAIAgents,
+			Class:    "Agent",
+			Language: models.LanguagePython,
+			HostedToolRefs: []models.HostedToolRef{
+				{Class: "HostedMCPTool", Resolved: &models.HostedToolDef{Class: "HostedMCPTool",
+					Kwargs: &models.KwargTree{Children: map[string]*models.KwargTree{
+						"tool_config": {Children: map[string]*models.KwargTree{
+							"server_label": {Value: &models.Expr{Kind: models.ExprLiteralString, Text: `"deepwiki"`}},
+							"server_url":   {Value: &models.Expr{Kind: models.ExprLiteralString, Text: `"https://mcp.deepwiki.com/mcp"`}},
+						}},
+					}}}},
+			},
+		},
+		models.RepoInventory{},
+		true},
+	{"OAI-115 fires when HostedMCPTool has no kwargs at all", "OAI-115",
+		models.AgentDef{
+			SDK:      models.SDKOpenAIAgents,
+			Class:    "Agent",
+			Language: models.LanguagePython,
+			HostedToolRefs: []models.HostedToolRef{
+				{Class: "HostedMCPTool", Resolved: &models.HostedToolDef{Class: "HostedMCPTool"}},
+			},
+		},
+		models.RepoInventory{},
+		true},
+	{"OAI-115 silent when tool_config sets allowed_tools", "OAI-115",
+		models.AgentDef{
+			SDK:      models.SDKOpenAIAgents,
+			Class:    "Agent",
+			Language: models.LanguagePython,
+			HostedToolRefs: []models.HostedToolRef{
+				{Class: "HostedMCPTool", Resolved: &models.HostedToolDef{Class: "HostedMCPTool",
+					Kwargs: &models.KwargTree{Children: map[string]*models.KwargTree{
+						"tool_config": {Children: map[string]*models.KwargTree{
+							"server_label":  {Value: &models.Expr{Kind: models.ExprLiteralString, Text: `"deepwiki"`}},
+							"allowed_tools": {Value: &models.Expr{Kind: models.ExprList, List: []models.Expr{{Kind: models.ExprLiteralString, Text: `"ask_question"`}}}},
+						}},
+					}}}},
+			},
+		},
+		models.RepoInventory{},
+		false},
+	// An agent with no HostedMCPTool at all is out of scope for this rule —
+	// nothing to restrict, so it must not fire just because allowed_tools is
+	// absent.
+	{"OAI-115 silent when agent has no HostedMCPTool", "OAI-115",
+		models.AgentDef{
+			SDK:      models.SDKOpenAIAgents,
+			Class:    "Agent",
+			Language: models.LanguagePython,
+			HostedToolRefs: []models.HostedToolRef{
+				{Class: "WebSearchTool", Resolved: &models.HostedToolDef{Class: "WebSearchTool"}},
+			},
+		},
+		models.RepoInventory{},
+		false},
+
 	// ─── CSDK-101 Claude subagent granted Bash ────────────────────────────────
 	{"CSDK-101 fires when AgentDefinition grants Bash", "CSDK-101",
 		models.AgentDef{

--- a/testdata/rules-fixture/openai_sdk/README.md
+++ b/testdata/rules-fixture/openai_sdk/README.md
@@ -18,5 +18,5 @@ This pack is calibrated against the OpenAI Agents SDK as documented at the URL a
 - `shell_safety.yaml` — OAI-012 (subprocess spawn)
 - `code_execution.yaml` — OAI-013 (eval/exec/compile on dynamic input)
 - `agent_safety.yaml` — OAI-101 (no input_guardrails + shell tools), OAI-102 (stop_on_first_tool), OAI-103 (loop pattern), OAI-104 (raw Agent + FS tools), OAI-109 (WebSearchTool without input_guardrails)
-- `mcp_safety.yaml` — OAI-106 (mcp_servers + no input_guardrails)
+- `mcp_safety.yaml` — OAI-106 (mcp_servers + no input_guardrails), OAI-115 (HostedMCPTool with no tool_config.allowed_tools)
 - `tracing.yaml` — OAI-201 (default tracing in use)

--- a/testdata/rules-fixture/openai_sdk/mcp_safety.yaml
+++ b/testdata/rules-fixture/openai_sdk/mcp_safety.yaml
@@ -3,10 +3,13 @@ policy:
   name: OpenAI Agents SDK MCP integration safety
   category: openai_sdk
   description: >
-    Rule covering tool-poisoning risk when an OpenAI agent wires MCP
-    servers. MCP tool descriptions are advertised by the MCP server, which
-    sits on a separate trust boundary from the agent; without an input
-    guardrail no pre-execution screen catches a poisoned tool list.
+    Rules covering tool-poisoning and unbounded-catalog risk when an OpenAI
+    agent wires MCP servers — either directly via mcp_servers=, or as a
+    hosted HostedMCPTool. MCP tool descriptions are advertised by the MCP
+    server, which sits on a separate trust boundary from the agent; without
+    an input guardrail no pre-execution screen catches a poisoned tool list,
+    and without an allow-list a hosted MCP tool inherits the server's full,
+    and potentially server-controlled, tool catalog.
 
 rules:
   - id: OAI-106
@@ -39,3 +42,37 @@ rules:
       Add at least one @input_guardrail that inspects the user's input AND
       the resolved tool list before the model is invoked. Pin MCP servers
       to known-trusted URLs/checksums and document the trust assumption.
+
+  - id: OAI-115
+    title: Agent wires a HostedMCPTool with no allowed_tools allow-list
+    severity: high
+    confidence: 0.7
+    language: python
+    applies_to:
+      - openai_agent
+      - openai_sandbox_agent
+    scope: agent
+    match:
+      all:
+        - agent_uses_hosted_tool_class: [HostedMCPTool]
+        - not:
+            agent_hosted_tool_kwarg_present:
+              class: HostedMCPTool
+              kwarg: tool_config.allowed_tools
+    explanation: >
+      This agent wires a HostedMCPTool whose tool_config names a hosted MCP
+      server but sets no allowed_tools. Unlike an explicit tools=[...] list,
+      HostedMCPTool connects the agent to every tool that server currently
+      exposes — a surface that is not enumerable from the agent's source,
+      can grow or change behavior whenever the server is updated, and sits
+      on the far side of a trust boundary this codebase does not control.
+      allowed_tools is the only static allow-list narrowing that catalog;
+      without it there is no boundary a code reviewer can check, and a
+      poisoned or newly-added tool description reaches the model unfiltered.
+    fix: >
+      Add allowed_tools to the tool_config dict, naming the specific tools
+      this agent is allowed to call, e.g. HostedMCPTool(tool_config={"type":
+      "mcp", "server_label": "deepwiki", "server_url": ...,
+      "allowed_tools": ["ask_question"]}). Re-review the list whenever the
+      agent's task changes, and keep require_approval at its default rather
+      than "never" for anything side-effecting.


### PR DESCRIPTION
Cheapest of three candidate rules from the OpenAI SDK tool access-control research (docs/decisions/tool-allowlist-scope.md) — structurally identical to ADK-111's MCPToolset finding, but reachable today with zero engine changes: HostedMCPTool is already a recognized hosted-tool class, dict literals already recurse into KwargTree, and dotted-path kwarg lookup already resolves tool_config.allowed_tools.

Severity high, confidence 0.7 — one notch below ADK-111's 0.75, honestly pricing in that OpenAI's require_approval defaults to 'always' for hosted MCP tools, giving some firing agents a runtime approval backstop ADK's MCPToolset has none of.

Placed in mcp_safety.yaml (not agent_safety.yaml) — topically exact fit alongside OAI-106's MCP trust-boundary rule, and avoids collision with agent_safety.yaml's unshipped OAI-113/114 reservations from unmerged branches.

Verified via a genuine end-to-end scan against
testdata/corpus/openai-hosted-mcp/simple.py (not just unit tests) — confirmed the rule fires without allowed_tools and goes silent once added, then reverted the temporary test setup.

check_rulebook.py confirms the doc closes exactly the gap it introduces (32 errors before/after adding the rule+doc together, would be 33 with the rule but no doc).