### PR TITLE
chore(release): stop hardcoding this repository's own name

### DIFF
--- a/.github/workflows/download-history.yml
+++ b/.github/workflows/download-history.yml
@@ -23,7 +23,9 @@ jobs:
       - name: Record cumulative downloads
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TARGET_REPO: trustabl/trustabl
+          # Resolve at run time so a rename cannot point the counter at a
+          # repository that no longer exists.
+          TARGET_REPO: ${{ github.repository }}
           HISTORY_FILE: .github/stats/download-history.json
         run: |
           python - <<'PY'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -73,9 +73,14 @@ checksum:
   algorithm: sha256
 
 release:
-  github:
-    owner: trustabl
-    name: trustabl
+  # No `github:` target here on purpose. GoReleaser infers the repository
+  # from the git remote, which actions/checkout sets to the repository the
+  # workflow is running in, so this follows a rename automatically.
+  #
+  # A hardcoded owner/name is a POST to api.github.com/repos/OWNER/REPO/
+  # releases. GitHub answers a renamed repository with a 301, and Go's HTTP
+  # client does not replay a POST body across a redirect — so the failure
+  # would land AFTER the tag was already public.
   draft: false
   prerelease: auto
   mode: replace


### PR DESCRIPTION
A rename is proposed for this repo. Two places name it as a literal, and the release target is the one that breaks hard.

.goreleaser.yaml pinned `release.github.owner/name` to trustabl/trustabl. Creating a release is a POST to api.github.com/repos/OWNER/REPO/releases; GitHub answers a renamed repository with a 301, and Go's HTTP client does not replay a POST body across a redirect. The tag would already be public by the time it failed. Dropping the block entirely is better than updating it: GoReleaser then infers the target from the git remote, which actions/checkout sets to the repository the workflow is running in, so it follows any rename automatically and needs no further edit.

download-history.yml hardcoded TARGET_REPO, which would point the download counter at a repository that no longer exists. The history file's own repo field is rewritten from that value on every run, so it self-corrects.

Both are correct under the current name and any future one.